### PR TITLE
Fix for cmocean module import

### DIFF
--- a/tools/analysis/m6plot.py
+++ b/tools/analysis/m6plot.py
@@ -15,10 +15,13 @@ import math
 import numpy, numpy.matlib
 import m6toolbox
 import VerticalSplitScale
-import cmocean
 
 try: from mpl_toolkits.basemap import Basemap
 except: print('Basemap module not found. Some regional plots may not function properly')
+try: import cmocean
+except: print('cmocean module not found. Some color maps may not render properly')
+
+from sys import modules
 
 def xyplot(field, x=None, y=None, area=None,
   xlabel=None, xunits=None, ylabel=None, yunits=None,
@@ -1288,7 +1291,8 @@ c = brownblue_cmap()
 c = parula_cmap()
 
 # Register cmocean colormaps
-cmoceanRegisterColormaps()
+if 'cmocean' in modules.keys():
+  cmoceanRegisterColormaps()
 
 # Test
 if __name__ == '__main__':


### PR DESCRIPTION
  - Lack of the cmocean submodule was causing the workflow to
    fail at GFDL.
  - Wrapped the 'import cmocean' statement in a try block.

@adcroft @nikizadehgfdl, can you see if this fixes the workflow issue?