### PR TITLE
Additional global average flux diagnostics

### DIFF
--- a/ice_ocean_SIS2/OM4_025/diag_table.MOM6
+++ b/ice_ocean_SIS2/OM4_025/diag_table.MOM6
@@ -90,10 +90,23 @@
  "ocean_model", "salt_flux", "salt_flux", "ocean_month", "all", "mean", "none",2
 
 # Monthly scalars
- "ocean_model", "SST_global",       "SST_global",       "ocean_scalar_month", "all", "mean", "none",2
- "ocean_model", "SSS_global",       "SSS_global",       "ocean_scalar_month", "all", "mean", "none",2
- "ocean_model", "temp_global",      "temp_global",      "ocean_scalar_month", "all", "mean", "none",2
- "ocean_model", "salt_global",      "salt_global",      "ocean_scalar_month", "all", "mean", "none",2
+ "ocean_model", "masso",               "masso",               "ocean_scalar_month",  "all", "mean",  "none",2  # global mean masscello
+ "ocean_model", "thetaoga",            "thetaoga",            "ocean_scalar_month",  "all", "mean",  "none",2  # global mean theta
+ "ocean_model", "soga",                "soga",                "ocean_scalar_month",  "all", "mean",  "none",2  # global mean salinity
+ "ocean_model", "tosga",               "tosga",               "ocean_scalar_month",  "all", "mean",  "none",2  # area mean SST
+ "ocean_model", "sosga",               "sosga",               "ocean_scalar_month",  "all", "mean",  "none",2  # area mean SSS
+ "ocean_model", "volo",                "volo",                "ocean_scalar_month",  "all", "mean",  "none",2  # ocean volume
+ "ocean_model", "ssh_ga",              "ssh_ga",              "ocean_scalar_month",  "all", "mean",  "none",2  # global mean ssh
+ "ocean_model", "prcme_ga",            "prcme_ga",            "ocean_scalar_month",  "all", "mean",  "none",2  # global mean prcme
+ "ocean_model", "precip_ga",           "precip_ga",           "ocean_scalar_month",  "all", "mean",  "none",2  # global mean precip
+ "ocean_model", "evap_ga",             "evap_ga",             "ocean_scalar_month",  "all", "mean",  "none",2  # global mean evaporation
+ "ocean_model", "net_heat_coupler_ga", "net_heat_coupler_ga", "ocean_scalar_month",  "all", "mean",  "none",2  # global mean net heat coupler
+ "ocean_model", "net_heat_surface_ga", "net_heat_surface_ga", "ocean_scalar_month",  "all", "mean",  "none",2  # global mean net heat surface
+ "ocean_model", "sens_ga",             "sens_ga",             "ocean_scalar_month",  "all", "mean",  "none",2  # global mean sensible heat
+ "ocean_model", "LwLatSens_ga",        "LwLatSens_ga",        "ocean_scalar_month",  "all", "mean",  "none",2  # global mean LW + latent + sensible
+ "ocean_model", "sw_ga",               "sw_ga",               "ocean_scalar_month",  "all", "mean",  "none",2  # global mean SW
+ "ocean_model", "lw_ga",               "lw_ga",               "ocean_scalar_month",  "all", "mean",  "none",2  # global mean LW
+ "ocean_model", "lat_ga",              "lat_ga",              "ocean_scalar_month",  "all", "mean",  "none",2  # global mean latent
 
 # Annual averages
  "ocean_model", "e",                "e",                "ocean_annual", "all", "mean", "none",2
@@ -134,10 +147,23 @@
  "ocean_model", "MEKE_KH",          "MEKE_KH",          "ocean_annual", "all", "mean", "none",2
 
 # Annual scalars
- "ocean_model", "SST_global",       "SST_global",       "ocean_scalar_annual", "all", "mean", "none",2
- "ocean_model", "SSS_global",       "SSS_global",       "ocean_scalar_annual", "all", "mean", "none",2
- "ocean_model", "temp_global",      "temp_global",      "ocean_scalar_annual", "all", "mean", "none",2
- "ocean_model", "salt_global",      "salt_global",      "ocean_scalar_annual", "all", "mean", "none",2
+ "ocean_model", "masso",               "masso",               "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean masscello
+ "ocean_model", "thetaoga",            "thetaoga",            "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean theta
+ "ocean_model", "soga",                "soga",                "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean salinity
+ "ocean_model", "tosga",               "tosga",               "ocean_scalar_annual",  "all", "mean",  "none",2  # area mean SST
+ "ocean_model", "sosga",               "sosga",               "ocean_scalar_annual",  "all", "mean",  "none",2  # area mean SSS
+ "ocean_model", "volo",                "volo",                "ocean_scalar_annual",  "all", "mean",  "none",2  # ocean volume
+ "ocean_model", "ssh_ga",              "ssh_ga",              "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean ssh
+ "ocean_model", "prcme_ga",            "prcme_ga",            "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean prcme
+ "ocean_model", "precip_ga",           "precip_ga",           "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean precip
+ "ocean_model", "evap_ga",             "evap_ga",             "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean evaporation
+ "ocean_model", "net_heat_coupler_ga", "net_heat_coupler_ga", "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean net heat coupler
+ "ocean_model", "net_heat_surface_ga", "net_heat_surface_ga", "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean net heat surface
+ "ocean_model", "sens_ga",             "sens_ga",             "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean sensible heat
+ "ocean_model", "LwLatSens_ga",        "LwLatSens_ga",        "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean LW + latent + sensible
+ "ocean_model", "sw_ga",               "sw_ga",               "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean SW
+ "ocean_model", "lw_ga",               "lw_ga",               "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean LW
+ "ocean_model", "lat_ga",              "lat_ga",              "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean latent
 
 # Monthly snapshots
  "ocean_model", "mass_wt", "mass_wt", "ocean_month_snap", "all", "none", "none",2

--- a/ocean_only/global_ALE/common/diag_table
+++ b/ocean_only/global_ALE/common/diag_table
@@ -330,6 +330,25 @@
 "ocean_model", "sosga",       "sosga",       "cmor_scalar",  "all", .true.,  "none",2  # area mean SSS
 "ocean_model", "volo",        "volo",        "cmor_scalar",  "all", .true.,  "none",2  # ocean volume 
 
+# Scalar fields for run-time monitoring:
+#=======================================
+"ocean_model", "masso",               "masso",               "scalar",  "all", .true.,  "none",2  # global mean masscello
+"ocean_model", "thetaoga",            "thetaoga",            "scalar",  "all", .true.,  "none",2  # global mean theta
+"ocean_model", "soga",                "soga",                "scalar",  "all", .true.,  "none",2  # global mean salinity
+"ocean_model", "tosga",               "tosga",               "scalar",  "all", .true.,  "none",2  # area mean SST
+"ocean_model", "sosga",               "sosga",               "scalar",  "all", .true.,  "none",2  # area mean SSS
+"ocean_model", "volo",                "volo",                "scalar",  "all", .true.,  "none",2  # ocean volume
+"ocean_model", "ssh_ga",              "ssh_ga",              "scalar",  "all", .true.,  "none",2  # global mean ssh
+"ocean_model", "prcme_ga",            "prcme_ga",            "scalar",  "all", .true.,  "none",2  # global mean prcme
+"ocean_model", "precip_ga",           "precip_ga",           "scalar",  "all", .true.,  "none",2  # global mean precip
+"ocean_model", "evap_ga",             "evap_ga",             "scalar",  "all", .true.,  "none",2  # global mean evaporation
+"ocean_model", "net_heat_coupler_ga", "net_heat_coupler_ga", "scalar",  "all", .true.,  "none",2  # global mean net heat coupler
+"ocean_model", "net_heat_surface_ga", "net_heat_surface_ga", "scalar",  "all", .true.,  "none",2  # global mean net heat surface
+"ocean_model", "sens_ga",             "sens_ga",             "scalar",  "all", .true.,  "none",2  # global mean sensible heat
+"ocean_model", "LwLatSens_ga",        "LwLatSens_ga",        "scalar",  "all", .true.,  "none",2  # global mean LW + latent + sensible
+"ocean_model", "sw_ga",               "sw_ga",               "scalar",  "all", .true.,  "none",2  # global mean SW
+"ocean_model", "lw_ga",               "lw_ga",               "scalar",  "all", .true.,  "none",2  # global mean LW
+"ocean_model", "lat_ga",              "lat_ga",              "scalar",  "all", .true.,  "none",2  # global mean latent
 
 # Static ocean fields:
 #=====================


### PR DESCRIPTION
Original scalar flux diagnostics were implemented as
integrals. Global average versions added for convenience.
Diags will be especially useful in monitoring coupled runs.

Modified diag_tables:
   ice_ocean_SIS2/OM4_025/diag_table.MOM6
   ocean_only/global_ALE/common/diag_table