### PR TITLE
Update ocn_annual.frepp

### DIFF
--- a/ice_ocean_SIS2/OM4_025/ocn_annual.frepp
+++ b/ice_ocean_SIS2/OM4_025/ocn_annual.frepp
@@ -86,6 +86,7 @@ if (`gfdl_platform` == "hpcs-csc") then
    module load netcdf/4.2
    module load python/2.7.3
    module load intel_compilers
+   module load git
 else
    echo "ERROR: invalid platform"
    #exit 1


### PR DESCRIPTION
The script is failing like:
```
make frepp_local                                                                                                                                                           
(cd ../../..; git submodule init tools/python/025gridGeneration/MIDAS)                                                                                                     
error: Malformed value for push.default: simple                                                                                                                            
error: Must be one of nothing, matching, tracking or current.                                                                                                              
fatal: bad config file line 6 in /home/Niki.Zadeh/.gitconfig                                                                                                               
make: *** [MIDAS/README.md] Error 128                                                                                                                                      
```

I think this is due to the old version of default git on analysis nodes. A "module load git" saves the day.

Why is this suddenly  happening I have no explanation for. May be something changed on analysis nodes.