### PR TITLE
Update MOM6_refineDiag.csh

### DIFF
--- a/tools/analysis/MOM6_refineDiag.csh
+++ b/tools/analysis/MOM6_refineDiag.csh
@@ -91,12 +91,6 @@ ls -l
 
 set script_dir=${out_dir}/mom6/tools/analysis
 
-echo '==Run some example annual scripts. These are not reviewed by scientists.' 
-
-echo '====annual mean Eddy Kinetic Energy======'
-mkdir -p $out_dir/refineDiag_ocean_annual/ocean_${yr1}/EddyKineticEnergy
-
-$script_dir/EddyKineticEnergy.py  -g $yr1.ocean_static.nc -o $out_dir/refineDiag_ocean_annual/ocean_${yr1}/EddyKineticEnergy -l ${yr1} $yr1.ocean_daily.nc
 $script_dir/calc_variance.py zos $yr1.ocean_daily.nc $refineDiagDir/$yr1.ocean_month_refined.nc
 
 echo "  ---------- end yearly analysis ----------  "


### PR DESCRIPTION
Since "ssu" and "ssv" diagnostics are no longer available in ocean_daily.nc the EddyKineticEnergy.py analysis script does not work anymore and there is no point to call it in  MOM6_refineDiag.csh .