### PR TITLE
Fix script calc_variance.py to use ocean_5daily

### DIFF
--- a/tools/analysis/calc_variance.py
+++ b/tools/analysis/calc_variance.py
@@ -27,7 +27,7 @@ nc_out = netCDF4.Dataset( args.annual_file, 'w', format='NETCDF3_64BIT' )
 
 if nt==365: days_in_month =   [31,28,31,30,31,30,31,31,30,31,30,31]
 elif nt==366: days_in_month = [31,29,31,30,31,30,31,31,30,31,30,31]
-elif nt==73 : days_in_month = [6,6,6,6,6,6,6,6,6,6,6,6] # for ocean_5daily.nc
+elif nt==73 : days_in_month = [6,6,6,6,6,6,6,7,6,6,6,6] # for ocean_5daily.nc
 else: raise Exception('First dimension appears to not match a days in a single year.')
 
 # Create dimensions

--- a/tools/analysis/calc_variance.py
+++ b/tools/analysis/calc_variance.py
@@ -27,6 +27,7 @@ nc_out = netCDF4.Dataset( args.annual_file, 'w', format='NETCDF3_64BIT' )
 
 if nt==365: days_in_month =   [31,28,31,30,31,30,31,31,30,31,30,31]
 elif nt==366: days_in_month = [31,29,31,30,31,30,31,31,30,31,30,31]
+elif nt==73 : days_in_month = [6,6,6,6,6,6,6,6,6,6,6,6] # for ocean_5daily.nc
 else: raise Exception('First dimension appears to not match a days in a single year.')
 
 # Create dimensions


### PR DESCRIPTION
- The analysis script calc_variance.py is failing because it was
  designed for ocean_daily.nc and expects 365 or 366 data points
  but it is fed a ocean_5daily file which has 73 data points.