### PR TITLE
Add 'unalis python' to sea ice script

### DIFF
--- a/tools/analysis/Krasting-SeaIce.csh
+++ b/tools/analysis/Krasting-SeaIce.csh
@@ -68,6 +68,7 @@ if (`gfdl_platform` == "hpcs-csc") then
    module load $fremodule
    module load fre-analysis/test
    module unload python
+   unalias python
 
    # This script relies on the ESMF regridder, available in 
    # uv-cdat version 1.5 and higher.  This package is currently


### PR DESCRIPTION
  - Guards against some users who alias python
    in their .cshrc and .login files.