### PR TITLE
User/smg/diag table updates

### DIFF
--- a/ice_ocean_SIS2/OM4_025/diag_table.MOM6
+++ b/ice_ocean_SIS2/OM4_025/diag_table.MOM6
@@ -37,7 +37,7 @@
  "ocean_model", "areacello",   "areacello",   "ocean_static", "all", "none", "none", 2
  "ocean_model", "deptho",      "deptho",      "ocean_static", "all", "none", "none", 2
 #"ocean_model", "basin",       "basin",       "ocean_static", "all", "none", "none", 2  # in /archive/gold/datasets/OM4_025/
- "ocean_model", "hfgeou",      "hfgeou"       "ocean_static", "all", "none", "none", 2  # for geothermal heat
+ "ocean_model", "hfgeou",      "hfgeou"       "ocean_static", "all", "none", "none", 2  # for static geothermal heat
 
 # Extra static geometry data beyond CMIP6/OMIP Table 2.1
  "ocean_model", "Coriolis",    "Coriolis",    "ocean_static", "all", "none", "none", 2
@@ -344,7 +344,7 @@
 
 # -----------------------------------------------------------------------------------------
 # CMIP6/OMIP Table K3: boundary heat fluxes
-#"ocean_model",  "hfgeou",          "hfgeou",           "ocean_annual",       "all", "mean", "none",2  # geothermal heat flux
+# "ocean_model",  "hfgeou",          "hfgeou",           "ocean_annual",       "all", "mean", "none",2  # geothermal heat flux is static 
  "ocean_model",  "hfrainds",        "hfrainds",         "ocean_annual",       "all", "mean", "none",2
  "ocean_model",  "hfevapds",        "hfevapds",         "ocean_annual",       "all", "mean", "none",2
  "ocean_model",  "hfrunoffds",      "hfrunoffds",       "ocean_annual",       "all", "mean", "none",2
@@ -359,7 +359,7 @@
  "ocean_model",  "rsdo",            "rsdo"              "ocean_annual",       "all", "mean", "none",2
  "ocean_model",  "hfds",            "hfds"              "ocean_annual",       "all", "mean", "none",2
 
-#"ocean_model",  "hfgeou",          "hfgeou",           "ocean_month",        "all", "mean", "none",2  # geothermal heat flux
+# "ocean_model",  "hfgeou",          "hfgeou",           "ocean_month",        "all", "mean", "none",2  # geothermal heat flux is static 
  "ocean_model",  "hfrainds",        "hfrainds",         "ocean_month",        "all", "mean", "none",2  # heat content of lprec,fprec,condensate
  "ocean_model",  "hfevapds",        "hfevapds",         "ocean_month",        "all", "mean", "none",2  # heat content of mass leaving ocean
  "ocean_model",  "hfrunoffds",      "hfrunoffds",       "ocean_month",        "all", "mean", "none",2  # heat content of lrunoff,frunoff

--- a/ice_ocean_SIS2/OM4_025/diag_table.MOM6_spinup
+++ b/ice_ocean_SIS2/OM4_025/diag_table.MOM6_spinup
@@ -1,0 +1,593 @@
+# MOM6 ocean diagnostics files for use in spin-up of CMIP6 simulations.
+# Generally only save annuals of 2d and 3d during spin up
+# Generally only save monthly for some of the 2d during spin up (such as surface fluxes)
+# Generally do not save any daily during spin up 
+#
+"ocean_daily",            1, "days",   1, "days", "time"
+"ocean_month_snap",       1, "months", 1, "days", "time"
+"ocean_month",            1, "months", 1, "days", "time"
+"ocean_month_z",          1, "months", 1, "days", "time"
+"ocean_annual",          12, "months", 1, "days", "time"
+"ocean_annual_z",        12, "months", 1, "days", "time"
+"ocean_scalar_month",     1, "months", 1, "days", "time"
+"ocean_scalar_annual",   12, "months", 1, "days", "time"
+"ocean_static",          -1, "months", 1, "days", "time" # ocean_static is a protected name. Do not change this line.
+
+# Sections for CMIP6/OMIP
+"ocean_Barents_opening",         1, "months",   1, "days", "time"
+"ocean_Bering_Strait",           1, "months",   1, "days", "time"
+"ocean_Davis_Strait",            1, "months",   1, "days", "time"
+"ocean_Windward_Passage",        1, "months",   1, "days", "time"
+"ocean_Denmark_Strait",          1, "months",   1, "days", "time"
+"ocean_Drake_Passage",           1, "months",   1, "days", "time"
+"ocean_English_Channel",         1, "months",   1, "days", "time"
+"ocean_Faroe_Scotland",          1, "months",   1, "days", "time"
+"ocean_Florida_Bahamas",         1, "months",   1, "days", "time"
+"ocean_Fram_Strait",             1, "months",   1, "days", "time"
+"ocean_Iceland_Faroe_V",         1, "months",   1, "days", "time"
+"ocean_Iceland_Faroe_U",         1, "months",   1, "days", "time"
+"ocean_Indonesian_Throughflow",  1, "months",   1, "days", "time"
+"ocean_Mozambique_Channel",      1, "months",   1, "days", "time"
+"ocean_Pacific_undercurrent",    1, "months",   1, "days", "time"
+"ocean_Taiwan_Luzon",            1, "months",   1, "days", "time"
+"ocean_Agulhas_section",         1, "months",   1, "days", "time"
+"ocean_Gibraltar_Strait",        1, "months",   1, "days", "time"
+"ocean_Iceland_Norway",          1, "months",   1, "days", "time"
+
+
+# -----------------------------------------------------------------------------------------
+# CMIP6/OMIP Table G1: static information
+ "ocean_model", "areacello",   "areacello",   "ocean_static", "all", "none", "none", 2
+ "ocean_model", "deptho",      "deptho",      "ocean_static", "all", "none", "none", 2
+#"ocean_model", "basin",       "basin",       "ocean_static", "all", "none", "none", 2  # in /archive/gold/datasets/OM4_025/
+ "ocean_model", "hfgeou",      "hfgeou"       "ocean_static", "all", "none", "none", 2  # for static geothermal heat
+
+# Extra static geometry data beyond CMIP6/OMIP Table 2.1
+ "ocean_model", "Coriolis",    "Coriolis",    "ocean_static", "all", "none", "none", 2
+ "ocean_model", "geolon",      "geolon",      "ocean_static", "all", "none", "none", 2
+ "ocean_model", "geolat",      "geolat",      "ocean_static", "all", "none", "none", 2
+ "ocean_model", "geolon_c",    "geolon_c",    "ocean_static", "all", "none", "none", 2
+ "ocean_model", "geolat_c",    "geolat_c",    "ocean_static", "all", "none", "none", 2
+ "ocean_model", "geolon_u",    "geolon_u",    "ocean_static", "all", "none", "none", 2
+ "ocean_model", "geolat_u",    "geolat_u",    "ocean_static", "all", "none", "none", 2
+ "ocean_model", "geolon_v",    "geolon_v",    "ocean_static", "all", "none", "none", 2
+ "ocean_model", "geolat_v",    "geolat_v",    "ocean_static", "all", "none", "none", 2
+ "ocean_model", "wet",         "wet",         "ocean_static", "all", "none", "none", 2
+ "ocean_model", "wet_c",       "wet_c",       "ocean_static", "all", "none", "none", 2
+ "ocean_model", "wet_u",       "wet_u",       "ocean_static", "all", "none", "none", 2
+ "ocean_model", "wet_v",       "wet_v",       "ocean_static", "all", "none", "none", 2
+ "ocean_model", "dxt",         "dxt",         "ocean_static", "all", "none", "none", 2
+ "ocean_model", "dyt",         "dyt",         "ocean_static", "all", "none", "none", 2
+ "ocean_model", "dxCu",        "dxCu",        "ocean_static", "all", "none", "none", 2
+ "ocean_model", "dyCu",        "dyCu",        "ocean_static", "all", "none", "none", 2
+ "ocean_model", "dxCv",        "dxCv",        "ocean_static", "all", "none", "none", 2
+ "ocean_model", "dyCv",        "dyCv",        "ocean_static", "all", "none", "none", 2
+
+
+# -----------------------------------------------------------------------------------------
+# CMIP6/OMIP Table H1: scalar fields such as tracers, cell mass/volume, sea level, MLD
+# Generally save annuals, and sometimes monthly and daily.
+ "ocean_model",   "pbo",          "pbo",              "ocean_annual",        "all", "mean", "none",2
+# "ocean_model",   "pbo",          "pbo",              "ocean_month",         "all", "mean", "none",2
+ "ocean_model",   "pso",          "pso",              "ocean_annual",        "all", "mean", "none",2
+# "ocean_model",   "pso",          "pso",              "ocean_month",         "all", "mean", "none",2
+ "ocean_model",   "masscello",    "masscello",        "ocean_annual",        "all", "mean", "none",2
+#"ocean_model",   "masscello",    "masscello",        "ocean_month",         "all", "mean", "none",2
+ "ocean_model",   "masso",        "masso",            "ocean_scalar_month",  "all", "mean", "none",2  # global sum masscello
+ "ocean_model",   "masso",        "masso",            "ocean_scalar_annual", "all", "mean", "none",2  # global sum masscello
+ "ocean_model",   "thkcello",     "thkcello",         "ocean_annual",        "all", "mean", "none",2  # Only needed in native space, a static field needs to be provided for CMIP6
+#"ocean_model",   "thkcello",     "thkcello",         "ocean_month",         "all", "mean", "none",2
+ "ocean_model",   "volo",         "volo",             "ocean_scalar_month",  "all", "mean", "none",2  # global sum thkcello
+ "ocean_model",   "volo",         "volo",             "ocean_scalar_annual", "all", "mean", "none",2  # global sum thkcello
+ "ocean_model",   "zos",          "zos",              "ocean_annual",        "all", "mean", "none",2
+ "ocean_model",   "zos",          "zos",              "ocean_month",         "all", "mean", "none",2
+# "ocean_model",   "zos",          "zos",              "ocean_daily",         "all", "mean", "none",2
+ "ocean_model",   "zossq",        "zossq",            "ocean_annual",        "all", "mean", "none",2
+# "ocean_model",   "zossq",        "zossq",            "ocean_month",         "all", "mean", "none",2
+#"ocean_model",   "zostoga",      "zostoga",          "ocean_month",         "all", "mean", "none",2  # to be done offline
+ "ocean_model",   "thetao",       "thetao",           "ocean_annual",        "all", "mean", "none",2  # if use pre-TEOS10
+#"ocean_model",   "thetao",       "thetao",           "ocean_month",         "all", "mean", "none",2  # if use pre-TEOS10
+ "ocean_model_z", "thetao",       "thetao",           "ocean_annual_z",      "all", "mean", "none",2  # if use pre-TEOS10
+# "ocean_model_z", "thetao",       "thetao",           "ocean_month_z",       "all", "mean", "none",2  # if use pre-TEOS10
+ "ocean_model_z", "thetao_xyave", "thetao_xyave",     "ocean_annual_z",      "all", "mean", "none",2  # if use pre-TEOS10
+ "ocean_model",   "thetaoga",     "thetaoga",         "ocean_scalar_month",  "all", "mean", "none",2  # global mean theta
+ "ocean_model",   "thetaoga",     "thetaoga",         "ocean_scalar_annual", "all", "mean", "none",2  # global mean theta
+#"ocean_model",   "bigthetao",    "bigthetao",        "ocean_annual",        "all", "mean", "none",2  # if use TEOS10
+#"ocean_model",   "bigthetao",    "bigthetao",        "ocean_month",         "all", "mean", "none",2  # if use TEOS10
+#"ocean_model",   "bigthetaoga",  "bigthetaoga",      "ocean_scalar_annual", "all", "mean", "none",2  # if use TEOS10
+#"ocean_model",   "bigthetaoga",  "bigthetaoga",      "ocean_scalar_month",  "all", "mean", "none",2  # if use TEOS10
+ "ocean_model",   "tos",          "tos",              "ocean_annual",        "all", "mean", "none",2
+ "ocean_model",   "tos",          "tos",              "ocean_month",         "all", "mean", "none",2
+# "ocean_model",   "tos",          "tos",              "ocean_daily",         "all", "mean", "none",2
+ "ocean_model",   "tosga",        "tosga",            "ocean_scalar_annual", "all", "mean", "none",2
+ "ocean_model",   "tosga",        "tosga",            "ocean_scalar_month",  "all", "mean", "none",2
+# "ocean_model",   "tossq",        "tossq",            "ocean_annual",        "all", "mean", "none",2
+# "ocean_model",   "tossq",        "tossq",            "ocean_month",         "all", "mean", "none",2
+# "ocean_model",   "tossq",        "tossq",            "ocean_daily",         "all", "mean", "none",2
+ "ocean_model",   "tob",          "tob",              "ocean_annual",        "all", "mean", "none",2
+# "ocean_model",   "tob",          "tob",              "ocean_month",         "all", "mean", "none",2
+ "ocean_model",   "so",           "so",               "ocean_annual",        "all", "mean", "none",2
+#"ocean_model",   "so",           "so",               "ocean_month",         "all", "mean", "none",2
+ "ocean_model_z", "so",           "so",               "ocean_annual_z",      "all", "mean", "none",2
+# "ocean_model_z", "so",           "so",               "ocean_month_z",       "all", "mean", "none",2
+ "ocean_model_z", "so_xyave",     "so_xyave",         "ocean_annual_z",      "all", "mean", "none",2
+ "ocean_model",   "soga",         "soga",             "ocean_scalar_annual", "all", "mean", "none",2
+ "ocean_model",   "soga",         "soga",             "ocean_scalar_month",  "all", "mean", "none",2
+ "ocean_model",   "sos",          "sos",              "ocean_annual",        "all", "mean", "none",2
+ "ocean_model",   "sos",          "sos",              "ocean_month",         "all", "mean", "none",2
+# "ocean_model",   "sos",          "sos",              "ocean_daily",         "all", "mean", "none",2
+ "ocean_model",   "sosga",        "sosga",            "ocean_scalar_annual", "all", "mean", "none",2
+ "ocean_model",   "sosga",        "sosga",            "ocean_scalar_month",  "all", "mean", "none",2
+# "ocean_model",   "sossq",        "sossq",            "ocean_annual",        "all", "mean", "none",2
+# "ocean_model",   "sossq",        "sossq",            "ocean_month",         "all", "mean", "none",2
+# "ocean_model",   "sossq",        "sossq",            "ocean_daily",         "all", "mean", "none",2
+ "ocean_model",   "sob",          "sob",              "ocean_annual",        "all", "mean", "none",2
+ "ocean_model",   "sob",          "sob",              "ocean_month",         "all", "mean", "none",2
+ "ocean_model_z", "obvfsq",       "obvfsq",           "ocean_annual_z",      "all", "mean", "none",2
+# "ocean_model_z", "obvfsq",       "obvfsq",           "ocean_month_z",       "all", "mean", "none",2
+ "ocean_model_z", "agessc",       "agessc",           "ocean_annual_z",      "all", "mean", "none",2		
+#"ocean_model",   "cfc11",        "cfc11",            "ocean_annual",        "all", "mean", "none",2  # get from generic tracer module
+#"ocean_model",   "cfc12",        "cfc12",            "ocean_annual",        "all", "mean", "none",2  # get from generic tracer module
+#"ocean_model",   "sf6",          "sf6",              "ocean_annual",        "all", "mean", "none",2  # get from generic tracer module
+ "ocean_model",   "mlotst"        "mlotst",           "ocean_annual",        "all", "mean", "none",2
+ "ocean_model",   "mlotst"        "mlotst",           "ocean_month",         "all", "mean", "none",2
+# "ocean_model",   "mlotstsq"      "mlotstsq",         "ocean_annual",        "all", "mean", "none",2
+# "ocean_model",   "mlotstsq"      "mlotstsq",         "ocean_month",         "all", "mean", "none",2
+#"ocean_model",   "msftbarot"     "msftbarot",        "ocean_month",         "all", "mean", "none",2  # to be done offline
+
+
+# -----------------------------------------------------------------------------------------
+# CMIP6/OMIP Table I1: components of vector fields
+# (umo,vmo)  =net mass transport from residual mean velocity (model resolved + SGS)
+# (uhml,vhml)=parameterized mixed layer restratification mass transport
+# (uhGM,vhGM)=parameterized eddy-induced mass transport from GM
+# (T_adx_2d,T_ady_2d) = heat transport by residual mean advection (yet to code neutral diffusion diagnostic)
+# Offline calculations needed for meridional overturning streamfunctions.
+#"ocean_model",  "uo",           "uo",               "ocean_annual",       "all", "mean", "none",2
+ "ocean_model_z","uo",           "uo",               "ocean_annual_z",     "all", "mean", "none",2
+# "ocean_model_z","uo",           "uo",               "ocean_month_z",      "all", "mean", "none",2
+#"ocean_model",  "uo",           "uo",               "ocean_month",        "all", "mean", "none",2
+#"ocean_model",  "vo",           "vo",               "ocean_annual",       "all", "mean", "none",2
+ "ocean_model_z","vo",           "vo",               "ocean_annual_z",     "all", "mean", "none",2
+# "ocean_model_z","vo",           "vo",               "ocean_month_z",      "all", "mean", "none",2
+#"ocean_model",  "vo",           "vo",               "ocean_month",        "all", "mean", "none",2
+#"ocean_model",  "umo",          "umo",              "ocean_annual",       "all", "mean", "none",2
+ "ocean_model_z","umo",          "umo",              "ocean_annual_z",     "all", "mean", "none",2
+#"ocean_model",  "vmo",          "vmo",              "ocean_annual",       "all", "mean", "none",2
+ "ocean_model_z","vmo",          "vmo",              "ocean_annual_z",     "all", "mean", "none",2
+#"ocean_model",  "wmo",          "wmo",              "ocean_annual",       "all", "mean", "none",2  # needs to be coded
+#"ocean_model",  "wmo",          "wmo",              "ocean_month",        "all", "mean", "none",2  # needs to be coded
+#"ocean_model",  "uhml",         "uhml",             "ocean_annual",       "all", "mean", "none",2
+ "ocean_model_z","uhml",         "uhml",             "ocean_annual_z",     "all", "mean", "none",2
+#"ocean_model",  "vhml",         "vhml",             "ocean_annual",       "all", "mean", "none",2
+ "ocean_model_z","vhml",         "vhml",             "ocean_annual_z",     "all", "mean", "none",2
+#"ocean_model",  "uhGM",         "uhGM",             "ocean_annual",       "all", "mean", "none",2
+ "ocean_model_z","uhGM",         "uhGM",             "ocean_annual_z",     "all", "mean", "none",2
+#"ocean_model",  "vhGM",         "vhGM",             "ocean_annual",       "all", "mean", "none",2
+ "ocean_model_z","vhGM",         "vhGM",             "ocean_annual_z",     "all", "mean", "none",2
+ "ocean_model_z","uh",           "uh",               "ocean_annual_z",     "all", "mean", "none",2
+ "ocean_model_z","vh",           "vh",               "ocean_annual_z",     "all", "mean", "none",2
+ "ocean_model_z","T_adx",        "T_adx",            "ocean_annual_z",     "all", "mean", "none",2
+ "ocean_model_z","T_ady",        "T_ady",            "ocean_annual_z",     "all", "mean", "none",2
+ "ocean_model",  "T_adx_2d",     "T_adx_2d",         "ocean_annual",       "all", "mean", "none",2
+ "ocean_model",  "T_ady_2d",     "T_ady_2d",         "ocean_annual",       "all", "mean", "none",2
+ "ocean_model_z","S_adx",        "S_adx",            "ocean_annual_z",     "all", "mean", "none",2
+ "ocean_model_z","S_ady",        "S_ady",            "ocean_annual_z",     "all", "mean", "none",2
+ "ocean_model",  "S_adx_2d",     "S_adx_2d",         "ocean_annual",       "all", "mean", "none",2
+ "ocean_model",  "S_ady_2d",     "S_ady_2d",         "ocean_annual",       "all", "mean", "none",2
+ "ocean_model",  "ndiff_tracer_trans_x_2d_T","ndiff_tracer_trans_x_2d_T",  "ocean_annual",  "all", "mean", "none",2
+ "ocean_model",  "ndiff_tracer_trans_y_2d_T","ndiff_tracer_trans_y_2d_T",  "ocean_annual",  "all", "mean", "none",2
+ "ocean_model",  "ndiff_tracer_trans_x_2d_S","ndiff_tracer_trans_x_2d_S",  "ocean_annual",  "all", "mean", "none",2
+ "ocean_model",  "ndiff_tracer_trans_y_2d_S","ndiff_tracer_trans_y_2d_S",  "ocean_annual",  "all", "mean", "none",2
+
+# -----------------------------------------------------------------------------------------
+# CMIP6/OMIP Table J1: in support of mass transport through straits
+# net transport of mass through straits is either done offline using
+# umo_2d and vmo_2d or via the Sections output just below.
+ "ocean_model",  "umo_2d",       "umo_2d",      "ocean_annual",        "all", "mean", "none",2
+ "ocean_model",  "vmo_2d",       "vmo_2d",      "ocean_annual",        "all", "mean", "none",2
+
+# "ocean_model",  "umo_2d",       "umo_2d",      "ocean_month",         "all", "mean", "none",2
+# "ocean_model",  "vmo_2d",       "vmo_2d",      "ocean_month",         "all", "mean", "none",2
+
+
+# Sections for CMIP6/OMIP choke points Table J1
+# A/ In bipolar Arctic, the lat/lon values are taken from the "nominal" grid values
+# B/ OM4 goes from -300 to 60.  So longitudes must be set within this range.
+# C/ Can use these sections for post-processing diagnostics to fill OMIP Table 2.4.
+
+# Barents Opening (north-south section)
+"ocean_model_z", "thetao", "theta",  "ocean_Barents_opening",    "all", "mean", "6. 6. 62. 80.2 -1 -1",2
+"ocean_model_z", "so",   "so",       "ocean_Barents_opening",    "all", "mean", "6. 6. 62. 80.2 -1 -1",2
+"ocean_model_z", "umo",  "umo",      "ocean_Barents_opening",    "all", "mean", "6. 6. 62. 80.2 -1 -1",2
+"ocean_model_z", "uo",   "uo",       "ocean_Barents_opening",    "all", "mean", "6. 6. 62. 80.2 -1 -1",2
+
+# Bering Strait (east-west section)
+"ocean_model_z", "thetao","thetao",  "ocean_Bering_Strait",    "all", "mean", "-171.4 -168.7  66.1 66.1 -1 -1",2
+"ocean_model_z", "so",   "so",       "ocean_Bering_Strait",    "all", "mean", "-171.4 -168.7  66.1 66.1 -1 -1",2
+"ocean_model_z", "vmo",  "vmo",      "ocean_Bering_Strait",    "all", "mean", "-171.4 -168.7  66.1 66.1 -1 -1",2
+"ocean_model_z", "vo",   "vo",       "ocean_Bering_Strait",    "all", "mean", "-171.4 -168.7  66.1 66.1 -1 -1",2
+
+# Caribbean (east-west section, Cuba-Haiti) Windward Passage
+"ocean_model_z", "thetao","thetao",  "ocean_Windward_Passage", "all", "mean", "-75.0 -72.5 19.96 19.96 -1 -1",2
+"ocean_model_z", "so",   "so",       "ocean_Windward_Passage", "all", "mean", "-75.0 -72.5 19.96 19.96 -1 -1",2
+"ocean_model_z", "vmo",  "vmo",      "ocean_Windward_Passage", "all", "mean", "-75.0 -72.5 19.96 19.96 -1 -1",2
+"ocean_model_z", "vo",   "vo",       "ocean_Windward_Passage", "all", "mean", "-75.0 -72.5 19.96 19.96 -1 -1",2
+
+# Approximate section to capture outflow of Arctic through Davis Strait (east-west section)
+"ocean_model_z", "thetao","thetao",  "ocean_Davis_Strait", "all", "mean", "-65.0 -48.0  66.0 66.0 -1 -1",2
+"ocean_model_z", "so",   "so",       "ocean_Davis_Strait", "all", "mean", "-65.0 -48.0  66.0 66.0 -1 -1",2
+"ocean_model_z", "vmo",  "vmo",      "ocean_Davis_Strait", "all", "mean", "-65.0 -48.0  66.0 66.0 -1 -1",2
+"ocean_model_z", "vo",   "vo",       "ocean_Davis_Strait", "all", "mean", "-65.0 -48.0  66.0 66.0 -1 -1",2
+
+# Approximate section to capture flow across Denmark Strait (east-west section)
+"ocean_model_z", "thetao","thetao",  "ocean_Denmark_Strait",   "all", "mean", "-42.5 -20. 65. 65. -1 -1",2
+"ocean_model_z", "so",   "so",       "ocean_Denmark_Strait",   "all", "mean", "-42.5 -20. 65. 65. -1 -1",2
+"ocean_model_z", "vmo",  "vmo",      "ocean_Denmark_Strait",   "all", "mean", "-42.5 -20. 65. 65. -1 -1",2
+"ocean_model_z", "vo",   "vo",       "ocean_Denmark_Strait",   "all", "mean", "-42.5 -20. 65. 65. -1 -1",2
+
+# Approximate section to capture flow through Drake Passage (north-south section)
+"ocean_model_z", "thetao","thetao",  "ocean_Drake_Passage",    "all", "mean", "-70. -70. -71. -54.5 -1 -1",2
+"ocean_model_z", "so",   "so",       "ocean_Drake_Passage",    "all", "mean", "-70. -70. -71. -54.5 -1 -1",2
+"ocean_model_z", "umo",  "umo",      "ocean_Drake_Passage",    "all", "mean", "-70. -70. -71. -54.5 -1 -1",2
+"ocean_model_z", "uo",   "uo",       "ocean_Drake_Passage",    "all", "mean", "-70. -70. -71. -54.5 -1 -1",2
+
+# English channel flow (north-south section)
+"ocean_model_z", "thetao","thetao",  "ocean_English_Channel",  "all", "mean", "2.16 2.16  50.8  51.2 -1 -1",2
+"ocean_model_z", "so",   "so",       "ocean_English_Channel",  "all", "mean", "2.16 2.16  50.8  51.2 -1 -1",2
+"ocean_model_z", "umo",  "umo",      "ocean_English_Channel",  "all", "mean", "2.16 2.16  50.8  51.2 -1 -1",2
+"ocean_model_z", "uo",   "uo",       "ocean_English_Channel",  "all", "mean", "2.16 2.16  50.8  51.2 -1 -1",2
+
+# Faroe-Scotland flow (north-south section)
+"ocean_model_z", "thetao","thetao",  "ocean_Faroe_Scotland",  "all", "mean", "-6.3 -6.3  58. 61.5 -1 -1",2
+"ocean_model_z", "so",   "so",       "ocean_Faroe_Scotland",  "all", "mean", "-6.3 -6.3  58. 61.5 -1 -1",2
+"ocean_model_z", "umo",  "umo",      "ocean_Faroe_Scotland",  "all", "mean", "-6.3 -6.3  58. 61.5 -1 -1",2
+"ocean_model_z", "uo",   "uo",       "ocean_Faroe_Scotland",  "all", "mean", "-6.3 -6.3  58. 61.5 -1 -1",2
+
+# Florida-Bahamas Strait (east-west section)
+"ocean_model_z", "thetao","thetao",  "ocean_Florida_Bahamas",  "all", "mean", "-80.5 -77.8  25. 25. -1 -1",2
+"ocean_model_z", "so",   "so",       "ocean_Florida_Bahamas",  "all", "mean", "-80.5 -77.8  25. 25. -1 -1",2
+"ocean_model_z", "vmo",  "vmo",      "ocean_Florida_Bahamas",  "all", "mean", "-80.5 -77.8  25. 25. -1 -1",2
+"ocean_model_z", "vo",   "vo",       "ocean_Florida_Bahamas",  "all", "mean", "-80.5 -77.8  25. 25. -1 -1",2
+
+# Fram Strait (east-west section)
+"ocean_model_z", "thetao","thetao",  "ocean_Fram_Strait",  "all", "mean", "-22. 0.0  81.2 81.2 -1 -1",2
+"ocean_model_z", "so",   "so",       "ocean_Fram_Strait",  "all", "mean", "-22. 0.0  81.2 81.2 -1 -1",2
+"ocean_model_z", "vmo",  "vmo",      "ocean_Fram_Strait",  "all", "mean", "-22. 0.0  81.2 81.2 -1 -1",2
+"ocean_model_z", "vo",   "vo",       "ocean_Fram_Strait",  "all", "mean", "-22. 0.0  81.2 81.2 -1 -1",2
+
+# Gibraltar Strait (north-south section)
+"ocean_model_z", "thetao","thetao",  "ocean_Gibraltar_Strait", "all", "mean", "-5. -5. 35.8 36.2 -1 -1",2
+"ocean_model_z", "so",   "so",       "ocean_Gibraltar_Strait", "all", "mean", "-5. -5. 35.8 36.2 -1 -1",2
+"ocean_model_z", "umo",  "umo",      "ocean_Gibraltar_Strait", "all", "mean", "-5. -5. 35.8 36.2 -1 -1",2
+"ocean_model_z", "uo",   "uo",       "ocean_Gibraltar_Strait", "all", "mean", "-5. -5. 35.8 36.2 -1 -1",2
+
+# Iceland-Faroe flow: 1st part of zig-zag for flow moving north/south; specific settings for OM4
+"ocean_model_z", "thetao", "thetao", "ocean_Iceland_Faroe_V", "all", "mean", "-17.89 -6. 62.25 62.25 -1 -1",2
+"ocean_model_z", "so",   "so",       "ocean_Iceland_Faroe_V", "all", "mean", "-17.89 -6. 62.25 62.25 -1 -1",2
+"ocean_model_z", "vmo",  "vmo",      "ocean_Iceland_Faroe_V", "all", "mean", "-17.89 -6. 62.25 62.25 -1 -1",2
+"ocean_model_z", "vo",   "vo",       "ocean_Iceland_Faroe_V", "all", "mean", "-17.89 -6. 62.25 62.25 -1 -1",2
+
+# Iceland-Faroe flow: 2nd part of zig-zag for flow moving east/west; specific settings for OM4
+"ocean_model_z", "thetao", "thetao", "ocean_Iceland_Faroe_U", "all", "mean", "-17.74 -17.74  62.31 63.6 -1 -1",2
+"ocean_model_z", "so",   "so",       "ocean_Iceland_Faroe_U", "all", "mean", "-17.74 -17.74  62.31 63.6 -1 -1",2
+"ocean_model_z", "umo",  "umo",      "ocean_Iceland_Faroe_U", "all", "mean", "-17.74 -17.74  62.31 63.6 -1 -1",2
+"ocean_model_z", "uo",   "uo",       "ocean_Iceland_Faroe_U", "all", "mean", "-17.74 -17.74  62.31 63.6 -1 -1",2
+
+# Indonesian Throughflow (east-west section): settings in spirit of OMIP "bulk" transport calculation
+"ocean_model_z", "thetao", "thetao", "ocean_Indonesian_Throughflow",  "all", "mean", "-246.0 -220.0  -8.1 -8.1 -1 -1",2
+"ocean_model_z", "so",   "so",       "ocean_Indonesian_Throughflow",  "all", "mean", "-246.0 -220.0  -8.1 -8.1 -1 -1",2
+"ocean_model_z", "vmo",  "vmo",      "ocean_Indonesian_Throughflow",  "all", "mean", "-246.0 -220.0  -8.1 -8.1 -1 -1",2
+"ocean_model_z", "vo",   "vo",       "ocean_Indonesian_Throughflow",  "all", "mean", "-246.0 -220.0  -8.1 -8.1 -1 -1",2
+
+# Mozambique Channel (east-west section)
+"ocean_model_z", "thetao", "thetao", "ocean_Mozambique_Channel",  "all", "mean", "39. 46. -16. -16. -1 -1",2
+"ocean_model_z", "so",   "so",       "ocean_Mozambique_Channel",  "all", "mean", "39. 46. -16. -16. -1 -1",2
+"ocean_model_z", "vmo",  "vmo",      "ocean_Mozambique_Channel",  "all", "mean", "39. 46. -16. -16. -1 -1",2
+"ocean_model_z", "vo",   "vo",       "ocean_Mozambique_Channel",  "all", "mean", "39. 46. -16. -16. -1 -1",2
+
+# Pacific Equatorial Undercurrent (north-south section)
+"ocean_model_z", "thetao", "thetao", "ocean_Pacific_undercurrent",  "all", "mean", "-155. -155. -2. 2. -1 -1",2
+"ocean_model_z", "so",   "so",       "ocean_Pacific_undercurrent",  "all", "mean", "-155. -155. -2. 2. -1 -1",2
+"ocean_model_z", "umo",  "umo",      "ocean_Pacific_undercurrent",  "all", "mean", "-155. -155. -2. 2. -1 -1",2
+"ocean_model_z", "uo",   "uo",       "ocean_Pacific_undercurrent",  "all", "mean", "-155. -155. -2. 2. -1 -1",2
+
+# Taiwan-Luzon (north-south section)
+"ocean_model_z", "thetao", "thetao", "ocean_Taiwan_Luzon",  "all", "mean", "-239.5 -239.5  17. 23. -1 -1",2
+"ocean_model_z", "so",   "so",       "ocean_Taiwan_Luzon",  "all", "mean", "-239.5 -239.5  17. 23. -1 -1",2
+"ocean_model_z", "umo",  "umo",      "ocean_Taiwan_Luzon",  "all", "mean", "-239.5 -239.5  17. 23. -1 -1",2
+"ocean_model_z", "uo",   "uo",       "ocean_Taiwan_Luzon",  "all", "mean", "-239.5 -239.5  17. 23. -1 -1",2
+
+# Agulhas section (north-south section; transport is closely tied to Drake Passage transport)
+"ocean_model_z", "thetao", "thetao", "ocean_Agulhas_section",  "all", "mean", "20. 20. -71.0 -34 -1 -1",2
+"ocean_model_z", "so",   "so",       "ocean_Agulhas_section",  "all", "mean", "20. 20. -71.0 -34 -1 -1",2
+"ocean_model_z", "umo",  "umo",      "ocean_Agulhas_section",  "all", "mean", "20. 20. -71.0 -34 -1 -1",2
+"ocean_model_z", "uo",   "uo",       "ocean_Agulhas_section",  "all", "mean", "20. 20. -71.0 -34 -1 -1",2
+
+# Iceland-Norway (east-west section)
+"ocean_model_z", "thetao","thetao",  "ocean_Iceland_Norway",   "all", "mean", "-20. 15. 65. 65. -1 -1",2
+"ocean_model_z", "so",   "so",       "ocean_Iceland_Norway",   "all", "mean", "-20. 15. 65. 65. -1 -1",2
+"ocean_model_z", "vmo",  "vmo",      "ocean_Iceland_Norway",   "all", "mean", "-20. 15. 65. 65. -1 -1",2
+"ocean_model_z", "vo",   "vo",       "ocean_Iceland_Norway",   "all", "mean", "-20. 15. 65. 65. -1 -1",2
+
+
+# -----------------------------------------------------------------------------------------
+# CMIP6/OMIP Table K1: surface mass fluxes
+ "ocean_model",  "prlq",         "prlq",             "ocean_annual",       "all", "mean", "none",2
+ "ocean_model",  "prsn",         "prsn",             "ocean_annual",       "all", "mean", "none",2
+ "ocean_model",  "evs",          "evs",              "ocean_annual",       "all", "mean", "none",2
+ "ocean_model",  "friver",       "friver",           "ocean_annual",       "all", "mean", "none",2
+ "ocean_model",  "ficeberg",     "ficeberg",         "ocean_annual",       "all", "mean", "none",2
+ "ocean_model",  "fsitherm",     "fsitherm",         "ocean_annual",       "all", "mean", "none",2  # need code to split ice melt from prlq
+ "ocean_model",  "wfo",          "wfo",              "ocean_annual",       "all", "mean", "none",2
+
+ "ocean_model",  "prlq",         "prlq",             "ocean_month",        "all", "mean", "none",2  # MOM6 has ice melt/form added to prlq
+ "ocean_model",  "prsn",         "prsn",             "ocean_month",        "all", "mean", "none",2
+ "ocean_model",  "evs",          "evs",              "ocean_month",        "all", "mean", "none",2
+ "ocean_model",  "friver",       "friver",           "ocean_month",        "all", "mean", "none",2
+ "ocean_model",  "ficeberg",     "ficeberg",         "ocean_month",        "all", "mean", "none",2
+ "ocean_model",  "fsitherm",     "fsitherm",         "ocean_month",        "all", "mean", "none",2  # need code to split ice melt from prlq
+ "ocean_model",  "wfo",          "wfo",              "ocean_month",        "all", "mean", "none",2
+
+# extra mass flux information beyond CMIP6/OMIP Table K1
+ "ocean_model", "net_massout", "net_massout", "ocean_annual", "all", "mean", "none",2
+ "ocean_model", "net_massin",  "net_massin",  "ocean_annual", "all", "mean", "none",2
+# "ocean_model", "net_massout", "net_massout", "ocean_month",  "all", "mean", "none",2
+# "ocean_model", "net_massin",  "net_massin",  "ocean_month",  "all", "mean", "none",2
+
+
+# -----------------------------------------------------------------------------------------
+# CMIP6/OMIP Table K2: surface salt fluxes
+ "ocean_model",  "sfdsi",        "sfdsi",            "ocean_annual",       "all", "mean", "none",2
+#"ocean_model",  "sfriver",      "sfriver",          "ocean_annual",       "all", "mean", "none",2  # to be coded if rivers have salt
+
+ "ocean_model",  "sfdsi",        "sfdsi",            "ocean_month",        "all", "mean", "none",2
+#"ocean_model",  "sfriver",      "sfriver",          "ocean_month",        "all", "mean", "none",2  # to be coded if rivers have salt
+
+
+# -----------------------------------------------------------------------------------------
+# CMIP6/OMIP Table K3: boundary heat fluxes
+# "ocean_model",  "hfgeou",          "hfgeou",           "ocean_annual",       "all", "mean", "none",2  # geothermal heat flux is static 
+ "ocean_model",  "hfrainds",        "hfrainds",         "ocean_annual",       "all", "mean", "none",2
+ "ocean_model",  "hfevapds",        "hfevapds",         "ocean_annual",       "all", "mean", "none",2
+ "ocean_model",  "hfrunoffds",      "hfrunoffds",       "ocean_annual",       "all", "mean", "none",2
+ "ocean_model",  "hfsnthermds",     "hfsnthermds",      "ocean_annual",       "all", "mean", "none",2
+ "ocean_model",  "hfsifrazil",      "hfsifrazil",       "ocean_annual",       "all", "mean", "none",2
+ "ocean_model",  "hfibthermds",     "hfibthermds",      "ocean_annual",       "all", "mean", "none",2
+ "ocean_model",  "hfsolidrunoffds", "hfsolidrunoffds",  "ocean_annual",       "all", "mean", "none",2  # =0 if ice = 0C
+ "ocean_model",  "rlntds",          "rlntds",           "ocean_annual",       "all", "mean", "none",2
+ "ocean_model",  "hflso",           "hflso",            "ocean_annual",       "all", "mean", "none",2
+ "ocean_model",  "hfsso",           "hfsso",            "ocean_annual",       "all", "mean", "none",2
+ "ocean_model",  "rsntds",          "rsntds"            "ocean_annual",       "all", "mean", "none",2
+ "ocean_model",  "rsdo",            "rsdo"              "ocean_annual",       "all", "mean", "none",2
+ "ocean_model",  "hfds",            "hfds"              "ocean_annual",       "all", "mean", "none",2
+
+# "ocean_model",  "hfgeou",          "hfgeou",           "ocean_month",        "all", "mean", "none",2  # geothermal heat flux is static 
+ "ocean_model",  "hfrainds",        "hfrainds",         "ocean_month",        "all", "mean", "none",2  # heat content of lprec,fprec,condensate
+ "ocean_model",  "hfevapds",        "hfevapds",         "ocean_month",        "all", "mean", "none",2  # heat content of mass leaving ocean
+ "ocean_model",  "hfrunoffds",      "hfrunoffds",       "ocean_month",        "all", "mean", "none",2  # heat content of lrunoff,frunoff
+ "ocean_model",  "hfsnthermds",     "hfsnthermds",      "ocean_month",        "all", "mean", "none",2  # latent heat to melt snow
+ "ocean_model",  "hfsifrazil",      "hfsifrazil",       "ocean_month",        "all", "mean", "none",2  # frazil formation
+#"ocean_model",  "hfsithermds",     "hfsithermds",      "ocean_month",        "all", "mean", "none",2  # computed in SIS2
+ "ocean_model",  "hfibthermds",     "hfibthermds",      "ocean_month",        "all", "mean", "none",2  # latent heat to melt icebergs
+ "ocean_model",  "hfsolidrunoffds", "hfsolidrunoffds",  "ocean_month",        "all", "mean", "none",2  # ne 0 since ice has SST
+ "ocean_model",  "rlntds",          "rlntds",           "ocean_month",        "all", "mean", "none",2  # longwave down
+ "ocean_model",  "hflso",           "hflso",            "ocean_month",        "all", "mean", "none",2  # latent heat for evap+melt
+ "ocean_model",  "hfsso",           "hfsso",            "ocean_month",        "all", "mean", "none",2  # sensible from air-sea and ice-sea
+ "ocean_model",  "rsntds",          "rsntds"            "ocean_month",        "all", "mean", "none",2  # shortwave
+# "ocean_model",  "rsdo",            "rsdo"              "ocean_month",        "all", "mean", "none",2  # penetrative shortwave flux at interface
+ "ocean_model",  "hfds",            "hfds"              "ocean_month",        "all", "mean", "none",2  # total heat entering ocean surface
+
+# Extra heat flux terms beyond Table K3 from CMIP6/OMIP
+ "ocean_model", "net_heat_coupler",       "net_heat_coupler",       "ocean_annual", "all", "mean", "none",2
+ "ocean_model", "heat_content_massin",    "heat_content_massin",    "ocean_annual", "all", "mean", "none",2
+ "ocean_model", "heat_content_massout",   "heat_content_massout",   "ocean_annual", "all", "mean", "none",2
+ "ocean_model", "heat_content_surfwater", "heat_content_surfwater", "ocean_annual", "all", "mean", "none",2
+ "ocean_model", "heat_content_fprec",     "heat_content_fprec",     "ocean_annual", "all", "mean", "none",2
+ "ocean_model", "heat_content_cond",      "heat_content_cond",      "ocean_annual", "all", "mean", "none",2
+ "ocean_model", "LwLatSens",              "LwLatSens",              "ocean_annual", "all", "mean", "none",2
+ "ocean_model", "Heat_PmE",               "Heat_PmE",               "ocean_annual", "all", "mean", "none",2
+ "ocean_model", "nonpenSW",               "nonpenSW",               "ocean_annual", "all", "mean", "none",2
+#"ocean_model", "internal_heat",          "internal_heat",          "ocean_annual", "all", "mean", "none",2
+ "ocean_model", "heat_content_vprec",     "heat_content_vprec",     "ocean_annual", "all", "mean", "none",2
+
+ "ocean_model", "net_heat_coupler",       "net_heat_coupler",       "ocean_month", "all", "mean", "none",2
+ "ocean_model", "heat_content_massin",    "heat_content_massin",    "ocean_month", "all", "mean", "none",2
+ "ocean_model", "heat_content_massout",   "heat_content_massout",   "ocean_month", "all", "mean", "none",2
+ "ocean_model", "heat_content_surfwater", "heat_content_surfwater", "ocean_month", "all", "mean", "none",2
+ "ocean_model", "heat_content_fprec",     "heat_content_fprec",     "ocean_month", "all", "mean", "none",2
+ "ocean_model", "heat_content_cond",      "heat_content_cond",      "ocean_month", "all", "mean", "none",2
+ "ocean_model", "LwLatSens",              "LwLatSens",              "ocean_month", "all", "mean", "none",2
+ "ocean_model", "Heat_PmE",               "Heat_PmE",               "ocean_month", "all", "mean", "none",2
+ "ocean_model", "nonpenSW",               "nonpenSW",               "ocean_month", "all", "mean", "none",2
+#"ocean_model", "internal_heat",          "internal_heat",          "ocean_month", "all", "mean", "none",2
+ "ocean_model", "heat_content_vprec",     "heat_content_vprec",     "ocean_month", "all", "mean", "none",2
+
+
+# -----------------------------------------------------------------------------------------
+# CMIP6/OMIP Table K4: boundary momentum fluxes
+ "ocean_model",  "tauuo",        "tauuo",            "ocean_annual",       "all", "mean", "none",2
+ "ocean_model",  "tauvo",        "tauvo",            "ocean_annual",       "all", "mean", "none",2
+ "ocean_model",  "tauuo",        "tauuo",            "ocean_month",        "all", "mean", "none",2
+ "ocean_model",  "tauvo",        "tauvo",            "ocean_month",        "all", "mean", "none",2
+
+# extra mechanical forcing beyond CMIP6/OMIP Table K4
+ "ocean_model", "ustar",  "ustar",  "ocean_annual", "all", "mean", "none",2
+ "ocean_model", "ustar",  "ustar",  "ocean_month",  "all", "mean", "none",2
+
+
+# -----------------------------------------------------------------------------------------
+# CMIP6/OMIP/BGC : this table should be computed in generic tracer code
+#"ocean_model",  "fgcfc11",      "fgcfc11",          "ocean_month",        "all", "mean", "none",2
+#"ocean_model",  "fgcfc12",      "fgcfc12",          "ocean_month",        "all", "mean", "none",2
+#"ocean_model",  "fgsf6",        "fgsf6",            "ocean_month",        "all", "mean", "none",2
+
+
+# -----------------------------------------------------------------------------------------
+# CMIP6/OMIP Table L1: table of heat and salt tendencies
+ "ocean_model",    "opottempmint",                 "opottempmint",                   "ocean_annual",     "all", "mean", "none",2
+#"ocean_model",    "ocontempmint",                 "ocontempmint",                   "ocean_annual",     "all", "mean", "none",2  # to be coded if use TEOS10
+ "ocean_model",    "somint",                       "somint",                         "ocean_annual",     "all", "mean", "none",2
+ "ocean_model_z",  "rsdoabsorb",                   "rsdoabsorb",                     "ocean_annual_z",   "all", "mean", "none",2
+ "ocean_model_z",  "opottemptend",                 "opottemptend",                   "ocean_annual_z",   "all", "mean", "none",2
+#"ocean_model_z",  "opottemprmadvect",             "opottemprmadvect",               "ocean_annual_z",   "all", "mean", "none",2 # T_advection_xy+Th_tendency_vert_remap
+ "ocean_model",    "opottemppmdiff",               "opottemppmdiff",                 "ocean_annual",     "all", "mean", "none",2
+ "ocean_model_z",  "opottempdiff",                 "opottempdiff",                   "ocean_annual_z",   "all", "mean", "none",2
+ "ocean_model_z",  "osalttend",                    "osalttend",                      "ocean_annual_z",   "all", "mean", "none",2
+#"ocean_model_z",  "osaltrmadvect",                "osaltrmadvect",                  "ocean_annual_z",   "all", "mean", "none",2 # S_advection_xy+Sh_tendency_vert_remap
+ "ocean_model_z",  "osaltpmdiff",                  "osaltpmdiff",                    "ocean_annual_z",   "all", "mean", "none",2
+ "ocean_model_z",  "osaltdiff",                    "osaltdiff",                      "ocean_annual_z",   "all", "mean", "none",2
+ "ocean_model_z",  "frazil_heat_tendency",         "frazil_heat_tendency",           "ocean_annual_z",   "all", "mean", "none",2
+ "ocean_model_z",  "T_advection_xy",               "T_advection_xy",                 "ocean_annual_z",   "all", "mean", "none",2
+ "ocean_model_z",  "S_advection_xy",               "S_advection_xy",                 "ocean_annual_z",   "all", "mean", "none",2
+ "ocean_model_z",  "Th_tendency_vert_remap",       "Th_tendency_vert_remap",         "ocean_annual_z",   "all", "mean", "none",2
+ "ocean_model_z",  "Sh_tendency_vert_remap",       "Sh_tendency_vert_remap",         "ocean_annual_z",   "all", "mean", "none",2
+ "ocean_model",  "boundary_forcing_heat_tendency", "boundary_forcing_heat_tendency", "ocean_annual",     "all", "mean", "none",2
+ "ocean_model",  "boundary_forcing_salt_tendency", "boundary_forcing_salt_tendency", "ocean_annual",     "all", "mean", "none",2
+
+# -----------------------------------------------------------------------------------------
+# CMIP6/OMIP Table M1: vertical tracer diffusivities and potential energy dissipation
+ "ocean_model_z",  "difvho",     "difvho",           "ocean_annual_z",      "all", "mean", "none",2
+ "ocean_model_z",  "difvso",     "difvso",           "ocean_annual_z",      "all", "mean", "none",2
+#"ocean_model",    "tnpeo",      "tnpeo",            "ocean_annual",        "all", "mean", "none",2  # code needed
+
+
+# -----------------------------------------------------------------------------------------
+# CMIP6/OMIP Table N1: lateral viscosity and diffusivities and impact on kinetic energy
+ "ocean_model",  "diftrblo",     "diftrblo",         "ocean_annual",        "all", "mean", "none",2
+ "ocean_model",  "diftrelo",     "diftrelo",         "ocean_annual",        "all", "mean", "none",2  # when neutral tracer diffusion
+ "ocean_model",  "difmxylo",     "difmxylo",         "ocean_annual",        "all", "mean", "none",2  # save if use Laplacian visc
+ "ocean_model",  "difmxybo",     "difmxybo",         "ocean_annual",        "all", "mean", "none",2
+ "ocean_model",  "dispkexyfo",   "dispkexyfo",       "ocean_annual",        "all", "mean", "none",2
+ "ocean_model",  "tnkebto",      "tnkebto",          "ocean_annual",        "all", "mean", "none",2
+
+
+#############################################################################################
+###### Diagnostics in addition to CMIP6/OMIP request#########################################
+
+# -----------------------------------------------------------------------------------------
+# High-frequency
+# "ocean_model", "SSU",          "ssu",              "ocean_daily", "all", "mean", "none",2
+# "ocean_model", "SSV",          "ssv",              "ocean_daily", "all", "mean", "none",2
+# "ocean_model", "tos",          "tos_max",          "ocean_daily", "all", "max",  "none",2
+# "ocean_model", "tos",          "tos_min",          "ocean_daily", "all", "min",  "none",2
+
+# -----------------------------------------------------------------------------------------
+# various fields
+
+ "ocean_model",   "e",                "e",                  "ocean_annual",   "all", "mean", "none",2
+#"ocean_model",   "e",                "e",                  "ocean_month",    "all", "mean", "none",2
+ "ocean_model",   "speed",            "speed",              "ocean_annual",   "all", "mean", "none",2
+#"ocean_model",   "speed",            "speed_pow2",         "ocean_annual",   "all", "pow2", "none",2
+ "ocean_model",   "KE",               "KE",                 "ocean_annual",   "all", "mean", "none",2
+ "ocean_model",   "mass_wt",          "mass_wt",            "ocean_annual",   "all", "mean", "none",2
+
+ "ocean_model",   "temp_layer_ave",   "temp_layer_ave",     "ocean_annual",   "all", "mean", "none",2
+ "ocean_model",   "salt_layer_ave",   "salt_layer_ave",     "ocean_annual",   "all", "mean", "none",2
+# "ocean_model",   "temp_layer_ave",   "temp_layer_ave",     "ocean_month",    "all", "mean", "none",2
+# "ocean_model",   "salt_layer_ave",   "salt_layer_ave",     "ocean_month",    "all", "mean", "none",2
+
+ "ocean_model_z", "Kd_interface",     "Kd_interface",       "ocean_annual_z", "all", "mean", "none",2
+ "ocean_model_z", "Kd_shear",         "Kd_shear",           "ocean_annual_z", "all", "mean", "none",2
+ "ocean_model_z", "Kd_itides",        "Kd_itides",          "ocean_annual_z", "all", "mean", "none",2
+ "ocean_model_z", "Kd_BBL",           "Kd_BBL",             "ocean_annual_z", "all", "mean", "none",2
+ "ocean_model_z", "Kd_ePBL",          "Kd_ePBL",            "ocean_annual_z", "all", "mean", "none",2
+ "ocean_model",   "TKE_tidal",        "TKE_tidal",          "ocean_annual",   "all", "mean", "none",2
+ "ocean_model",   "TKE_itidal",       "TKE_itidal",         "ocean_annual",   "all", "mean", "none",2
+
+ "ocean_model",   "MLD_003",          "MLD_003",            "ocean_annual",   "all", "mean", "none",2
+ "ocean_model",   "MLD_003",          "MLD_003",            "ocean_month",    "all", "mean", "none",2
+ "ocean_model",   "MLD_003",          "MLD_003_min",        "ocean_annual",   "all", "min",  "none",2
+ "ocean_model",   "MLD_003",          "MLD_003_max",        "ocean_annual",   "all", "max",  "none",2
+# "ocean_model",   "MLD_restrat",      "MLD_restrat",        "ocean_month",    "all", "mean", "none",2
+# "ocean_model",   "udml_restrat",     "udml_restrat",       "ocean_month",    "all", "mean", "none",2
+# "ocean_model",   "vdml_restrat",     "vdml_restrat",       "ocean_month",    "all", "mean", "none",2
+# "ocean_model",   "uml_restrat",      "uml_restrat",        "ocean_month",    "all", "mean", "none",2
+# "ocean_model",   "vml_restrat",      "vml_restrat",        "ocean_month",    "all", "mean", "none",2
+
+ "ocean_model",   "LT_Enhancement",   "LT_Enhancement",     "ocean_annual",   "all", "mean", "none",2
+ "ocean_model",   "MSTAR",            "MSTAR",              "ocean_annual",   "all", "mean", "none",2
+# "ocean_model",   "LT_Enhancement",   "LT_Enhancement",     "ocean_month",    "all", "mean", "none",2
+# "ocean_model",   "MSTAR",            "MSTAR",              "ocean_month",    "all", "mean", "none",2
+
+
+#"ocean_model",   "vintage",          "vintage",            "ocean_annual",   "all", "mean", "none",2
+
+ "ocean_model",   "MEKE_Ue",          "MEKE_Ue",            "ocean_annual",   "all", "mean", "none",2
+ "ocean_model",   "MEKE_Le",          "MEKE_Le",            "ocean_annual",   "all", "mean", "none",2
+ "ocean_model",   "MEKE_KH",          "MEKE_KH",            "ocean_annual",   "all", "mean", "none",2
+ "ocean_model",   "subML_N2",         "subML_N2",           "ocean_annual",   "all", "mean", "none",2
+
+ "ocean_model",   "zos",              "zos_pow2",           "ocean_annual",   "all", "pow2", "none",2
+ "ocean_model",   "tos",              "tos_pow2",           "ocean_annual",   "all", "pow2", "none",2
+ "ocean_model",   "tos",              "tos_max",            "ocean_annual",   "all", "max",  "none",2
+ "ocean_model",   "tos",              "tos_min",            "ocean_annual",   "all", "min",  "none",2
+
+# -----------------------------------------------------------------------------------------
+# Monthly time series
+ "ocean_model", "ave_wfo",             "ave_wfo",            "ocean_scalar_month",  "all", "mean",  "none",2  # global mean prcme
+ "ocean_model", "ave_evs",             "ave_evs",            "ocean_scalar_month",  "all", "mean",  "none",2  # global mean evaporation
+ "ocean_model", "ave_hfsso",           "ave_hfsso",          "ocean_scalar_month",  "all", "mean",  "none",2  # global mean sensible heat
+ "ocean_model", "ave_rsntds",          "ave_rsntds",         "ocean_scalar_month",  "all", "mean",  "none",2  # global mean SW
+ "ocean_model", "ave_rlntds",          "ave_rlntds",         "ocean_scalar_month",  "all", "mean",  "none",2  # global mean LW
+ "ocean_model", "ave_hflso",           "ave_hflso",          "ocean_scalar_month",  "all", "mean",  "none",2  # global mean latent
+ "ocean_model", "ave_hfds",            "ave_hfds",           "ocean_scalar_month",  "all", "mean",  "none",2  # global mean net heat surf
+ "ocean_model", "net_heat_coupler_ga", "net_heat_coupler_ga","ocean_scalar_month",  "all", "mean",  "none",2  # global mean net heat coupl
+ "ocean_model", "LwLatSens_ga",        "LwLatSens_ga",       "ocean_scalar_month",  "all", "mean",  "none",2  # global mean LW+lat+sens
+ "ocean_model", "ssh_ga",              "ssh_ga",             "ocean_scalar_month",  "all", "mean",  "none",2  # global mean ssh
+ "ocean_model", "precip_ga",           "precip_ga",          "ocean_scalar_month",  "all", "mean",  "none",2  # global mean precip
+
+# Annual time series
+ "ocean_model", "ave_wfo",             "ave_wfo",             "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean prcme
+ "ocean_model", "ave_evs",             "ave_evs",             "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean evaporation
+ "ocean_model", "ave_hfsso",           "ave_hfsso",           "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean sensible heat
+ "ocean_model", "ave_rsntds",          "ave_rsntds",          "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean SW
+ "ocean_model", "ave_rlntds",          "ave_rlntds",          "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean LW
+ "ocean_model", "ave_hflso",           "ave_hflso",           "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean latent
+ "ocean_model", "ave_hfds",            "ave_hfds",            "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean net heat surface
+ "ocean_model", "net_heat_coupler_ga", "net_heat_coupler_ga", "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean net heat coupler
+ "ocean_model", "LwLatSens_ga",        "LwLatSens_ga",        "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean LW + latent + sensible
+ "ocean_model", "ssh_ga",              "ssh_ga",              "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean ssh
+ "ocean_model", "precip_ga",           "precip_ga",           "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean precip
+
+# -----------------------------------------------------------------------------------------
+# Monthly snapshots
+# "ocean_model", "mass_wt",     "mass_wt",     "ocean_month_snap", "all", "none", "none",2
+# "ocean_model", "opottempmint","opottempmint","ocean_month_snap", "all", "none", "none",2
+# "ocean_model", "somint",      "somint",      "ocean_month_snap", "all", "none", "none",2
+
+# -----------------------------------------------------------------------------------------
+# tracer concentration time tendencies due to various processes
+
+# vertical diffusion tendencies for T and S
+"ocean_model","diabatic_diff_temp_tendency","diabatic_diff_temp_tendency","ocean_annual","all","mean","none",2
+"ocean_model","diabatic_diff_saln_tendency","diabatic_diff_saln_tendency","ocean_annual","all","mean","none",2
+
+# neutral diffusion tendencies for T and S
+"ocean_model","ndiff_tracer_conc_tendency_T","ndiff_tracer_conc_tendency_T" ,"ocean_annual","all","mean","none",2
+"ocean_model","ndiff_tracer_conc_tendency_S","ndiff_tracer_conc_tendency_S" ,"ocean_annual","all","mean","none",2
+"ocean_model","opottemppmdiff_2d"           ,"opottemppmdiff_2d"            ,"ocean_annual","all","mean","none",2
+"ocean_model","osaltpmdiff_2d"              ,"osaltpmdiff_2d"               ,"ocean_annual","all","mean","none",2
+
+# net tendencies and lateral advection tendencies for T and S
+ "ocean_model", "T_tendency",        "T_tendency",         "ocean_annual","all","mean","none",2
+ "ocean_model", "S_tendency",        "S_tendency",         "ocean_annual","all","mean","none",2
+ "ocean_model", "opottemptend_2d",   "opottemptend_2d",    "ocean_annual","all","mean","none",2
+ "ocean_model", "osalttend_2d",      "osalttend_2d",       "ocean_annual","all","mean","none",2
+ "ocean_model", "T_advection_xy_2d", "T_advection_xy_2d",  "ocean_annual","all","mean","none",2
+ "ocean_model", "S_advection_xy_2d", "S_advection_xy_2d",  "ocean_annual","all","mean","none",2
+
+# tendencies from vertical remapping for T and S
+"ocean_model","T_tendency_vert_remap",     "T_tendency_vert_remap",     "ocean_annual","all","mean","none",2
+"ocean_model","S_tendency_vert_remap",     "S_tendency_vert_remap",     "ocean_annual","all","mean","none",2
+"ocean_model","Th_tendency_vert_remap_2d", "Th_tendency_vert_remap_2d", "ocean_annual","all","mean","none",2
+"ocean_model","Sh_tendency_vert_remap_2d", "Sh_tendency_vert_remap_2d", "ocean_annual","all","mean","none",2
+
+# tendencies from boundary terms which have a 3d contribution
+"ocean_model","frazil_heat_tendency_2d"           ,"frazil_heat_tendency_2d",          "ocean_annual","all","mean","none",2
+"ocean_model","boundary_forcing_heat_tendency_2d" ,"boundary_forcing_heat_tendency_2d","ocean_annual","all","mean","none",2
+"ocean_model","boundary_forcing_salt_tendency_2d" ,"boundary_forcing_salt_tendency_2d","ocean_annual","all","mean","none",2
+
+
+
+


### PR DESCRIPTION
These are two modifications to diag table for use with CMIP6.

--diag_table.MOM6 now has the geothermal heating diagnostic enabled.  This is a static 2d field.  
--diag_table.MOM6_spinup removes daily fields and removes most of the monthly fields as well. The aim is to reduce the archive output for spin up.

Steve 