### PR TITLE
Update diag_table.SIS

### DIFF
--- a/ice_ocean_SIS2/OM4_025/diag_table.SIS
+++ b/ice_ocean_SIS2/OM4_025/diag_table.SIS
@@ -47,17 +47,14 @@
 #"ice_model", "FW_X",       "FW_X",         "ice_month", "all", "mean", "none", 2
 #"ice_model", "FW_Y",       "FW_Y",         "ice_month", "all", "mean", "none", 2
  "ice_model", "FRAZIL",     "FRAZIL",       "ice_month", "all", "mean", "none", 2
- "ice_model", "HI",         "HI",           "ice_month", "all", "mean", "none", 2
 #"ice_model", "HI_PART",    "HI_PART",      "ice_month", "all", "mean", "none", 2
- "ice_model", "HS",         "HS",           "ice_month", "all", "mean", "none", 2
- "ice_model", "IX_TRANS",   "IX_TRANS",     "ice_month", "all", "mean", "none", 2
+  "ice_model", "IX_TRANS",   "IX_TRANS",     "ice_month", "all", "mean", "none", 2
  "ice_model", "IY_TRANS",   "IY_TRANS",     "ice_month", "all", "mean", "none", 2
  "ice_model", "LH",         "LH",           "ice_month", "all", "mean", "none", 2
  "ice_model", "LSNK",       "LSNK",         "ice_month", "all", "mean", "none", 2
  "ice_model", "LSRC",       "LSRC",         "ice_month", "all", "mean", "none", 2
  "ice_model", "LW",         "LW",           "ice_month", "all", "mean", "none", 2
 #"ice_model", "LWDN",       "LWDN",         "ice_month", "all", "mean", "none", 2
- "ice_model", "MI",         "MI",           "ice_month", "all", "mean", "none", 2
  "ice_model", "RAIN",       "RAIN",         "ice_month", "all", "mean", "none", 2
 #"ice_model", "RDG_RATE",   "RDG_RATE",     "ice_month", "all", "mean", "none", 2
 #"ice_model", "RDG_FRAC",   "RDG_FRAC",     "ice_month", "all", "mean", "none", 2
@@ -83,11 +80,11 @@
 #"ice_model", "SW_VIS_DIF", "SW_VIS_DIF",   "ice_month", "all", "mean", "none", 2
 #"ice_model", "SW_VIS_DIR", "SW_VIS_DIR",   "ice_month", "all", "mean", "none", 2
  "ice_model", "TMELT",      "TMELT",        "ice_month", "all", "mean", "none", 2
- "ice_model", "TS",         "TS",           "ice_month", "all", "mean", "none", 2
+ "ice_model", "TSN",        "TSN",           "ice_month", "all", "mean", "none", 2
  "ice_model", "T1",         "T1",           "ice_month", "all", "mean", "none", 2
  "ice_model", "T2",         "T2",           "ice_month", "all", "mean", "none", 2
- "ice_model", "UI",         "UI",           "ice_month", "all", "mean", "none", 2
- "ice_model", "VI",         "VI",           "ice_month", "all", "mean", "none", 2
+ "ice_model", "T3",         "T3",           "ice_month", "all", "mean", "none", 2
+ "ice_model", "T4",         "T4",           "ice_month", "all", "mean", "none", 2
  "ice_model", "UO",         "UO",           "ice_month", "all", "mean", "none", 2
  "ice_model", "VO",         "VO",           "ice_month", "all", "mean", "none", 2
  "ice_model", "XPRT",       "XPRT",         "ice_month", "all", "mean", "none", 2


### PR DESCRIPTION
Michael Winton wrote:
Could you please change the CM4 SIS2 diag_table to add:

T3, T4, and TSN (new temperatures for layers in SIS2 but not in SIS)

and remove:

TS, HI, HS, UI, VI, and MI

which are now redundant with CMIP6 diagnostics sitemptop, sithick, sisnthick, siu, siv,
and the sum of simass and sisnmass, respectively.