### PR TITLE
Updated cmocean module import

### DIFF
--- a/tools/analysis/m6plot.py
+++ b/tools/analysis/m6plot.py
@@ -18,8 +18,14 @@ import VerticalSplitScale
 
 try: from mpl_toolkits.basemap import Basemap
 except: print('Basemap module not found. Some regional plots may not function properly')
-try: import cmocean
-except: print('cmocean module not found. Some color maps may not render properly')
+
+try: 
+  import cmocean
+except: 
+  if "HTTP_USER_AGENT" in os.environ.keys():
+    pass
+  else:
+    print('cmocean module not found. Some color maps may not render properly')
 
 from sys import modules
 


### PR DESCRIPTION
  - If running in a webapp, keys off of environment to
    determine whether or not to print error message.
    (If error message thrown before "Content-type" header
     is declared, most servers will display a page error.)