### PR TITLE
Reset exec permissions of python scripts

### DIFF
--- a/tools/analysis/MOM6_refineDiag.csh
+++ b/tools/analysis/MOM6_refineDiag.csh
@@ -90,6 +90,8 @@ pwd
 ls -l
 
 set script_dir=${out_dir}/mom6/tools/analysis
+#gcp does not preserve executable bit, re-set it in order to work after transfer
+chmod +x $script_dir/*.py
 
 set ocean_static_file = $yr1.ocean_static.nc
 if ( -e $yr1.ocean_static_no_mask_table.nc ) set ocean_static_file = $yr1.ocean_static_no_mask_table.nc


### PR DESCRIPTION
- gcp does not preserve the executbale permissions of the files
  hence the python scripts cannot be called directly after transfer
  from gaea to gfdl and hence analysis fails.
  This commit tries to reset the missing x permission.