### PR TITLE
correction to handle a none-None type

### DIFF
--- a/tools/analysis/m6plot.py
+++ b/tools/analysis/m6plot.py
@@ -84,7 +84,7 @@ def xyplot(field, x=None, y=None, area=None,
   if interactive: addStatusBar(xCoord, yCoord, maskedField)
   cb = plt.colorbar(fraction=.08, pad=0.02, extend=extend)
   if centerlabels and len(clim)>2: cb.set_ticks(  0.5*(clim[:-1]+clim[1:]) )
-  elif len(clim)>2: cb.set_ticks( clim )
+  elif clim is not None and len(clim)>2: cb.set_ticks( clim )
   axis.set_axis_bgcolor(landcolor)
   plt.xlim( xLims )
   plt.ylim( yLims )


### PR DESCRIPTION
When the input clim is  a "None Type" the script fails with:

  File "/nbhome/Niki.Zadeh/ulm_201510_mom6_2016.03.22/OMp5_COBALT.2016.03.22/mom6/tools/analysis/m6plot.py", line 87, in xyplot
    elif len(clim)>2: cb.set_ticks( clim )
TypeError: object of type 'NoneType' has no len()

This fixes the issue.