### PR TITLE
Adding required volcello to diag_table

### DIFF
--- a/ice_ocean_SIS2/SIS2_icebergs/diag_table
+++ b/ice_ocean_SIS2/SIS2_icebergs/diag_table
@@ -182,6 +182,11 @@ GOLD_SIS
 "ocean_model","LwLatSens","LwLatSens","ocean_day","all",.true.,"none",2
 "ocean_model","p_surf",   "p_surf",   "ocean_day","all",.true.,"none",2
 "ocean_model","salt_flux","salt_flux","ocean_day","all",.true.,"none",2
+# -----------------------------------------------------------------------------------------
+# CMIP6/OMIP Table H1: scalar fields such as tracers, cell mass/volume, sea level, MLD
+# Generally save annuals, and sometimes monthly and daily.
+ "ocean_model_z", "volcello",     "volcello",         "ocean_day_z",      "all", "mean", "none",2 # Cell measure for 3d data
+ "ocean_model",   "volcello",     "volcello",         "ocean_day",        "all", "mean", "none",2 # Cell measure for 3d data
 
 # Static ocean fields:
 #=====================


### PR DESCRIPTION
- Tests won't run without adding the volcello to diag_table
FATAL from PE     3: diag_manager_mod::init_field_cell_measures: VOLUME measures field "ocean_model/volcello" NOT in diag_table with correct output frequency for field ocean_model/h