### PR TITLE
update SIS_override

### DIFF
--- a/coupled_AM2_LM3_SIS2/AM2_SIS2B_MOM6i_1deg/SIS_override
+++ b/coupled_AM2_LM3_SIS2/AM2_SIS2B_MOM6i_1deg/SIS_override
@@ -1,1 +1,1 @@
-# Blank file in which we can put "overrides" for parameters
+! Blank file in which we can put "overrides" for parameters


### PR DESCRIPTION
The # char to comment causes crash, it should be replaced by !

```
WARNING from PE     0: Unused line in INPUT/SIS_override : # Blank file in which we can put "overrides" for parameters

FATAL from PE     0: Run stopped because of unused parameter lines.
```