### PR TITLE
Adds Baltic OM4_05 test case

### DIFF
--- a/ice_ocean_SIS2/Baltic_OM4_05/INPUT/MOM_channels_global_025
+++ b/ice_ocean_SIS2/Baltic_OM4_05/INPUT/MOM_channels_global_025
@@ -1,0 +1,1 @@
+../../OM4_025/INPUT/MOM_channels_global_025

--- a/ice_ocean_SIS2/Baltic_OM4_05/INPUT/analysis_vgrid_lev35.v1.cdl
+++ b/ice_ocean_SIS2/Baltic_OM4_05/INPUT/analysis_vgrid_lev35.v1.cdl
@@ -1,0 +1,26 @@
+netcdf analysis_vgrid_lev35.v1 {
+dimensions:
+	zt = 35 ;
+	zw = 36 ;
+variables:
+	double zw(zw) ;
+		zw:comment = "Used for diagnostics only, based on WOA09 standard levels" ;
+		zw:long_name = "Diagnostic depth coordinate interface position" ;
+		zw:units = "m" ;
+	double zt(zt) ;
+		zt:comment = "Used for diagnostics only, based on WOA09 standard levels" ;
+		zt:long_name = "Diagnostic depth coordinate level position" ;
+		zt:units = "m" ;
+
+// global attributes:
+		:filename = "analysis_vgrid_lev35.v1.nc" ;
+data:
+
+ zw = 0, 5, 15, 25, 40, 62.5, 87.5, 112.5, 137.5, 175, 225, 275, 350, 450, 
+    550, 650, 750, 850, 950, 1050, 1150, 1250, 1350, 1450, 1625, 1875, 2250, 
+    2750, 3250, 3750, 4250, 4750, 5250, 5750, 6250, 6750 ;
+
+ zt = 2.5, 10, 20, 30, 50, 75, 100, 125, 150, 200, 250, 300, 400, 500, 600, 
+    700, 800, 900, 1000, 1100, 1200, 1300, 1400, 1500, 1750, 2000, 2500, 
+    3000, 3500, 4000, 4500, 5000, 5500, 6000, 6500 ;
+}

--- a/ice_ocean_SIS2/Baltic_OM4_05/INPUT/hycom1_75_800m.cdl
+++ b/ice_ocean_SIS2/Baltic_OM4_05/INPUT/hycom1_75_800m.cdl
@@ -1,0 +1,1 @@
+../../OM4_025/INPUT/hycom1_75_800m.cdl

--- a/ice_ocean_SIS2/Baltic_OM4_05/INPUT/make_from_OM4_05
+++ b/ice_ocean_SIS2/Baltic_OM4_05/INPUT/make_from_OM4_05
@@ -1,0 +1,31 @@
+#!/bin/tcsh
+# This script is intended to make a subset of the OM4_05 grid to make a test case for the Baltic region (closed boundaries)
+
+# Some routines may need
+module load fre-nctools nco
+
+# Set some environment variables
+set OM4_INPUT="/archive/gold/datasets/OM4_05/INPUT/"
+set OM4_MOSAIC="/archive/gold/datasets/OM4_05/INPUT/mosaic.v20151203.unpacked/"
+set NX_MIN=612
+set NX_MAX=660
+set NY_MIN=410
+set NY_MAX=462
+
+# First make a subset of the supergrid
+#ncks -O -d nx,1224,1321 -d ny,820,925 -d nxp,1224,1322 -d nyp,820,926 $OM4_MOSAIC/ocean_hgrid.nc ocean_hgrid.nc
+#
+## Regrid the topography
+#ncks -O -d nx,$NX_MIN,$NX_MAX -d ny,$NY_MIN,$NY_MAX $OM4_MOSAIC/ocean_topog.nc ocean_topog.nc
+#ncap2 -A -s 'defdim("ntiles",1)' ocean_topog.nc ocean_topog.nc
+#
+## Make ocean, land, mosaic
+#make_solo_mosaic --num_tiles 1 --dir . --mosaic_name ocean_mosaic --tile_file ocean_hgrid.nc --periodx 360
+#make_quick_mosaic --input_mosaic ocean_mosaic.nc --mosaic_name grid_spec --ocean_topog ocean_topog.nc
+#
+## Process input files
+#ncks -O -d ny,$NY_MIN,$NY_MAX -d nx,$NX_MIN,$NX_MAX $OM4_INPUT/tidal_amplitude.v2015.12.03.nc tidal_amplitude.v2015.12.03.nc
+#ncks -O -d LAT,$NY_MIN,$NY_MAX -d LON,$NX_MIN,$NX_MAX $OM4_INPUT/seawifs_1998-2006_smoothed_2X.v2015.12.03.nc seawifs_1998-2006_smoothed_2X.v2015.12.03.nc
+#ncks -O -d LAT,$NY_MIN,$NY_MAX -d LON,$NX_MIN,$NX_MAX $OM4_INPUT/salt_restore.v2015.12.03.nc salt_restore.v2015.12.03.nc
+#ncks -O -d grid_y_T,$NY_MIN,$NY_MAX -d grid_x_T,$NX_MIN,$NX_MAX $OM4_INPUT/runoff.daitren.clim.v2011.02.10a.720x576.nc runoff.daitren.clim.v2011.02.10a.720x576.nc
+ncks -O -d j,$NY_MIN,$NY_MAX -d i,$NX_MIN,$NX_MAX $OM4_INPUT/geothermal_davies2013_v1.nc geothermal_davies2013_v1.nc 

--- a/ice_ocean_SIS2/Baltic_OM4_05/INPUT/make_from_OM4_05
+++ b/ice_ocean_SIS2/Baltic_OM4_05/INPUT/make_from_OM4_05
@@ -12,20 +12,20 @@ set NX_MAX=660
 set NY_MIN=410
 set NY_MAX=462
 
-# First make a subset of the supergrid
-#ncks -O -d nx,1224,1321 -d ny,820,925 -d nxp,1224,1322 -d nyp,820,926 $OM4_MOSAIC/ocean_hgrid.nc ocean_hgrid.nc
-#
-## Regrid the topography
-#ncks -O -d nx,$NX_MIN,$NX_MAX -d ny,$NY_MIN,$NY_MAX $OM4_MOSAIC/ocean_topog.nc ocean_topog.nc
-#ncap2 -A -s 'defdim("ntiles",1)' ocean_topog.nc ocean_topog.nc
-#
-## Make ocean, land, mosaic
-#make_solo_mosaic --num_tiles 1 --dir . --mosaic_name ocean_mosaic --tile_file ocean_hgrid.nc --periodx 360
-#make_quick_mosaic --input_mosaic ocean_mosaic.nc --mosaic_name grid_spec --ocean_topog ocean_topog.nc
-#
-## Process input files
-#ncks -O -d ny,$NY_MIN,$NY_MAX -d nx,$NX_MIN,$NX_MAX $OM4_INPUT/tidal_amplitude.v2015.12.03.nc tidal_amplitude.v2015.12.03.nc
-#ncks -O -d LAT,$NY_MIN,$NY_MAX -d LON,$NX_MIN,$NX_MAX $OM4_INPUT/seawifs_1998-2006_smoothed_2X.v2015.12.03.nc seawifs_1998-2006_smoothed_2X.v2015.12.03.nc
-#ncks -O -d LAT,$NY_MIN,$NY_MAX -d LON,$NX_MIN,$NX_MAX $OM4_INPUT/salt_restore.v2015.12.03.nc salt_restore.v2015.12.03.nc
-#ncks -O -d grid_y_T,$NY_MIN,$NY_MAX -d grid_x_T,$NX_MIN,$NX_MAX $OM4_INPUT/runoff.daitren.clim.v2011.02.10a.720x576.nc runoff.daitren.clim.v2011.02.10a.720x576.nc
+ First make a subset of the supergrid
+ncks -O -d nx,1224,1321 -d ny,820,925 -d nxp,1224,1322 -d nyp,820,926 $OM4_MOSAIC/ocean_hgrid.nc ocean_hgrid.nc
+
+# Regrid the topography
+ncks -O -d nx,$NX_MIN,$NX_MAX -d ny,$NY_MIN,$NY_MAX $OM4_MOSAIC/ocean_topog.nc ocean_topog.nc
+ncap2 -A -s 'defdim("ntiles",1)' ocean_topog.nc ocean_topog.nc
+
+# Make ocean, land, mosaic
+make_solo_mosaic --num_tiles 1 --dir . --mosaic_name ocean_mosaic --tile_file ocean_hgrid.nc --periodx 360
+make_quick_mosaic --input_mosaic ocean_mosaic.nc --mosaic_name grid_spec --ocean_topog ocean_topog.nc
+
+# Process input files
+ncks -O -d ny,$NY_MIN,$NY_MAX -d nx,$NX_MIN,$NX_MAX $OM4_INPUT/tidal_amplitude.v2015.12.03.nc tidal_amplitude.v2015.12.03.nc
+ncks -O -d LAT,$NY_MIN,$NY_MAX -d LON,$NX_MIN,$NX_MAX $OM4_INPUT/seawifs_1998-2006_smoothed_2X.v2015.12.03.nc seawifs_1998-2006_smoothed_2X.v2015.12.03.nc
+ncks -O -d LAT,$NY_MIN,$NY_MAX -d LON,$NX_MIN,$NX_MAX $OM4_INPUT/salt_restore.v2015.12.03.nc salt_restore.v2015.12.03.nc
+ncks -O -d grid_y_T,$NY_MIN,$NY_MAX -d grid_x_T,$NX_MIN,$NX_MAX $OM4_INPUT/runoff.daitren.clim.v2011.02.10a.720x576.nc runoff.daitren.clim.v2011.02.10a.720x576.nc
 ncks -O -d j,$NY_MIN,$NY_MAX -d i,$NX_MIN,$NX_MAX $OM4_INPUT/geothermal_davies2013_v1.nc geothermal_davies2013_v1.nc 

--- a/ice_ocean_SIS2/Baltic_OM4_05/MOM_input
+++ b/ice_ocean_SIS2/Baltic_OM4_05/MOM_input
@@ -1,0 +1,1 @@
+../OM4_05/MOM_input

--- a/ice_ocean_SIS2/Baltic_OM4_05/MOM_override
+++ b/ice_ocean_SIS2/Baltic_OM4_05/MOM_override
@@ -1,0 +1,5 @@
+! Blank file in which we can put "overrides" for parameters !VERBOSITY = 9
+#override NIGLOBAL = 49
+#override NJGLOBAL = 53
+#override REENTRANT_X = False
+#override TRIPOLAR_N = False

--- a/ice_ocean_SIS2/Baltic_OM4_05/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/Baltic_OM4_05/MOM_parameter_doc.all
@@ -1,0 +1,2213 @@
+! This file was written by the model and records all non-layout or debugging parameters used at run-time.
+
+! === module MOM ===
+VERBOSITY = 2                   ! default = 2
+                                ! Integer controlling level of messaging
+                                !   0 = Only FATAL messages
+                                !   2 = Only FATAL, WARNING, NOTE [default]
+                                !   9 = All)
+DO_UNIT_TESTS = False           !   [Boolean] default = False
+                                ! If True, exercises unit tests at model start up.
+SPLIT = True                    !   [Boolean] default = True
+                                ! Use the split time stepping if true.
+CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False
+                                ! If true, the in-situ density is used to calculate the
+                                ! effective sea level that is returned to the coupler. If false,
+                                ! the Boussinesq parameter RHO_0 is used.
+ENABLE_THERMODYNAMICS = True    !   [Boolean] default = True
+                                ! If true, Temperature and salinity are used as state
+                                ! variables.
+USE_EOS = True                  !   [Boolean] default = True
+                                ! If true,  density is calculated from temperature and
+                                ! salinity with an equation of state.  If USE_EOS is
+                                ! true, ENABLE_THERMODYNAMICS must be true as well.
+DIABATIC_FIRST = False          !   [Boolean] default = False
+                                ! If true, apply diabatic and thermodynamic processes,
+                                ! including buoyancy forcing and mass gain or loss,
+                                ! before stepping the dynamics forward.
+USE_CONTEMP_ABSSAL = False      !   [Boolean] default = False
+                                ! If true, , the prognostics T&S are the conservative temperature
+                                ! and absolute salinity. Care should be taken to convert them
+                                ! to potential temperature and practical salinity before
+                                ! exchanging them with the coupler and/or reporting T&S diagnostics.
+ADIABATIC = False               !   [Boolean] default = False
+                                ! There are no diapycnal mass fluxes if ADIABATIC is
+                                ! true. This assumes that KD = KDML = 0.0 and that
+                                ! there is no buoyancy forcing, but makes the model
+                                ! faster by eliminating subroutine calls.
+OFFLINE_TRACER_MODE = False     !   [Boolean] default = False
+                                ! If true, barotropic and baroclinic dynamics, thermodynamics
+                                ! are all bypassed with all the fields necessary to integrate
+                                ! the tracer advection and diffusion equation are read in from
+                                ! files stored from a previous integration of the prognostic model.
+                                ! NOTE: This option only used in the ocean_solo_driver.
+USE_REGRIDDING = True           !   [Boolean] default = False
+                                ! If True, use the ALE algorithm (regridding/remapping).
+                                ! If False, use the layered isopycnal algorithm.
+BULKMIXEDLAYER = False          !   [Boolean] default = False
+                                ! If true, use a Kraus-Turner-like bulk mixed layer
+                                ! with transitional buffer layers.  Layers 1 through
+                                ! NKML+NKBL have variable densities. There must be at
+                                ! least NKML+NKBL+1 layers if BULKMIXEDLAYER is true.
+                                ! BULKMIXEDLAYER can not be used with USE_REGRIDDING.
+                                ! The default is influenced by ENABLE_THERMODYNAMICS.
+THICKNESSDIFFUSE = True         !   [Boolean] default = False
+                                ! If true, interface heights are diffused with a
+                                ! coefficient of KHTH.
+THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
+                                ! If true, do thickness diffusion before dynamics.
+                                ! This is only used if THICKNESSDIFFUSE is true.
+BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
+                                ! If true, there are separate values for the basin depths
+                                ! at velocity points.  Otherwise the effects of topography
+                                ! are entirely determined from thickness points.
+DEBUG = False                   !   [Boolean] default = False
+                                ! If true, write out verbose debugging data.
+DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
+                                ! If true, calculate all diagnostics that are useful for
+                                ! debugging truncations.
+DT = 1800.0                     !   [s]
+                                ! The (baroclinic) dynamics time step.  The time-step that
+                                ! is actually used will be an integer fraction of the
+                                ! forcing time-step (DT_FORCING in ocean-only mode or the
+                                ! coupling timestep in coupled mode.)
+DT_THERM = 1.08E+04             !   [s] default = 1800.0
+                                ! The thermodynamic and tracer advection time step.
+                                ! Ideally DT_THERM should be an integer multiple of DT
+                                ! and less than the forcing or coupling time-step, unless
+                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
+                                ! can be an integer multiple of the coupling timestep.  By
+                                ! default DT_THERM is set to DT.
+THERMO_SPANS_COUPLING = True    !   [Boolean] default = False
+                                ! If true, the MOM will take thermodynamic and tracer
+                                ! timesteps that can be longer than the coupling timestep.
+                                ! The actual thermodynamic timestep that is used in this
+                                ! case is the largest integer multiple of the coupling
+                                ! timestep that is less than or equal to DT_THERM.
+HMIX_SFC_PROP = 1.0             !   [m] default = 1.0
+                                ! If BULKMIXEDLAYER is false, HMIX_SFC_PROP is the depth
+                                ! over which to average to find surface properties like
+                                ! SST and SSS or density (but not surface velocities).
+HMIX_UV_SFC_PROP = 0.0          !   [m] default = 0.0
+                                ! If BULKMIXEDLAYER is false, HMIX_UV_SFC_PROP is the depth
+                                ! over which to average to find surface flow properties,
+                                ! SSU, SSV. A non-positive value indicates no averaging.
+MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
+                                ! The minimum amount of time in seconds between
+                                ! calculations of depth-space diagnostics. Making this
+                                ! larger than DT_THERM reduces the  performance penalty
+                                ! of regridding to depth online.
+INTERPOLATE_P_SURF = False      !   [Boolean] default = False
+                                ! If true, linearly interpolate the surface pressure
+                                ! over the coupling time step, using the specified value
+                                ! at the end of the step.
+DTBT_RESET_PERIOD = 1.08E+04    !   [s] default = 1.08E+04
+                                ! The period between recalculations of DTBT (if DTBT <= 0).
+                                ! If DTBT_RESET_PERIOD is negative, DTBT is set based
+                                ! only on information available at initialization.  If
+                                ! dynamic, DTBT will be set at least every forcing time
+                                ! step, and if 0, every dynamics time step.  The default is
+                                ! set by DT_THERM.  This is only used if SPLIT is true.
+FRAZIL = True                   !   [Boolean] default = False
+                                ! If true, water freezes if it gets too cold, and the
+                                ! the accumulated heat deficit is returned in the
+                                ! surface state.  FRAZIL is only used if
+                                ! ENABLE_THERMODYNAMICS is true.
+DO_GEOTHERMAL = True            !   [Boolean] default = False
+                                ! If true, apply geothermal heating.
+BOUND_SALINITY = True           !   [Boolean] default = False
+                                ! If true, limit salinity to being positive. (The sea-ice
+                                ! model may ask for more salt than is available and
+                                ! drive the salinity negative otherwise.)
+C_P = 3992.0                    !   [J kg-1 K-1] default = 3991.86795711963
+                                ! The heat capacity of sea water, approximated as a
+                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
+                                ! true. The default value is from the TEOS-10 definition
+                                ! of conservative temperature.
+P_REF = 2.0E+07                 !   [Pa] default = 2.0E+07
+                                ! The pressure that is used for calculating the coordinate
+                                ! density.  (1 Pa = 1e4 dbar, so 2e7 is commonly used.)
+                                ! This is only used if USE_EOS and ENABLE_THERMODYNAMICS
+                                ! are true.
+FIRST_DIRECTION = 0             ! default = 0
+                                ! An integer that indicates which direction goes first
+                                ! in parts of the code that use directionally split
+                                ! updates, with even numbers (or 0) used for x- first
+                                ! and odd numbers used for y-first.
+CHECK_BAD_SURFACE_VALS = True   !   [Boolean] default = False
+                                ! If true, check the surface state for ridiculous values.
+BAD_VAL_SSH_MAX = 50.0          !   [m] default = 20.0
+                                ! The value of SSH above which a bad value message is
+                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+BAD_VAL_SSS_MAX = 75.0          !   [PPT] default = 45.0
+                                ! The value of SSS above which a bad value message is
+                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+BAD_VAL_SST_MAX = 55.0          !   [deg C] default = 45.0
+                                ! The value of SST above which a bad value message is
+                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+BAD_VAL_SST_MIN = -3.0          !   [deg C] default = -2.1
+                                ! The value of SST below which a bad value message is
+                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+BAD_VAL_COLUMN_THICKNESS = 0.0  !   [m] default = 0.0
+                                ! The value of column thickness below which a bad value message is
+                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+SAVE_INITIAL_CONDS = False      !   [Boolean] default = False
+                                ! If true, write the initial conditions to a file given
+                                ! by IC_OUTPUT_FILE.
+IC_OUTPUT_FILE = "MOM_IC"       ! default = "MOM_IC"
+                                ! The file into which to write the initial conditions.
+WRITE_GEOM = 1                  ! default = 1
+                                ! If =0, never write the geometry and vertical grid files.
+                                ! If =1, write the geometry and vertical grid files only for
+                                ! a new simulation. If =2, always write the geometry and
+                                ! vertical grid files. Other values are invalid.
+
+! === module MOM_domains ===
+REENTRANT_X = False             !   [Boolean] default = True
+                                ! If true, the domain is zonally reentrant.
+REENTRANT_Y = False             !   [Boolean] default = False
+                                ! If true, the domain is meridionally reentrant.
+TRIPOLAR_N = False              !   [Boolean] default = False
+                                ! Use tripolar connectivity at the northern edge of the
+                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+NIGLOBAL = 49                   !
+                                ! The total number of thickness grid points in the
+                                ! x-direction in the physical domain. With STATIC_MEMORY_
+                                ! this is set in MOM_memory.h at compile time.
+NJGLOBAL = 53                   !
+                                ! The total number of thickness grid points in the
+                                ! y-direction in the physical domain. With STATIC_MEMORY_
+                                ! this is set in MOM_memory.h at compile time.
+DEBUG_CHKSUMS = False           !   [Boolean] default = False
+                                ! If true, checksums are performed on arrays in the
+                                ! various vec_chksum routines.
+DEBUG_REDUNDANT = False         !   [Boolean] default = False
+                                ! If true, debug redundant data points during calls to
+                                ! the various vec_chksum routines.
+
+! === module MOM_hor_index ===
+! Sets the horizontal array index types.
+
+! === module MOM_verticalGrid ===
+! Parameters providing information about the vertical grid.
+G_EARTH = 9.8                   !   [m s-2] default = 9.8
+                                ! The gravitational acceleration of the Earth.
+RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
+                                ! The mean ocean density used with BOUSSINESQ true to
+                                ! calculate accelerations and the mass for conservation
+                                ! properties, or with BOUSSINSEQ false to convert some
+                                ! parameters from vertical units of m to kg m-2.
+BOUSSINESQ = True               !   [Boolean] default = True
+                                ! If true, make the Boussinesq approximation.
+ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
+                                ! The minumum layer thickness, usually one-Angstrom.
+H_TO_M = 1.0                    !   [m H-1] default = 1.0
+                                ! A constant that translates the model's internal
+                                ! units of thickness into m.
+NK = 75                         !   [nondim]
+                                ! The number of model layers.
+
+! === module MOM_fixed_initialization ===
+INPUTDIR = "INPUT"              ! default = "."
+                                ! The directory in which input files are found.
+
+! === module MOM_grid_init ===
+GRID_CONFIG = "mosaic"          !
+                                ! A character string that determines the method for
+                                ! defining the horizontal grid.  Current options are:
+                                !     mosaic - read the grid from a mosaic (supergrid)
+                                !              file set by GRID_FILE.
+                                !     cartesian - use a (flat) Cartesian grid.
+                                !     spherical - use a simple spherical grid.
+                                !     mercator - use a Mercator spherical grid.
+GRID_FILE = "ocean_hgrid.nc"    !
+                                ! Name of the file from which to read horizontal grid data.
+TOPO_CONFIG = "file"            !
+                                ! This specifies how bathymetry is specified:
+                                !     file - read bathymetric information from the file
+                                !       specified by (TOPO_FILE).
+                                !     flat - flat bottom set to MAXIMUM_DEPTH.
+                                !     bowl - an analytically specified bowl-shaped basin
+                                !       ranging between MAXIMUM_DEPTH and MINIMUM_DEPTH.
+                                !     spoon - a similar shape to 'bowl', but with an vertical
+                                !       wall at the southern face.
+                                !     halfpipe - a zonally uniform channel with a half-sine
+                                !       profile in the meridional direction.
+                                !     benchmark - use the benchmark test case topography.
+                                !     Neverland - use the Neverland test case topography.
+                                !     DOME - use a slope and channel configuration for the
+                                !       DOME sill-overflow test case.
+                                !     ISOMIP - use a slope and channel configuration for the
+                                !       ISOMIP test case.
+                                !     DOME2D - use a shelf and slope configuration for the
+                                !       DOME2D gravity current/overflow test case.
+                                !     Kelvin - flat but with rotated land mask.
+                                !     seamount - Gaussian bump for spontaneous motion test case.
+                                !     shelfwave - exponential slope for shelfwave test case.
+                                !     supercritical - flat but with 8.95 degree land mask.
+                                !     Phillips - ACC-like idealized topography used in the Phillips config.
+                                !     dense - Denmark Strait-like dense water formation and overflow.
+                                !     USER - call a user modified routine.
+TOPO_FILE = "ocean_topog.nc"    ! default = "topog.nc"
+                                ! The file from which the bathymetry is read.
+TOPO_VARNAME = "depth"          ! default = "depth"
+                                ! The name of the bathymetry variable in TOPO_FILE.
+TOPO_EDITS_FILE = ""            ! default = ""
+                                ! The file from which to read a list of i,j,z topography overrides.
+MAXIMUM_DEPTH = 6500.0          !   [m]
+                                ! The maximum depth of the ocean.
+MINIMUM_DEPTH = 9.5             !   [m] default = 0.0
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than
+                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
+                                ! If MASKING_DEPTH is specified, then all depths shallower than
+                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+
+! === module MOM_open_boundary ===
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
+                                ! The number of open boundary segments.
+EXTEND_OBC_SEGMENTS = False     !   [Boolean] default = False
+                                ! If true, extend OBC segments. This option is used to recover
+                                ! legacy solutions dependent on an incomplete implementaion of OBCs.
+                                ! This option will be obsoleted in the future.
+MASKING_DEPTH = 0.0             !   [m] default = -9999.0
+                                ! The depth below which to mask points as land points, for which all
+                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+CHANNEL_CONFIG = "list"         ! default = "none"
+                                ! A parameter that determines which set of channels are
+                                ! restricted to specific  widths.  Options are:
+                                !     none - All channels have the grid width.
+                                !     global_1deg - Sets 16 specific channels appropriate
+                                !       for a 1-degree model, as used in CM2G.
+                                !     list - Read the channel locations and widths from a
+                                !       text file, like MOM_channel_list in the MOM_SIS
+                                !       test case.
+                                !     file - Read open face widths everywhere from a
+                                !       NetCDF file on the model grid.
+CHANNEL_LIST_FILE = "MOM_channels_global_025" ! default = "MOM_channel_list"
+                                ! The file from which the list of narrowed channels is read.
+CHANNEL_LIST_360_LON_CHECK = True !   [Boolean] default = True
+                                ! If true, the channel configuration list works for any
+                                ! longitudes in the range of -360 to 360.
+ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
+                                ! This specifies how the Coriolis parameter is specified:
+                                !     2omegasinlat - Use twice the planetary rotation rate
+                                !       times the sine of latitude.
+                                !     betaplane - Use a beta-plane or f-plane.
+                                !     USER - call a user modified routine.
+OMEGA = 7.2921E-05              !   [s-1] default = 7.2921E-05
+                                ! The rotation rate of the earth.
+PARALLEL_RESTARTFILES = True    !   [Boolean] default = False
+                                ! If true, each processor writes its own restart file,
+                                ! otherwise a single restart file is generated
+
+! === module MOM_tracer_registry ===
+
+! === module MOM_EOS ===
+EQN_OF_STATE = "WRIGHT"         ! default = "WRIGHT"
+                                ! EQN_OF_STATE determines which ocean equation of state
+                                ! should be used.  Currently, the valid choices are
+                                ! "LINEAR", "UNESCO", "WRIGHT", "NEMO" and "TEOS10".
+                                ! This is only used if USE_EOS is true.
+EOS_QUADRATURE = False          !   [Boolean] default = False
+                                ! If true, always use the generic (quadrature) code
+                                ! code for the integrals of density.
+TFREEZE_FORM = "LINEAR"         ! default = "LINEAR"
+                                ! TFREEZE_FORM determines which expression should be
+                                ! used for the freezing point.  Currently, the valid
+                                ! choices are "LINEAR", "MILLERO_78", "TEOS10"
+TFREEZE_S0_P0 = 0.0             !   [deg C] default = 0.0
+                                ! When TFREEZE_FORM=LINEAR,
+                                ! this is the freezing potential temperature at
+                                ! S=0, P=0.
+DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
+                                ! When TFREEZE_FORM=LINEAR,
+                                ! this is the derivative of the freezing potential
+                                ! temperature with salinity.
+DTFREEZE_DP = -7.75E-08         !   [deg C Pa-1] default = 0.0
+                                ! When TFREEZE_FORM=LINEAR,
+                                ! this is the derivative of the freezing potential
+                                ! temperature with pressure.
+
+! === module MOM_restart ===
+RESTARTFILE = "MOM.res"         ! default = "MOM.res"
+                                ! The name-root of the restart file.
+LARGE_FILE_SUPPORT = True       !   [Boolean] default = True
+                                ! If true, use the file-size limits with NetCDF large
+                                ! file support (4Gb), otherwise the limit is 2Gb.
+MAX_FIELDS = 100                ! default = 100
+                                ! The maximum number of restart fields that can be used.
+
+! === module MOM_tracer_flow_control ===
+USE_USER_TRACER_EXAMPLE = False !   [Boolean] default = False
+                                ! If true, use the USER_tracer_example tracer package.
+USE_DOME_TRACER = False         !   [Boolean] default = False
+                                ! If true, use the DOME_tracer tracer package.
+USE_ISOMIP_TRACER = False       !   [Boolean] default = False
+                                ! If true, use the ISOMIP_tracer tracer package.
+USE_IDEAL_AGE_TRACER = True     !   [Boolean] default = False
+                                ! If true, use the ideal_age_example tracer package.
+USE_REGIONAL_DYES = False       !   [Boolean] default = False
+                                ! If true, use the regional_dyes tracer package.
+USE_OIL_TRACER = False          !   [Boolean] default = False
+                                ! If true, use the oil_tracer tracer package.
+USE_ADVECTION_TEST_TRACER = False !   [Boolean] default = False
+                                ! If true, use the advection_test_tracer tracer package.
+USE_OCMIP2_CFC = False          !   [Boolean] default = False
+                                ! If true, use the MOM_OCMIP2_CFC tracer package.
+USE_generic_tracer = False      !   [Boolean] default = False
+                                ! If true and _USE_GENERIC_TRACER is defined as a
+                                ! preprocessor macro, use the MOM_generic_tracer packages.
+USE_PSEUDO_SALT_TRACER = False  !   [Boolean] default = False
+                                ! If true, use the pseudo salt tracer, typically run as a diagnostic.
+USE_BOUNDARY_IMPULSE_TRACER = False !   [Boolean] default = False
+                                ! If true, use the boundary impulse tracer.
+USE_DYED_OBC_TRACER = False     !   [Boolean] default = False
+                                ! If true, use the dyed_obc_tracer tracer package.
+
+! === module ideal_age_example ===
+DO_IDEAL_AGE = True             !   [Boolean] default = True
+                                ! If true, use an ideal age tracer that is set to 0 age
+                                ! in the mixed layer and ages at unit rate in the interior.
+DO_IDEAL_VINTAGE = False        !   [Boolean] default = False
+                                ! If true, use an ideal vintage tracer that is set to an
+                                ! exponentially increasing value in the mixed layer and
+                                ! is conserved thereafter.
+DO_IDEAL_AGE_DATED = False      !   [Boolean] default = False
+                                ! If true, use an ideal age tracer that is everywhere 0
+                                ! before IDEAL_AGE_DATED_START_YEAR, but the behaves like
+                                ! the standard ideal age tracer - i.e. is set to 0 age in
+                                ! the mixed layer and ages at unit rate in the interior.
+AGE_IC_FILE = ""                ! default = ""
+                                ! The file in which the age-tracer initial values can be
+                                ! found, or an empty string for internal initialization.
+AGE_IC_FILE_IS_Z = False        !   [Boolean] default = False
+                                ! If true, AGE_IC_FILE is in depth space, not layer space
+TRACERS_MAY_REINIT = False      !   [Boolean] default = False
+                                ! If true, tracers may go through the initialization code
+                                ! if they are not found in the restart files.  Otherwise
+                                ! it is a fatal error if the tracers are not found in the
+                                ! restart files of a restarted run.
+
+! === module MOM_coord_initialization ===
+COORD_CONFIG = "file"           !
+                                ! This specifies how layers are to be defined:
+                                !     ALE or none - used to avoid defining layers in ALE mode
+                                !     file - read coordinate information from the file
+                                !       specified by (COORD_FILE).
+                                !     BFB - Custom coords for buoyancy-forced basin case
+                                !       based on SST_S, T_BOT and DRHO_DT.
+                                !     linear - linear based on interfaces not layers
+                                !     layer_ref - linear based on layer densities
+                                !     ts_ref - use reference temperature and salinity
+                                !     ts_range - use range of temperature and salinity
+                                !       (T_REF and S_REF) to determine surface density
+                                !       and GINT calculate internal densities.
+                                !     gprime - use reference density (RHO_0) for surface
+                                !       density and GINT calculate internal densities.
+                                !     ts_profile - use temperature and salinity profiles
+                                !       (read from COORD_FILE) to set layer densities.
+                                !     USER - call a user modified routine.
+GFS = 9.8                       !   [m s-2] default = 9.8
+                                ! The reduced gravity at the free surface.
+COORD_FILE = "layer_coord.nc"   !
+                                ! The file from which the coordinate densities are read.
+COORD_VAR = "Layer"             ! default = "Layer"
+                                ! The variable in COORD_FILE that is to be used for the
+                                ! coordinate densities.
+BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
+                                ! When defined, the reconstruction is extrapolated
+                                ! within boundary cells rather than assume PCM for the.
+                                ! calculation of pressure. e.g. if PPM is used, a
+                                ! PPM reconstruction will also be used within
+                                ! boundary cells.
+RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
+                                ! If True, use vertical reconstruction of T/S within
+                                ! the integrals of teh FV pressure gradient calculation.
+                                ! If False, use the constant-by-layer algorithm.
+                                ! By default, this is True when using ALE and False otherwise.
+PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
+                                ! Type of vertical reconstruction of T/S to use in integrals
+                                ! within the FV pressure gradient calculation. 1: PLM reconstruction.
+                                !  2: PPM reconstruction.
+REMAP_UV_USING_OLD_ALG = True   !   [Boolean] default = True
+                                ! If true, uses the old remapping-via-a-delta-z method for
+                                ! remapping u and v. If false, uses the new method that remaps
+                                ! between grids described by an old and new thickness.
+REGRIDDING_COORDINATE_MODE = "HYCOM1" ! default = "LAYER"
+                                ! Coordinate mode for vertical regridding.
+                                ! Choose among the following possibilities:
+                                !  LAYER - Isopycnal or stacked shallow water layers
+                                !  ZSTAR, Z* - stetched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  SIGMA - terrain following coordinates
+                                !  RHO   - continuous isopycnal
+                                !  HYCOM1 - HyCOM-like hybrid coordinate
+                                !  SLIGHT - stretched coordinates above continuous isopycnal
+                                !  ADAPTIVE - optimize for smooth neutral density surfaces
+REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
+                                ! Units of the regridding coordinuate.
+INTERPOLATION_SCHEME = "P1M_H2" ! default = "P1M_H2"
+                                ! This sets the interpolation scheme to use to
+                                ! determine the new grid. These parameters are
+                                ! only relevant when REGRIDDING_COORDINATE_MODE is
+                                ! set to a function of state. Otherwise, it is not
+                                ! used. It can be one of the following schemes:
+                                !  P1M_H2     (2nd-order accurate)
+                                !  P1M_H4     (2nd-order accurate)
+                                !  P1M_IH4    (2nd-order accurate)
+                                !  PLM        (2nd-order accurate)
+                                !  PPM_H4     (3rd-order accurate)
+                                !  PPM_IH4    (3rd-order accurate)
+                                !  P3M_IH4IH3 (4th-order accurate)
+                                !  P3M_IH6IH5 (4th-order accurate)
+                                !  PQM_IH4IH3 (4th-order accurate)
+                                !  PQM_IH6IH5 (5th-order accurate)
+BOUNDARY_EXTRAPOLATION = True   !   [Boolean] default = False
+                                ! When defined, a proper high-order reconstruction
+                                ! scheme is used within boundary cells rather
+                                ! than PCM. E.g., if PPM is used for remapping, a
+                                ! PPM reconstruction will also be used within
+                                ! boundary cells.
+ALE_COORDINATE_CONFIG = "HYBRID:hycom1_75_800m.nc,sigma2,FNC1:2,4000,4.5,.01" ! default = "UNIFORM"
+                                ! Determines how to specify the coordinate
+                                ! resolution. Valid options are:
+                                !  PARAM       - use the vector-parameter ALE_RESOLUTION
+                                !  UNIFORM[:N] - uniformly distributed
+                                !  FILE:string - read from a file. The string specifies
+                                !                the filename and variable name, separated
+                                !                by a comma or space, e.g. FILE:lev.nc,dz
+                                !                or FILE:lev.nc,interfaces=zw
+                                !  WOA09[:N]   - the WOA09 vertical grid (approximately)
+                                !  FNC1:string - FNC1:dz_min,H_total,power,precision
+                                !  HYBRID:string - read from a file. The string specifies
+                                !                the filename and two variable names, separated
+                                !                by a comma or space, for sigma-2 and dz. e.g.
+                                !                HYBRID:vgrid.nc,sigma2,dz
+!ALE_RESOLUTION = 7*2.0, 2*2.01, 2.02, 2.03, 2.05, 2.08, 2.11, 2.15, 2.21, 2.2800000000000002, 2.37, 2.48, 2.61, 2.77, 2.95, 3.17, 3.4299999999999997, 3.74, 4.09, 4.49, 4.95, 5.48, 6.07, 6.74, 7.5, 8.34, 9.280000000000001, 10.33, 11.49, 12.77, 14.19, 15.74, 17.450000000000003, 19.31, 21.35, 23.56, 25.97, 28.580000000000002, 31.41, 34.47, 37.77, 41.32, 45.14, 49.25, 53.65, 58.370000000000005, 63.42, 68.81, 74.56, 80.68, 87.21000000000001, 94.14, 101.51, 109.33, 117.62, 126.4, 135.68, 145.5, 155.87, 166.81, 178.35, 190.51, 203.31, 216.78, 230.93, 245.8, 261.42, 277.83 !   [m]
+                                ! The distribution of vertical resolution for the target
+                                ! grid used for Eulerian-like coordinates. For example,
+                                ! in z-coordinate mode, the parameter is a list of level
+                                ! thicknesses (in m). In sigma-coordinate mode, the list
+                                ! is of non-dimensional fractions of the water column.
+!TARGET_DENSITIES = 1010.0, 1014.3034, 1017.8088, 1020.843, 1023.5566, 1025.813, 1027.0275, 1027.9114, 1028.6422, 1029.2795, 1029.852, 1030.3762, 1030.8626, 1031.3183, 1031.7486, 1032.1572, 1032.5471, 1032.9207, 1033.2798, 1033.6261, 1033.9608, 1034.2519, 1034.4817, 1034.6774, 1034.8508, 1035.0082, 1035.1533, 1035.2886, 1035.4159, 1035.5364, 1035.6511, 1035.7608, 1035.8661, 1035.9675, 1036.0645, 1036.1554, 1036.2411, 1036.3223, 1036.3998, 1036.4739, 1036.5451, 1036.6137, 1036.68, 1036.7441, 1036.8062, 1036.8526, 1036.8874, 1036.9164, 1036.9418, 1036.9647, 1036.9857, 1037.0052, 1037.0236, 1037.0409, 1037.0574, 1037.0738, 1037.0902, 1037.1066, 1037.123, 1037.1394, 1037.1558, 1037.1722, 1037.1887, 1037.206, 1037.2241, 1037.2435, 1037.2642, 1037.2866, 1037.3112, 1037.3389, 1037.3713, 1037.4118, 1037.475, 1037.6332, 1037.8104, 1038.0 !   [m]
+                                ! HYBRID target densities for itnerfaces
+REGRID_COMPRESSIBILITY_FRACTION = 0.01 !   [not defined] default = 0.0
+                                ! When interpolating potential density profiles we can add
+                                ! some artificial compressibility solely to make homogenous
+                                ! regions appear stratified.
+MIN_THICKNESS = 0.001           !   [m] default = 0.001
+                                ! When regridding, this is the minimum layer
+                                ! thickness allowed.
+MAXIMUM_INT_DEPTH_CONFIG = "FNC1:5,8000.0,1.0,.01" ! default = "NONE"
+                                ! Determines how to specify the maximum interface depths.
+                                ! Valid options are:
+                                !  NONE        - there are no maximum interface depths
+                                !  PARAM       - use the vector-parameter MAXIMUM_INTERFACE_DEPTHS
+                                !  FILE:string - read from a file. The string specifies
+                                !                the filename and variable name, separated
+                                !                by a comma or space, e.g. FILE:lev.nc,Z
+                                !  FNC1:string - FNC1:dz_min,H_total,power,precision
+!MAXIMUM_INT_DEPTHS = 0.0, 5.0, 12.75, 23.25, 36.49, 52.480000000000004, 71.22, 92.71000000000001, 116.94000000000001, 143.92000000000002, 173.65, 206.13, 241.36, 279.33000000000004, 320.05000000000007, 363.5200000000001, 409.7400000000001, 458.7000000000001, 510.4100000000001, 564.8700000000001, 622.0800000000002, 682.0300000000002, 744.7300000000002, 810.1800000000003, 878.3800000000003, 949.3300000000004, 1023.0200000000004, 1099.4600000000005, 1178.6500000000005, 1260.5900000000006, 1345.2700000000007, 1432.7000000000007, 1522.8800000000008, 1615.8100000000009, 1711.490000000001, 1809.910000000001, 1911.080000000001, 2015.0000000000011, 2121.670000000001, 2231.080000000001, 2343.2400000000007, 2458.1500000000005, 2575.8100000000004, 2696.2200000000003, 2819.3700000000003, 2945.2700000000004, 3073.9200000000005, 3205.3200000000006, 3339.4600000000005, 3476.3500000000004, 3615.9900000000002, 3758.38, 3903.52, 4051.4, 4202.03, 4355.41, 4511.54, 4670.41, 4832.03, 4996.4, 5163.5199999999995, 5333.379999999999, 5505.989999999999, 5681.3499999999985, 5859.459999999998, 6040.319999999998, 6223.919999999998, 6410.269999999999, 6599.369999999999, 6791.219999999999, 6985.8099999999995, 7183.15, 7383.24, 7586.08, 7791.67, 8000.0
+                                ! The list of maximum depths for each interface.
+MAX_LAYER_THICKNESS_CONFIG = "FNC1:400,31000.0,0.1,.01" ! default = "NONE"
+                                ! Determines how to specify the maximum layer thicknesses.
+                                ! Valid options are:
+                                !  NONE        - there are no maximum layer thicknesses
+                                !  PARAM       - use the vector-parameter MAX_LAYER_THICKNESS
+                                !  FILE:string - read from a file. The string specifies
+                                !                the filename and variable name, separated
+                                !                by a comma or space, e.g. FILE:lev.nc,Z
+                                !  FNC1:string - FNC1:dz_min,H_total,power,precision
+!MAX_LAYER_THICKNESS = 400.0, 409.63, 410.32, 410.75, 411.07, 411.32, 411.52, 411.7, 411.86, 412.0, 412.13, 412.24, 412.35, 412.45, 412.54, 412.63, 412.71, 412.79, 412.86, 412.93, 413.0, 413.06, 413.12, 413.18, 413.24, 413.29, 413.34, 413.39, 413.44, 413.49, 413.54, 413.58, 413.62, 413.67, 413.71, 413.75, 413.78, 413.82, 413.86, 413.9, 413.93, 413.97, 414.0, 414.03, 414.06, 414.1, 414.13, 414.16, 414.19, 414.22, 414.24, 414.27, 414.3, 414.33, 414.35, 414.38, 414.41, 414.43, 414.46, 414.48, 414.51, 414.53, 414.55, 414.58, 414.6, 414.62, 414.65, 414.67, 414.69, 414.71, 414.73, 414.75, 414.77, 414.79, 414.83 !   [m]
+                                ! The list of maximum thickness for each layer.
+REMAPPING_SCHEME = "PPM_H4"     ! default = "PLM"
+                                ! This sets the reconstruction scheme used
+                                ! for vertical remapping for all variables.
+                                ! It can be one of the following schemes:
+                                ! PCM         (1st-order accurate)
+                                ! PLM         (2nd-order accurate)
+                                ! PPM_H4      (3rd-order accurate)
+                                ! PPM_IH4     (3rd-order accurate)
+                                ! PQM_IH4IH3  (4th-order accurate)
+                                ! PQM_IH6IH5  (5th-order accurate)
+FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
+                                ! If true, cell-by-cell reconstructions are checked for
+                                ! consistency and if non-monotonicty or an inconsistency is
+                                ! detected then a FATAL error is issued.
+FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
+                                ! If true, the results of remapping are checked for
+                                ! conservation and new extrema and if an inconsistency is
+                                ! detected then a FATAL error is issued.
+REMAP_BOUND_INTERMEDIATE_VALUES = False !   [Boolean] default = False
+                                ! If true, the values on the intermediate grid used for remapping
+                                ! are forced to be bounded, which might not be the case due to
+                                ! round off.
+REMAP_BOUNDARY_EXTRAP = False   !   [Boolean] default = False
+                                ! If true, values at the interfaces of boundary cells are
+                                ! extrapolated instead of piecewise constant
+REMAP_AFTER_INITIALIZATION = False !   [Boolean] default = True
+                                ! If true, applies regridding and remapping immediately after
+                                ! initialization so that the state is ALE consistent. This is a
+                                ! legacy step and should not be needed if the initialization is
+                                ! consistent with the coordinate mode.
+REGRID_TIME_SCALE = 0.0         !   [s] default = 0.0
+                                ! The time-scale used in blending between the current (old) grid
+                                ! and the target (new) grid. A short time-scale favors the target
+                                ! grid (0. or anything less than DT_THERM) has no memory of the old
+                                ! grid. A very long time-scale makes the model more Lagrangian.
+REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
+                                ! The depth above which no time-filtering is applied. Above this depth
+                                ! final grid exactly matches the target (new) grid.
+REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
+                                ! The depth below which full time-filtering is applied with time-scale
+                                ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
+                                ! REGRID_FILTER_SHALLOW_DEPTH the filter wieghts adopt a cubic profile.
+
+! === module MOM_grid ===
+! Parameters providing information about the lateral grid.
+
+! === module MOM_state_initialization ===
+INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
+                                ! If true, intialize the layer thicknesses, temperatures,
+                                ! and salnities from a Z-space file on a latitude-
+                                ! longitude grid.
+
+! === module MOM_initialize_layers_from_Z ===
+TEMP_SALT_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "temp_salt_z.nc"
+                                ! The name of the z-space input file used to initialize
+                                ! temperatures (T) and salinities (S). If T and S are not
+                                ! in the same file, TEMP_Z_INIT_FILE and SALT_Z_INIT_FILE
+                                ! must be set.
+TEMP_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "WOA05_pottemp_salt.nc"
+                                ! The name of the z-space input file used to initialize
+                                ! temperatures, only.
+SALT_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "WOA05_pottemp_salt.nc"
+                                ! The name of the z-space input file used to initialize
+                                ! temperatures, only.
+Z_INIT_FILE_PTEMP_VAR = "PTEMP" ! default = "ptemp"
+                                ! The name of the potential temperature variable in
+                                ! TEMP_Z_INIT_FILE.
+Z_INIT_FILE_SALT_VAR = "SALT"   ! default = "salt"
+                                ! The name of the salinity variable in
+                                ! SALT_Z_INIT_FILE.
+Z_INIT_HOMOGENIZE = False       !   [Boolean] default = False
+                                ! If True, then horizontally homogenize the interpolated
+                                ! initial conditions.
+Z_INIT_ALE_REMAPPING = True     !   [Boolean] default = False
+                                ! If True, then remap straight to model coordinate from file.
+Z_INIT_REMAPPING_SCHEME = "PPM_IH4" ! default = "PPM_IH4"
+                                ! The remapping scheme to use if using Z_INIT_ALE_REMAPPING
+                                ! is True.
+Z_INIT_REMAP_GENERAL = True     !   [Boolean] default = False
+                                ! If false, only initializes to z* coordinates.
+                                ! If true, allows initialization directly to general coordinates.
+Z_INIT_REMAP_FULL_COLUMN = True !   [Boolean] default = True
+                                ! If false, only reconstructs profiles for valid data points.
+                                ! If true, inserts vanished layers below the valid data.
+Z_INIT_REMAP_OLD_ALG = True     !   [Boolean] default = True
+                                ! If false, uses the preferred remapping algorithm for initialization.
+                                ! If true, use an older, less robust algorithm for remapping.
+VELOCITY_CONFIG = "zero"        ! default = "zero"
+                                ! A string that determines how the initial velocities
+                                ! are specified for a new run:
+                                !     file - read velocities from the file specified
+                                !       by (VELOCITY_FILE).
+                                !     zero - the fluid is initially at rest.
+                                !     uniform - the flow is uniform (determined by
+                                !       parameters INITIAL_U_CONST and INITIAL_V_CONST).
+                                !     rossby_front - a mixed layer front in thermal wind balance.
+                                !     soliton - Equatorial Rossby soliton.
+                                !     USER - call a user modified routine.
+CONVERT_THICKNESS_UNITS = False !   [Boolean] default = False
+                                ! If true,  convert the thickness initial conditions from
+                                ! units of m to kg m-2 or vice versa, depending on whether
+                                ! BOUSSINESQ is defined. This does not apply if a restart
+                                ! file is read.
+DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
+                                ! If true,  depress the initial surface to avoid huge
+                                ! tsunamis when a large surface pressure is applied.
+TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
+                                ! If true, cuts way the top of the column for initial conditions
+                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! surface pressure which is read from file.
+REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
+                                ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
+                                ! algorithm to push the initial grid to be consistent with the initial
+                                ! condition. Useful only for state-based and iterative coordinates.
+SPONGE = False                  !   [Boolean] default = False
+                                ! If true, sponges may be applied anywhere in the domain.
+                                ! The exact location and properties of those sponges are
+                                ! specified via SPONGE_CONFIG.
+
+! === module MOM_diag_mediator ===
+NUM_DIAG_COORDS = 2             ! default = 1
+                                ! The number of diagnostic vertical coordinates to use.
+                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+DIAG_COORDS = "z Z ZSTAR", "rho2 RHO2 RHO" !
+                                ! A list of string tuples associating diag_table modules to
+                                ! a coordinate definition used for diagnostics. Each string
+                                ! is of the form "MODULE_SUFFIX,PARAMETER_SUFFIX,COORDINATE_NAME".
+DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
+                                ! Set the default missing value to use for diagnostics.
+AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
+                                ! A file into which to write a list of all available
+                                ! ocean diagnostics that can be included in a diag_table.
+DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
+                                ! Determines how to specify the coordinate
+                                ! resolution. Valid options are:
+                                !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
+                                !  UNIFORM[:N] - uniformly distributed
+                                !  FILE:string - read from a file. The string specifies
+                                !                the filename and variable name, separated
+                                !                by a comma or space, e.g. FILE:lev.nc,dz
+                                !                or FILE:lev.nc,interfaces=zw
+                                !  WOA09[:N]   - the WOA09 vertical grid (approximately)
+                                !  FNC1:string - FNC1:dz_min,H_total,power,precision
+                                !  HYBRID:string - read from a file. The string specifies
+                                !                the filename and two variable names, separated
+                                !                by a comma or space, for sigma-2 and dz. e.g.
+                                !                HYBRID:vgrid.nc,sigma2,dz
+DIAG_COORD_DEF_RHO2 = "RFNC1:35,999.5,1028,1028.5,8.,1038.,0.0078125" ! default = "WOA09"
+                                ! Determines how to specify the coordinate
+                                ! resolution. Valid options are:
+                                !  PARAM       - use the vector-parameter DIAG_COORD_RES_RHO2
+                                !  UNIFORM[:N] - uniformly distributed
+                                !  FILE:string - read from a file. The string specifies
+                                !                the filename and variable name, separated
+                                !                by a comma or space, e.g. FILE:lev.nc,dz
+                                !                or FILE:lev.nc,interfaces=zw
+                                !  WOA09[:N]   - the WOA09 vertical grid (approximately)
+                                !  FNC1:string - FNC1:dz_min,H_total,power,precision
+                                !  HYBRID:string - read from a file. The string specifies
+                                !                the filename and two variable names, separated
+                                !                by a comma or space, for sigma-2 and dz. e.g.
+                                !                HYBRID:vgrid.nc,sigma2,dz
+
+! === module MOM_MEKE ===
+USE_MEKE = True                 !   [Boolean] default = False
+                                ! If true, turns on the MEKE scheme which calculates
+                                ! a sub-grid mesoscale eddy kinetic energy budget.
+MEKE_DAMPING = 0.0              !   [s-1] default = 0.0
+                                ! The local depth-indepented MEKE dissipation rate.
+MEKE_CD_SCALE = 0.0             !   [nondim] default = 0.0
+                                ! The ratio of the bottom eddy velocity to the column mean
+                                ! eddy velocity, i.e. sqrt(2*MEKE). This should be less than 1
+                                ! to account for the surface intensification of MEKE.
+MEKE_CB = 25.0                  !   [nondim] default = 25.0
+                                ! A coefficient in the expression for the ratio of bottom projected
+                                ! eddy energy and mean column energy (see Jansen et al. 2015).
+MEKE_MIN_GAMMA2 = 1.0E-04       !   [nondim] default = 1.0E-04
+                                ! The minimum allowed value of gamma_b^2.
+MEKE_CT = 50.0                  !   [nondim] default = 50.0
+                                ! A coefficient in the expression for the ratio of barotropic
+                                ! eddy energy and mean column energy (see Jansen et al. 2015).
+MEKE_GMCOEFF = 1.0              !   [nondim] default = -1.0
+                                ! The efficiency of the conversion of potential energy
+                                ! into MEKE by the thickness mixing parameterization.
+                                ! If MEKE_GMCOEFF is negative, this conversion is not
+                                ! used or calculated.
+MEKE_FRCOEFF = -1.0             !   [nondim] default = -1.0
+                                ! The efficiency of the conversion of mean energy into
+                                ! MEKE.  If MEKE_FRCOEFF is negative, this conversion
+                                ! is not used or calculated.
+MEKE_BGSRC = 1.0E-13            !   [W kg-1] default = 0.0
+                                ! A background energy source for MEKE.
+MEKE_KH = -1.0                  !   [m2 s-1] default = -1.0
+                                ! A background lateral diffusivity of MEKE.
+                                ! Use a negative value to not apply lateral diffusion to MEKE.
+MEKE_K4 = -1.0                  !   [m4 s-1] default = -1.0
+                                ! A lateral bi-harmonic diffusivity of MEKE.
+                                ! Use a negative value to not apply bi-harmonic diffusion to MEKE.
+MEKE_DTSCALE = 1.0              !   [nondim] default = 1.0
+                                ! A scaling factor to accelerate the time evolution of MEKE.
+MEKE_KHCOEFF = 1.0              !   [nondim] default = 1.0
+                                ! A scaling factor in the expression for eddy diffusivity
+                                ! which is otherwise proportional to the MEKE velocity-
+                                ! scale times an eddy mixing-length. This factor
+                                ! must be >0 for MEKE to contribute to the thickness/
+                                ! and tracer diffusivity in the rest of the model.
+MEKE_USCALE = 0.0               !   [m s-1] default = 0.0
+                                ! The background velocity that is combined with MEKE to
+                                ! calculate the bottom drag.
+MEKE_VISC_DRAG = True           !   [Boolean] default = True
+                                ! If true, use the vertvisc_type to calculate the bottom
+                                ! drag acting on MEKE.
+MEKE_KHTH_FAC = 1.0             !   [nondim] default = 0.0
+                                ! A factor that maps MEKE%Kh to KhTh.
+MEKE_KHTR_FAC = 0.0             !   [nondim] default = 0.0
+                                ! A factor that maps MEKE%Kh to KhTr.
+MEKE_KHMEKE_FAC = 1.0           !   [nondim] default = 0.0
+                                ! A factor that maps MEKE%Kh to Kh for MEKE itself.
+MEKE_OLD_LSCALE = False         !   [Boolean] default = False
+                                ! If true, use the old formula for length scale which is
+                                ! a function of grid spacing and deformation radius.
+MEKE_RD_MAX_SCALE = False       !   [nondim] default = False
+                                ! If true, the length scale used by MEKE is the minimum of
+                                ! the deformation radius or grid-spacing. Only used if
+                                ! MEKE_OLD_LSCALE=True
+MEKE_VISCOSITY_COEFF = 0.0      !   [nondim] default = 0.0
+                                ! If non-zero, is the scaling coefficient in the expression for
+                                ! viscosity used to parameterize lateral momentum mixing by
+                                ! unresolved eddies represented by MEKE. Can be negative to
+                                ! represent backscatter from the unresolved eddies.
+MEKE_FIXED_MIXING_LENGTH = 0.0  !   [m] default = 0.0
+                                ! If positive, is a fixed length contribution to the expression
+                                ! for mixing length used in MEKE-derived diffusiviity.
+MEKE_ALPHA_DEFORM = 0.0         !   [nondim] default = 0.0
+                                ! If positive, is a coefficient weighting the deformation scale
+                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+MEKE_ALPHA_RHINES = 0.15        !   [nondim] default = 0.05
+                                ! If positive, is a coefficient weighting the Rhines scale
+                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+MEKE_ALPHA_EADY = 0.15          !   [nondim] default = 0.05
+                                ! If positive, is a coefficient weighting the Eady length scale
+                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+MEKE_ALPHA_FRICT = 0.0          !   [nondim] default = 0.0
+                                ! If positive, is a coefficient weighting the frictional arrest scale
+                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+MEKE_ALPHA_GRID = 0.0           !   [nondim] default = 0.0
+                                ! If positive, is a coefficient weighting the grid-spacing as a scale
+                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+MEKE_COLD_START = False         !   [Boolean] default = False
+                                ! If true, initialize EKE to zero. Otherwise a local equilibrium solution
+                                ! is used as an initial condition for EKE.
+MEKE_BACKSCAT_RO_C = 0.0        !   [nondim] default = 0.0
+                                ! The coefficient in the Rossby number function for scaling the buharmonic
+                                ! frictional energy source. Setting to non-zero enables the Rossby number function.
+MEKE_BACKSCAT_RO_POW = 0.0      !   [nondim] default = 0.0
+                                ! The power in the Rossby number function for scaling the biharmomnic
+                                ! frictional energy source.
+MEKE_ADVECTION_FACTOR = 0.0     !   [nondim] default = 0.0
+                                ! A scale factor in front of advection of eddy energy. Zero turns advection off.
+                                ! Using unity would be normal but other values could accomodate a mismatch
+                                ! between the advecting barotropic flow and the vertical structure of MEKE.
+CDRAG = 0.003                   !   [nondim] default = 0.003
+                                ! CDRAG is the drag coefficient relating the magnitude of
+                                ! the velocity field to the bottom stress.
+
+! === module MOM_lateral_mixing_coeffs ===
+USE_VARIABLE_MIXING = True      !   [Boolean] default = False
+                                ! If true, the variable mixing code will be called.  This
+                                ! allows diagnostics to be created even if the scheme is
+                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
+                                ! this is set to true regardless of what is in the
+                                ! parameter file.
+RESOLN_SCALED_KH = True         !   [Boolean] default = False
+                                ! If true, the Laplacian lateral viscosity is scaled away
+                                ! when the first baroclinic deformation radius is well
+                                ! resolved.
+RESOLN_SCALED_KHTH = True       !   [Boolean] default = False
+                                ! If true, the interface depth diffusivity is scaled away
+                                ! when the first baroclinic deformation radius is well
+                                ! resolved.
+RESOLN_SCALED_KHTR = False      !   [Boolean] default = False
+                                ! If true, the epipycnal tracer diffusivity is scaled
+                                ! away when the first baroclinic deformation radius is
+                                ! well resolved.
+RESOLN_USE_EBT = False          !   [Boolean] default = False
+                                ! If true, uses the equivalent barotropic wave speed instead
+                                ! of first baroclinic wave for calculating the resolution fn.
+KHTH_USE_EBT_STRUCT = True      !   [Boolean] default = False
+                                ! If true, uses the equivalent barotropic structure
+                                ! as the vertical structure of thickness diffusivity.
+KHTH_SLOPE_CFF = 0.0            !   [nondim] default = 0.0
+                                ! The nondimensional coefficient in the Visbeck formula
+                                ! for the interface depth diffusivity
+KHTR_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
+                                ! The nondimensional coefficient in the Visbeck formula
+                                ! for the epipycnal tracer diffusivity
+USE_STORED_SLOPES = True        !   [Boolean] default = False
+                                ! If true, the isopycnal slopes are calculated once and
+                                ! stored for re-use. This uses more memory but avoids calling
+                                ! the equation of state more times than should be necessary.
+RESOLN_N2_FILTER_DEPTH = 2000.0 !   [m] default = 2000.0
+                                ! The depth below which N2 is monotonized to avoid stratification
+                                ! artifacts from altering the equivalent barotropic mode structure.
+VISBECK_MAX_SLOPE = 0.0         !   [nondim] default = 0.0
+                                ! If non-zero, is an upper bound on slopes used in the
+                                ! Visbeck formula for diffusivity. This does not affect the
+                                ! isopycnal slope calculation used within thickness diffusion.
+KD_SMOOTH = 1.0E-06             !   [not defined] default = 1.0E-06
+                                ! A diapycnal diffusivity that is used to interpolate
+                                ! more sensible values of T & S into thin layers.
+VARMIX_KTOP = 2                 !   [nondim] default = 2
+                                ! The layer number at which to start vertical integration
+                                ! of S*N for purposes of finding the Eady growth rate.
+VISBECK_L_SCALE = 0.0           !   [m] default = 0.0
+                                ! The fixed length scale in the Visbeck formula.
+KH_RES_SCALE_COEF = 1.0         !   [nondim] default = 1.0
+                                ! A coefficient that determines how KhTh is scaled away if
+                                ! RESOLN_SCALED_... is true, as
+                                ! F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
+KH_RES_FN_POWER = 100           !   [nondim] default = 2
+                                ! The power of dx/Ld in the Kh resolution function.  Any
+                                ! positive integer may be used, although even integers
+                                ! are more efficient to calculate.  Setting this greater
+                                ! than 100 results in a step-function being used.
+VISC_RES_SCALE_COEF = 1.0       !   [nondim] default = 1.0
+                                ! A coefficient that determines how Kh is scaled away if
+                                ! RESOLN_SCALED_... is true, as
+                                ! F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
+                                ! This function affects lateral viscosity, Kh, and not KhTh.
+VISC_RES_FN_POWER = 100         !   [nondim] default = 100
+                                ! The power of dx/Ld in the Kh resolution function.  Any
+                                ! positive integer may be used, although even integers
+                                ! are more efficient to calculate.  Setting this greater
+                                ! than 100 results in a step-function being used.
+                                ! This function affects lateral viscosity, Kh, and not KhTh.
+INTERPOLATE_RES_FN = False      !   [Boolean] default = True
+                                ! If true, interpolate the resolution function to the
+                                ! velocity points from the thickness points; otherwise
+                                ! interpolate the wave speed and calculate the resolution
+                                ! function independently at each point.
+USE_VISBECK_SLOPE_BUG = False   !   [Boolean] default = False
+                                ! If true, then retain a legacy bug in the calculation of weights
+                                ! applied to isoneutral slopes. There was an erroneous k-indexing
+                                ! for layer thicknesses. In addition, masking at coastlines was not
+                                ! used which introduced potential restart issues.  This flag will be
+                                ! deprecated in a future release.
+GILL_EQUATORIAL_LD = True       !   [Boolean] default = False
+                                ! If true, uses Gill's definition of the baroclinic
+                                ! equatorial deformation radius, otherwise, if false, use
+                                ! Pedlosky's definition. These definitions differ by a factor
+                                ! of 2 infront of the beta term in the denominator. Gill'sis the more appropriate definition.
+
+! === module MOM_set_visc ===
+BOTTOMDRAGLAW = True            !   [Boolean] default = True
+                                ! If true, the bottom stress is calculated with a drag
+                                ! law of the form c_drag*|u|*u. The velocity magnitude
+                                ! may be an assumed value or it may be based on the
+                                ! actual velocity in the bottommost HBBL, depending on
+                                ! LINEAR_DRAG.
+CHANNEL_DRAG = True             !   [Boolean] default = False
+                                ! If true, the bottom drag is exerted directly on each
+                                ! layer proportional to the fraction of the bottom it
+                                ! overlies.
+LINEAR_DRAG = False             !   [Boolean] default = False
+                                ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
+                                ! law is cdrag*DRAG_BG_VEL*u.
+DOUBLE_DIFFUSION = False        !   [Boolean] default = False
+                                ! If true, increase diffusivitives for temperature or salt
+                                ! based on double-diffusive paramaterization from MOM4/KPP.
+PRANDTL_TURB = 1.25             !   [nondim] default = 1.0
+                                ! The turbulent Prandtl number applied to shear
+                                ! instability.
+DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
+                                ! If true, use a bulk Richardson number criterion to
+                                ! determine the mixed layer thickness for viscosity.
+HBBL = 10.0                     !   [m]
+                                ! The thickness of a bottom boundary layer with a
+                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
+                                ! the thickness over which near-bottom velocities are
+                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
+                                ! but LINEAR_DRAG is not.
+DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
+                                ! LINEAR_DRAG) or an unresolved  velocity that is
+                                ! combined with the resolved velocity to estimate the
+                                ! velocity magnitude.  DRAG_BG_VEL is only used when
+                                ! BOTTOMDRAGLAW is defined.
+BBL_USE_EOS = True              !   [Boolean] default = False
+                                ! If true, use the equation of state in determining the
+                                ! properties of the bottom boundary layer.  Otherwise use
+                                ! the layer target potential densities.
+BBL_THICK_MIN = 0.1             !   [m] default = 0.0
+                                ! The minimum bottom boundary layer thickness that can be
+                                ! used with BOTTOMDRAGLAW. This might be
+                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! near-bottom viscosity.
+HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
+                                ! The minimum top boundary layer thickness that can be
+                                ! used with BOTTOMDRAGLAW. This might be
+                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! near-top viscosity.
+HTBL_SHELF = 10.0               !   [m] default = 10.0
+                                ! The thickness over which near-surface velocities are
+                                ! averaged for the drag law under an ice shelf.  By
+                                ! default this is the same as HBBL
+KV = 1.0E-04                    !   [m2 s-1]
+                                ! The background kinematic viscosity in the interior.
+                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+KV_BBL_MIN = 0.0                !   [m2 s-1] default = 1.0E-04
+                                ! The minimum viscosities in the bottom boundary layer.
+KV_TBL_MIN = 0.0                !   [m2 s-1] default = 1.0E-04
+                                ! The minimum viscosities in the top boundary layer.
+SMAG_CONST_CHANNEL = 0.15       !   [nondim] default = 0.15
+                                ! The nondimensional Laplacian Smagorinsky constant used
+                                ! in calculating the channel drag if it is enabled.  The
+                                ! default is to use the same value as SMAG_LAP_CONST if
+                                ! it is defined, or 0.15 if it is not. The value used is
+                                ! also 0.15 if the specified value is negative.
+TIDES = False                   !   [Boolean] default = False
+                                ! If true, apply tidal momentum forcing.
+BE = 0.6                        !   [nondim] default = 0.6
+                                ! If SPLIT is true, BE determines the relative weighting
+                                ! of a  2nd-order Runga-Kutta baroclinic time stepping
+                                ! scheme (0.5) and a backward Euler scheme (1) that is
+                                ! used for the Coriolis and inertial terms.  BE may be
+                                ! from 0.5 to 1, but instability may occur near 0.5.
+                                ! BE is also applicable if SPLIT is false and USE_RK2
+                                ! is true.
+BEGW = 0.0                      !   [nondim] default = 0.0
+                                ! If SPLIT is true, BEGW is a number from 0 to 1 that
+                                ! controls the extent to which the treatment of gravity
+                                ! waves is forward-backward (0) or simulated backward
+                                ! Euler (1).  0 is almost always used.
+                                ! If SPLIT is false and USE_RK2 is true, BEGW can be
+                                ! between 0 and 0.5 to damp gravity waves.
+SPLIT_BOTTOM_STRESS = False     !   [Boolean] default = False
+                                ! If true, provide the bottom stress calculated by the
+                                ! vertical viscosity to the barotropic solver.
+BT_USE_LAYER_FLUXES = True      !   [Boolean] default = True
+                                ! If true, use the summed layered fluxes plus an
+                                ! adjustment due to the change in the barotropic velocity
+                                ! in the barotropic continuity equation.
+
+! === module MOM_continuity ===
+CONTINUITY_SCHEME = "PPM"       ! default = "PPM"
+                                ! CONTINUITY_SCHEME selects the discretization for the
+                                ! continuity solver. The only valid value currently is:
+                                !    PPM - use a positive-definite (or monotonic)
+                                !          piecewise parabolic reconstruction solver.
+
+! === module MOM_continuity_PPM ===
+MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
+                                ! If true, CONTINUITY_PPM uses the Colella and Woodward
+                                ! monotonic limiter.  The default (false) is to use a
+                                ! simple positive definite limiter.
+SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
+                                ! If true, CONTINUITY_PPM uses a simple 2nd order
+                                ! (arithmetic mean) interpolation of the edge values.
+                                ! This may give better PV conservation propterties. While
+                                ! it formally reduces the accuracy of the continuity
+                                ! solver itself in the strongly advective limit, it does
+                                ! not reduce the overall order of accuracy of the dynamic
+                                ! core.
+UPWIND_1ST_CONTINUITY = False   !   [Boolean] default = False
+                                ! If true, CONTINUITY_PPM becomes a 1st-order upwind
+                                ! continuity solver.  This scheme is highly diffusive
+                                ! but may be useful for debugging or in single-column
+                                ! mode where its minimal stencil is useful.
+ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.75E-09
+                                ! The tolerance for the differences between the
+                                ! barotropic and baroclinic estimates of the sea surface
+                                ! height due to the fluxes through each face.  The total
+                                ! tolerance for SSH is 4 times this value.  The default
+                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
+                                ! than about 10^-15*MAXIMUM_DEPTH.
+ETA_TOLERANCE_AUX = 0.001       !   [m] default = 1.0E-06
+                                ! The tolerance for free-surface height discrepancies
+                                ! between the barotropic solution and the sum of the
+                                ! layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as
+                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
+                                ! The tolerance for barotropic velocity discrepancies
+                                ! between the barotropic solution and  the sum of the
+                                ! layer thicknesses.
+CONT_PPM_AGGRESS_ADJUST = False !   [Boolean] default = False
+                                ! If true, allow the adjusted velocities to have a
+                                ! relative CFL change up to 0.5.
+CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
+                                ! If true, use the ratio of the open face lengths to the
+                                ! tracer cell areas when estimating CFL numbers.  The
+                                ! default is set by CONT_PPM_AGGRESS_ADJUST.
+CONTINUITY_CFL_LIMIT = 0.5      !   [nondim] default = 0.5
+                                ! The maximum CFL of the adjusted velocities.
+CONT_PPM_BETTER_ITER = True     !   [Boolean] default = True
+                                ! If true, stop corrective iterations using a velocity
+                                ! based criterion and only stop if the iteration is
+                                ! better than all predecessors.
+CONT_PPM_USE_VISC_REM_MAX = True !   [Boolean] default = True
+                                ! If true, use more appropriate limiting bounds for
+                                ! corrections in strongly viscous columns.
+CONT_PPM_MARGINAL_FACE_AREAS = True !   [Boolean] default = True
+                                ! If true, use the marginal face areas from the continuity
+                                ! solver for use as the weights in the barotropic solver.
+                                ! Otherwise use the transport averaged areas.
+
+! === module MOM_CoriolisAdv ===
+NOSLIP = False                  !   [Boolean] default = False
+                                ! If true, no slip boundary conditions are used; otherwise
+                                ! free slip boundary conditions are assumed. The
+                                ! implementation of the free slip BCs on a C-grid is much
+                                ! cleaner than the no slip BCs. The use of free slip BCs
+                                ! is strongly encouraged, and no slip BCs are not used with
+                                ! the biharmonic viscosity.
+CORIOLIS_EN_DIS = False         !   [Boolean] default = False
+                                ! If true, two estimates of the thickness fluxes are used
+                                ! to estimate the Coriolis term, and the one that
+                                ! dissipates energy relative to the other one is used.
+CORIOLIS_SCHEME = "SADOURNY75_ENSTRO" ! default = "SADOURNY75_ENERGY"
+                                ! CORIOLIS_SCHEME selects the discretization for the
+                                ! Coriolis terms. Valid values are:
+                                !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
+                                !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
+                                !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
+                                !    ARAKAWA_LAMB81    - Arakawa & Lamb, 1981; En. + Enst.
+                                !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
+                                !                         Arakawa & Hsu and Sadourny energy
+BOUND_CORIOLIS = True           !   [Boolean] default = False
+                                ! If true, the Coriolis terms at u-points are bounded by
+                                ! the four estimates of (f+rv)v from the four neighboring
+                                ! v-points, and similarly at v-points.  This option would
+                                ! have no effect on the SADOURNY Coriolis scheme if it
+                                ! were possible to use centered difference thickness fluxes.
+KE_SCHEME = "KE_ARAKAWA"        ! default = "KE_ARAKAWA"
+                                ! KE_SCHEME selects the discretization for acceleration
+                                ! due to the kinetic energy gradient. Valid values are:
+                                !    KE_ARAKAWA, KE_SIMPLE_GUDONOV, KE_GUDONOV
+PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
+                                ! PV_ADV_SCHEME selects the discretization for PV
+                                ! advection. Valid values are:
+                                !    PV_ADV_CENTERED - centered (aka Sadourny, 75)
+                                !    PV_ADV_UPWIND1  - upwind, first order
+
+! === module MOM_PressureForce ===
+ANALYTIC_FV_PGF = True          !   [Boolean] default = True
+                                ! If true the pressure gradient forces are calculated
+                                ! with a finite volume form that analytically integrates
+                                ! the equations of state in pressure to avoid any
+                                ! possibility of numerical thermobaric instability, as
+                                ! described in Adcroft et al., O. Mod. (2008).
+
+! === module MOM_PressureForce_AFV ===
+MASS_WEIGHT_IN_PRESSURE_GRADIENT = True !   [Boolean] default = False
+                                ! If true, use mass weighting when interpolation T/S for
+                                ! top/bottom integrals in AFV pressure gradient calculation.
+
+! === module MOM_hor_visc ===
+LAPLACIAN = True                !   [Boolean] default = False
+                                ! If true, use a Laplacian horizontal viscosity.
+KH = 0.0                        !   [m2 s-1] default = 0.0
+                                ! The background Laplacian horizontal viscosity.
+KH_BG_MIN = 0.0                 !   [m2 s-1] default = 0.0
+                                ! The minimum value allowed for Laplacian horizontal viscosity, KH.
+KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
+                                ! The velocity scale which is multiplied by the grid
+                                ! spacing to calculate the Laplacian viscosity.
+                                ! The final viscosity is the largest of this scaled
+                                ! viscosity, the Smagorinsky and Leith viscosities, and KH.
+SMAGORINSKY_KH = False          !   [Boolean] default = False
+                                ! If true, use a Smagorinsky nonlinear eddy viscosity.
+LEITH_KH = False                !   [Boolean] default = False
+                                ! If true, use a Leith nonlinear eddy viscosity.
+MODIFIED_LEITH = False          !   [Boolean] default = False
+                                ! If true, add a term to Leith viscosity which is
+                                ! proportional to the gradient of divergence.
+BOUND_KH = True                 !   [Boolean] default = True
+                                ! If true, the Laplacian coefficient is locally limited
+                                ! to be stable.
+BETTER_BOUND_KH = True          !   [Boolean] default = True
+                                ! If true, the Laplacian coefficient is locally limited
+                                ! to be stable with a better bounding than just BOUND_KH.
+BIHARMONIC = True               !   [Boolean] default = True
+                                ! If true, use a biharmonic horizontal viscosity.
+                                ! BIHARMONIC may be used with LAPLACIAN.
+AH = 0.0                        !   [m4 s-1] default = 0.0
+                                ! The background biharmonic horizontal viscosity.
+AH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
+                                ! The velocity scale which is multiplied by the cube of
+                                ! the grid spacing to calculate the biharmonic viscosity.
+                                ! The final viscosity is the largest of this scaled
+                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+SMAGORINSKY_AH = True           !   [Boolean] default = False
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
+                                ! viscosity.
+LEITH_AH = False                !   [Boolean] default = False
+                                ! If true, use a biharmonic Leith nonlinear eddy
+                                ! viscosity.
+BOUND_AH = True                 !   [Boolean] default = True
+                                ! If true, the biharmonic coefficient is locally limited
+                                ! to be stable.
+BETTER_BOUND_AH = True          !   [Boolean] default = True
+                                ! If true, the biharmonic coefficient is locally limited
+                                ! to be stable with a better bounding than just BOUND_AH.
+SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
+                                ! The nondimensional biharmonic Smagorinsky constant,
+                                ! typically 0.015 - 0.06.
+BOUND_CORIOLIS_BIHARM = True    !   [Boolean] default = True
+                                ! If true use a viscosity that increases with the square
+                                ! of the velocity shears, so that the resulting viscous
+                                ! drag is of comparable magnitude to the Coriolis terms
+                                ! when the velocity differences between adjacent grid
+                                ! points is 0.5*BOUND_CORIOLIS_VEL.  The default is the
+                                ! value of BOUND_CORIOLIS (or false).
+BOUND_CORIOLIS_VEL = 6.0        !   [m s-1] default = 6.0
+                                ! The velocity scale at which BOUND_CORIOLIS_BIHARM causes
+                                ! the biharmonic drag to have comparable magnitude to the
+                                ! Coriolis acceleration.  The default is set by MAXVEL.
+USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
+                                ! If true, use Use the land mask for the computation of thicknesses
+                                ! at velocity locations. This eliminates the dependence on arbitrary
+                                ! values over land or outside of the domain. Default is False in order to
+                                ! maintain answers with legacy experiments but should be changed to True
+                                ! for new experiments.
+HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
+                                ! The nondimensional coefficient of the ratio of the
+                                ! viscosity bounds to the theoretical maximum for
+                                ! stability without considering other terms.
+USE_KH_BG_2D = False            !   [Boolean] default = False
+                                ! If true, read a file containing 2-d background harmonic
+                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+
+! === module MOM_vert_friction ===
+DIRECT_STRESS = False           !   [Boolean] default = False
+                                ! If true, the wind stress is distributed over the
+                                ! topmost HMIX_STRESS of fluid (like in HYCOM), and KVML
+                                ! may be set to a very small value.
+U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
+                                ! The absolute path to a file into which the accelerations
+                                ! leading to zonal velocity truncations are written.
+                                ! Undefine this for efficiency if this diagnostic is not
+                                ! needed.
+V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
+                                ! The absolute path to a file into which the accelerations
+                                ! leading to meridional velocity truncations are written.
+                                ! Undefine this for efficiency if this diagnostic is not
+                                ! needed.
+HARMONIC_VISC = False           !   [Boolean] default = False
+                                ! If true, use the harmonic mean thicknesses for
+                                ! calculating the vertical viscosity.
+HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
+                                ! A scale to determine when water is in the boundary
+                                ! layers based solely on harmonic mean thicknesses for
+                                ! the purpose of determining the extent to which the
+                                ! thicknesses used in the viscosities are upwinded.
+HMIX_FIXED = 0.5                !   [m]
+                                ! The prescribed depth over which the near-surface
+                                ! viscosity and diffusivity are elevated when the bulk
+                                ! mixed layer is not used.
+KVML = 1.0E-04                  !   [m2 s-1] default = 1.0E-04
+                                ! The kinematic viscosity in the mixed layer.  A typical
+                                ! value is ~1e-2 m2 s-1. KVML is not used if
+                                ! BULKMIXEDLAYER is true.  The default is set by KV.
+MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
+                                ! The maximum velocity allowed before the velocity
+                                ! components are truncated.
+CFL_BASED_TRUNCATIONS = True    !   [Boolean] default = True
+                                ! If true, base truncations on the CFL number, and not an
+                                ! absolute speed.
+CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
+                                ! The value of the CFL number that will cause velocity
+                                ! components to be truncated; instability can occur past 0.5.
+CFL_REPORT = 0.5                !   [nondim] default = 0.5
+                                ! The value of the CFL number that causes accelerations
+                                ! to be reported; the default is CFL_TRUNCATE.
+CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
+                                ! The time over which the CFL trunction value is ramped
+                                ! up at the beginning of the run.
+CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
+                                ! The start value of the truncation CFL number used when
+                                ! ramping up CFL_TRUNC.
+
+! === module MOM_PointAccel ===
+MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
+                                ! The maximum number of colums of truncations that any PE
+                                ! will write out during a run.
+
+! === module MOM_barotropic ===
+BOUND_BT_CORRECTION = True      !   [Boolean] default = False
+                                ! If true, the corrective pseudo mass-fluxes into the
+                                ! barotropic solver are limited to values that require
+                                ! less than maxCFL_BT_cont to be accommodated.
+BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
+                                ! If true, and BOUND_BT_CORRECTION is true, use the
+                                ! BT_cont_type variables to set limits determined by
+                                ! MAXCFL_BT_CONT on the CFL number of the velocites
+                                ! that are likely to be driven by the corrective mass fluxes.
+ADJUST_BT_CONT = False          !   [Boolean] default = False
+                                ! If true, adjust the curve fit to the BT_cont type
+                                ! that is used by the barotropic solver to match the
+                                ! transport about which the flow is being linearized.
+GRADUAL_BT_ICS = False          !   [Boolean] default = False
+                                ! If true, adjust the initial conditions for the
+                                ! barotropic solver to the values from the layered
+                                ! solution over a whole timestep instead of instantly.
+                                ! This is a decent approximation to the inclusion of
+                                ! sum(u dh_dt) while also correcting for truncation errors.
+BT_USE_VISC_REM_U_UH0 = False   !   [Boolean] default = False
+                                ! If true, use the viscous remnants when estimating the
+                                ! barotropic velocities that were used to calculate uh0
+                                ! and vh0.  False is probably the better choice.
+USE_BT_CONT_TYPE = True         !   [Boolean] default = True
+                                ! If true, use a structure with elements that describe
+                                ! effective face areas from the summed continuity solver
+                                ! as a function the barotropic flow in coupling between
+                                ! the barotropic and baroclinic flow.  This is only used
+                                ! if SPLIT is true.
+NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
+                                ! If true, use nonlinear transports in the barotropic
+                                ! continuity equation.  This does not apply if
+                                ! USE_BT_CONT_TYPE is true.
+BT_MASS_SOURCE_LIMIT = 0.0      !   [nondim] default = 0.0
+                                ! The fraction of the initial depth of the ocean that can
+                                ! be added to or removed from the bartropic solution
+                                ! within a thermodynamic time step.  By default this is 0
+                                ! for no correction.
+BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
+                                ! If true, step the barotropic velocity first and project
+                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! transport.  The default (false) is to use a predictor
+                                ! continuity step to find the pressure field, and then
+                                ! to do a corrector continuity step using a weighted
+                                ! average of the old and new velocities, with weights
+                                ! of (1-BEBT) and BEBT.
+DYNAMIC_SURFACE_PRESSURE = True !   [Boolean] default = False
+                                ! If true, add a dynamic pressure due to a viscous ice
+                                ! shelf, for instance.
+ICE_LENGTH_DYN_PSURF = 1.0E+04  !   [m] default = 1.0E+04
+                                ! The length scale at which the Rayleigh damping rate due
+                                ! to the ice strength should be the same as if a Laplacian
+                                ! were applied, if DYNAMIC_SURFACE_PRESSURE is true.
+DEPTH_MIN_DYN_PSURF = 1.0E-06   !   [m] default = 1.0E-06
+                                ! The minimum depth to use in limiting the size of the
+                                ! dynamic surface pressure for stability, if
+                                ! DYNAMIC_SURFACE_PRESSURE is true..
+CONST_DYN_PSURF = 0.9           !   [nondim] default = 0.9
+                                ! The constant that scales the dynamic surface pressure,
+                                ! if DYNAMIC_SURFACE_PRESSURE is true.  Stable values
+                                ! are < ~1.0.
+SADOURNY = True                 !   [Boolean] default = True
+                                ! If true, the Coriolis terms are discretized with the
+                                ! Sadourny (1975) energy conserving scheme, otherwise
+                                ! the Arakawa & Hsu scheme is used.  If the internal
+                                ! deformation radius is not resolved, the Sadourny scheme
+                                ! should probably be used.
+BT_THICK_SCHEME = "FROM_BT_CONT" ! default = "FROM_BT_CONT"
+                                ! A string describing the scheme that is used to set the
+                                ! open face areas used for barotropic transport and the
+                                ! relative weights of the accelerations. Valid values are:
+                                !    ARITHMETIC - arithmetic mean layer thicknesses
+                                !    HARMONIC - harmonic mean layer thicknesses
+                                !    HYBRID (the default) - use arithmetic means for
+                                !       layers above the shallowest bottom, the harmonic
+                                !       mean for layers below, and a weighted average for
+                                !       layers that straddle that depth
+                                !    FROM_BT_CONT - use the average thicknesses kept
+                                !       in the h_u and h_v fields of the BT_cont_type
+BT_STRONG_DRAG = False          !   [Boolean] default = False
+                                ! If true, use a stronger estimate of the retarding
+                                ! effects of strong bottom drag, by making it implicit
+                                ! with the barotropic time-step instead of implicit with
+                                ! the baroclinic time-step and dividing by the number of
+                                ! barotropic steps.
+BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
+                                ! If true, apply a linear drag to the barotropic velocities,
+                                ! using rates set by lin_drag_u & _vdivided by the depth of
+                                ! the ocean.  This was introduced to facilitate tide modeling.
+CLIP_BT_VELOCITY = False        !   [Boolean] default = False
+                                ! If true, limit any velocity components that exceed
+                                ! CFL_TRUNCATE.  This should only be used as a desperate
+                                ! debugging measure.
+MAXCFL_BT_CONT = 0.25           !   [nondim] default = 0.25
+                                ! The maximum permitted CFL number associated with the
+                                ! barotropic accelerations from the summed velocities
+                                ! times the time-derivatives of thicknesses.
+DT_BT_FILTER = -0.25            !   [sec or nondim] default = -0.25
+                                ! A time-scale over which the barotropic mode solutions
+                                ! are filtered, in seconds if positive, or as a fraction
+                                ! of DT if negative. When used this can never be taken to
+                                ! be longer than 2*dt.  Set this to 0 to apply no filtering.
+G_BT_EXTRA = 0.0                !   [nondim] default = 0.0
+                                ! A nondimensional factor by which gtot is enhanced.
+SSH_EXTRA = 10.0                !   [m] default = 10.0
+                                ! An estimate of how much higher SSH might get, for use
+                                ! in calculating the safe external wave speed. The
+                                ! default is the minimum of 10 m or 5% of MAXIMUM_DEPTH.
+DEBUG_BT = False                !   [Boolean] default = False
+                                ! If true, write out verbose debugging data within the
+                                ! barotropic time-stepping loop. The data volume can be
+                                ! quite large if this is true.
+BEBT = 0.2                      !   [nondim] default = 0.1
+                                ! BEBT determines whether the barotropic time stepping
+                                ! uses the forward-backward time-stepping scheme or a
+                                ! backward Euler scheme. BEBT is valid in the range from
+                                ! 0 (for a forward-backward treatment of nonrotating
+                                ! gravity waves) to 1 (for a backward Euler treatment).
+                                ! In practice, BEBT must be greater than about 0.05.
+DTBT = -0.9                     !   [s or nondim] default = -0.98
+                                ! The barotropic time step, in s. DTBT is only used with
+                                ! the split explicit time stepping. To set the time step
+                                ! automatically based the maximum stable value use 0, or
+                                ! a negative value gives the fraction of the stable value.
+                                ! Setting DTBT to 0 is the same as setting it to -0.98.
+                                ! The value of DTBT that will actually be used is an
+                                ! integer fraction of DT, rounding down.
+BT_USE_OLD_CORIOLIS_BRACKET_BUG = True !   [Boolean] default = False
+                                ! If True, use an order of operations that is not bitwise
+                                ! rotationally symmetric in the meridional Coriolis term of
+                                ! the barotropic solver.
+
+! === module MOM_thickness_diffuse ===
+KHTH = 0.0                      !   [m2 s-1] default = 0.0
+                                ! The background horizontal thickness diffusivity.
+KHTH_MIN = 0.0                  !   [m2 s-1] default = 0.0
+                                ! The minimum horizontal thickness diffusivity.
+KHTH_MAX = 0.0                  !   [m2 s-1] default = 0.0
+                                ! The maximum horizontal thickness diffusivity.
+KHTH_MAX_CFL = 0.1              !   [nondimensional] default = 0.8
+                                ! The maximum value of the local diffusive CFL ratio that
+                                ! is permitted for the thickness diffusivity. 1.0 is the
+                                ! marginally unstable value in a pure layered model, but
+                                ! much smaller numbers (e.g. 0.1) seem to work better for
+                                ! ALE-based models.
+DETANGLE_INTERFACES = False     !   [Boolean] default = False
+                                ! If defined add 3-d structured enhanced interface height
+                                ! diffusivities to horizonally smooth jagged layers.
+KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
+                                ! A slope beyond which the calculated isopycnal slope is
+                                ! not reliable and is scaled away.
+KHTH_USE_FGNV_STREAMFUNCTION = True !   [Boolean] default = False
+                                ! If true, use the streamfunction formulation of
+                                ! Ferrari et al., 2010, which effectively emphasizes
+                                ! graver vertical modes by smoothing in the vertical.
+FGNV_FILTER_SCALE = 0.1         !   [not defined] default = 1.0
+                                ! A coefficient scaling the vertical smoothing term in the
+                                ! Ferrari et al., 2010, streamfunction formulation.
+FGNV_C_MIN = 0.0                !   [m s-1] default = 0.0
+                                ! A minium wave speed used in the Ferrari et al., 2010,
+                                ! streamfunction formulation.
+FGNV_STRAT_FLOOR = 1.0E-15      !   [nondim] default = 1.0E-15
+                                ! A floor for Brunt-Vasaila frequency in the Ferrari et al., 2010,
+                                ! streamfunction formulation, expressed as a fraction of planetary
+                                ! rotation, OMEGA. This should be tiny but non-zero to avoid degeneracy.
+
+! === module MOM_mixed_layer_restrat ===
+MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
+                                ! If true, a density-gradient dependent re-stratifying
+                                ! flow is imposed in the mixed layer. Can be used in ALE mode
+                                ! without restriction but in layer mode can only be used if
+                                ! BULKMIXEDLAYER is true.
+FOX_KEMPER_ML_RESTRAT_COEF = 1.0 !   [nondim] default = 0.0
+                                ! A nondimensional coefficient that is proportional to
+                                ! the ratio of the deformation radius to the dominant
+                                ! lengthscale of the submesoscale mixed layer
+                                ! instabilities, times the minimum of the ratio of the
+                                ! mesoscale eddy kinetic energy to the large-scale
+                                ! geostrophic kinetic energy or 1 plus the square of the
+                                ! grid spacing over the deformation radius, as detailed
+                                ! by Fox-Kemper et al. (2010)
+FOX_KEMPER_ML_RESTRAT_COEF2 = 0.0 !   [nondim] default = 0.0
+                                ! As for FOX_KEMPER_ML_RESTRAT_COEF but used in a second application
+                                ! of the MLE restratification parameterization.
+MLE_FRONT_LENGTH = 200.0        !   [m] default = 0.0
+                                ! If non-zero, is the frontal-length scale used to calculate the
+                                ! upscaling of buoyancy gradients that is otherwise represented
+                                ! by the parameter FOX_KEMPER_ML_RESTRAT_COEF. If MLE_FRONT_LENGTH is
+                                ! non-zero, it is recommended to set FOX_KEMPER_ML_RESTRAT_COEF=1.0.
+MLE_USE_PBL_MLD = True          !   [Boolean] default = False
+                                ! If true, the MLE parameterization will use the mixed-layer
+                                ! depth provided by the active PBL parameterization. If false,
+                                ! MLE will estimate a MLD based on a density difference with the
+                                ! surface using the parameter MLE_DENSITY_DIFF.
+MLE_MLD_DECAY_TIME = 2.592E+06  !   [s] default = 0.0
+                                ! The time-scale for a running-mean filter applied to the mixed-layer
+                                ! depth used in the MLE restratification parameterization. When
+                                ! the MLD deepens below the current running-mean the running-mean
+                                ! is instantaneously set to the current MLD.
+MLE_MLD_DECAY_TIME2 = 0.0       !   [s] default = 0.0
+                                ! The time-scale for a running-mean filter applied to the filtered
+                                ! mixed-layer depth used in a second MLE restratification parameterization.
+                                ! When the MLD deepens below the current running-mean the running-mean
+                                ! is instantaneously set to the current MLD.
+MLE_TAIL_DH = 0.0               !   [nondim] default = 0.0
+                                ! Fraction by which to extend the mixed-layer restratification
+                                ! depth used for a smoother stream function at the base of
+                                ! the mixed-layer.
+MLE_MLD_STRETCH = 1.0           !   [nondim] default = 1.0
+                                ! A scaling coefficient for stretching/shrinking the MLD
+                                ! used in the MLE scheme. This simply multiplies MLD wherever used.
+MLE_USE_MLD_AVE_BUG = False     !   [Boolean] default = False
+                                ! If true, do not account for MLD mismatch to interface positions.
+DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
+                                ! The lower fraction of water column over which N2 is limited as monotonic
+                                ! for the purposes of calculating the equivalent barotropic wave speed.
+DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
+                                ! The depth below which N2 is limited as monotonic for the
+                                ! purposes of calculating the equivalent barotropic wave speed.
+
+! === module MOM_diag_to_Z ===
+Z_OUTPUT_GRID_FILE = "analysis_vgrid_lev35.v1.nc" ! default = ""
+                                ! The file that specifies the vertical grid for
+                                ! depth-space diagnostics, or blank to disable
+                                ! depth-space output.
+!NK_ZSPACE (from file) = 35     !   [nondim]
+                                ! The number of depth-space levels.  This is determined
+                                ! from the size of the variable zw in the output grid file.
+
+! === module MOM_diabatic_driver ===
+! The following parameters are used for diabatic processes.
+ENERGETICS_SFC_PBL = True       !   [Boolean] default = False
+                                ! If true, use an implied energetics planetary boundary
+                                ! layer scheme to determine the diffusivity and viscosity
+                                ! in the surface boundary layer.
+EPBL_IS_ADDITIVE = False        !   [Boolean] default = True
+                                ! If true, the diffusivity from ePBL is added to all
+                                ! other diffusivities. Otherwise, the larger of kappa-
+                                ! shear and ePBL diffusivities are used.
+INTERNAL_TIDES = False          !   [Boolean] default = False
+                                ! If true, use the code that advances a separate set of
+                                ! equations for the internal tide energy density.
+MASSLESS_MATCH_TARGETS = True   !   [Boolean] default = True
+                                ! If true, the temperature and salinity of massless layers
+                                ! are kept consistent with their target densities.
+                                ! Otherwise the properties of massless layers evolve
+                                ! diffusively to match massive neighboring layers.
+AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
+                                ! If true, the net incoming and outgoing fresh water fluxes are combined
+                                ! and applied as either incoming or outgoing depending on the sign of the net.
+                                ! If false, the net incoming fresh water flux is added to the model and
+                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+DEBUG_CONSERVATION = False      !   [Boolean] default = False
+                                ! If true, monitor conservation and extrema.
+MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
+                                ! If true, mix the passive tracers in massless layers at
+                                ! the bottom into the interior as though a diffusivity of
+                                ! KD_MIN_TR were operating.
+KD_MIN_TR = 1.5E-06             !   [m2 s-1] default = 1.5E-06
+                                ! A minimal diffusivity that should always be applied to
+                                ! tracers, especially in massless layers near the bottom.
+                                ! The default is 0.1*KD.
+KD_BBL_TR = 0.0                 !   [m2 s-1] default = 0.0
+                                ! A bottom boundary layer tracer diffusivity that will
+                                ! allow for explicitly specified bottom fluxes. The
+                                ! entrainment at the bottom is at least sqrt(Kd_BBL_tr*dt)
+                                ! over the same distance.
+TRACER_TRIDIAG = False          !   [Boolean] default = False
+                                ! If true, use the passive tracer tridiagonal solver for T and S
+MINIMUM_FORCING_DEPTH = 0.001   !   [m] default = 0.001
+                                ! The smallest depth over which forcing can be applied. This
+                                ! only takes effect when near-surface layers become thin
+                                ! relative to this scale, in which case the forcing tendencies
+                                ! scaled down by distributing the forcing over this depth scale.
+EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
+                                ! The largest fraction of a layer than can be lost to forcing
+                                ! (e.g. evaporation, sea-ice formation) in one time-step. The unused
+                                ! mass loss is passed down through the column.
+DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
+                                ! The density difference used to determine a diagnostic mixed
+                                ! layer depth, MLD_user, following the definition of Levitus 1982.
+                                ! The MLD is the depth at which the density is larger than the
+                                ! surface density by the specified amount.
+
+! === module MOM_KPP ===
+! This is the MOM wrapper to CVmix:KPP
+! See http://code.google.com/p/cvmix/
+USE_KPP = False                 !   [Boolean] default = False
+                                ! If true, turns on the [CVmix] KPP scheme of Large et al., 1994,
+                                ! to calculate diffusivities and non-local transport in the OBL.
+SALT_REJECT_BELOW_ML = False    !   [Boolean] default = False
+                                ! If true, place salt from brine rejection below the mixed layer,
+                                ! into the first non-vanished layer for which the column remains stable
+
+! === module MOM_diffConvection ===
+! This module implements enhanced diffusivity as a
+! function of static stability, N^2.
+USE_CONVECTION = False          !   [Boolean] default = False
+                                ! If true, turns on the diffusive convection scheme that
+                                ! increases diapycnal diffusivities at statically unstable
+                                ! interfaces. Relevant parameters are contained in the
+                                ! CONVECTION% parameter block.
+CONVECTION%
+PASSIVE = False                 !   [Boolean] default = False
+                                ! If True, puts KPP into a passive-diagnostic mode.
+KD_CONV = 1.0                   !   [m2/s] default = 1.0
+                                ! DIffusivity used in statically unstable regions of column.
+%CONVECTION
+
+! === module MOM_entrain_diffusive ===
+CORRECT_DENSITY = True          !   [Boolean] default = True
+                                ! If true, and USE_EOS is true, the layer densities are
+                                ! restored toward their target values by the diapycnal
+                                ! mixing, as described in Hallberg (MWR, 2000).
+MAX_ENT_IT = 5                  ! default = 5
+                                ! The maximum number of iterations that may be used to
+                                ! calculate the interior diapycnal entrainment.
+TOLERANCE_ENT = 1.643167672515498E-05 !   [m] default = 1.643167672515498E-05
+                                ! The tolerance with which to solve for entrainment values.
+
+! === module MOM_geothermal ===
+GEOTHERMAL_SCALE = 1.0          !   [W m-2 or various] default = 0.0
+                                ! The constant geothermal heat flux, a rescaling
+                                ! factor for the heat flux read from GEOTHERMAL_FILE, or
+                                ! 0 to disable the geothermal heating.
+GEOTHERMAL_FILE = "geothermal_davies2013_v1.nc" ! default = ""
+                                ! The file from which the geothermal heating is to be
+                                ! read, or blank to use a constant heating rate.
+GEOTHERMAL_THICKNESS = 0.1      !   [m] default = 0.1
+                                ! The thickness over which to apply geothermal heating.
+GEOTHERMAL_DRHO_DT_INPLACE = -0.01 !   [kg m-3 K-1] default = -0.01
+                                ! The value of drho_dT above which geothermal heating
+                                ! simply heats water in place instead of moving it between
+                                ! isopycnal layers.  This must be negative.
+GEOTHERMAL_VARNAME = "geothermal_hf" ! default = "geo_heat"
+                                ! The name of the geothermal heating variable in
+                                ! GEOTHERMAL_FILE.
+
+! === module MOM_set_diffusivity ===
+FLUX_RI_MAX = 0.2               !   [not defined] default = 0.2
+                                ! The flux Richardson number where the stratification is
+                                ! large enough that N2 > omega2.  The full expression for
+                                ! the Flux Richardson number is usually
+                                ! FLUX_RI_MAX*N2/(N2+OMEGA2).
+ML_RADIATION = False            !   [Boolean] default = False
+                                ! If true, allow a fraction of TKE available from wind
+                                ! work to penetrate below the base of the mixed layer
+                                ! with a vertical decay scale determined by the minimum
+                                ! of: (1) The depth of the mixed layer, (2) an Ekman
+                                ! length scale.
+BBL_EFFIC = 0.2                 !   [nondim] default = 0.2
+                                ! The efficiency with which the energy extracted by
+                                ! bottom drag drives BBL diffusion.  This is only
+                                ! used if BOTTOMDRAGLAW is true.
+BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
+                                ! The maximum decay scale for the BBL diffusion, or 0
+                                ! to allow the mixing to penetrate as far as
+                                ! stratification and rotation permit.  The default is 0.
+                                ! This is only used if BOTTOMDRAGLAW is true.
+BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
+                                ! If true, take the maximum of the diffusivity from the
+                                ! BBL mixing and the other diffusivities. Otherwise,
+                                ! diffusiviy from the BBL_mixing is simply added.
+USE_LOTW_BBL_DIFFUSIVITY = True !   [Boolean] default = False
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
+                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
+                                ! the original BBL scheme.
+LOTW_BBL_USE_OMEGA = True       !   [Boolean] default = True
+                                ! If true, use the maximum of Omega and N for the TKE to diffusion
+                                ! calculation. Otherwise, N is N.
+SIMPLE_TKE_TO_KD = True         !   [Boolean] default = False
+                                ! If true, uses a simple estimate of Kd/TKE that will
+                                ! work for arbitrary vertical coordinates. If false,
+                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+BRYAN_LEWIS_DIFFUSIVITY = False !   [Boolean] default = False
+                                ! If true, use a Bryan & Lewis (JGR 1979) like tanh
+                                ! profile of background diapycnal diffusivity with depth.
+HENYEY_IGW_BACKGROUND = True    !   [Boolean] default = False
+                                ! If true, use a latitude-dependent scaling for the near
+                                ! surface background diffusivity, as described in
+                                ! Harrison & Hallberg, JPO 2008.
+HENYEY_IGW_BACKGROUND_NEW = False !   [Boolean] default = False
+                                ! If true, use a better latitude-dependent scaling for the
+                                ! background diffusivity, as described in
+                                ! Harrison & Hallberg, JPO 2008.
+HENYEY_N0_2OMEGA = 20.0         !   [nondim] default = 20.0
+                                ! The ratio of the typical Buoyancy frequency to twice
+                                ! the Earth's rotation period, used with the Henyey
+                                ! scaling from the mixing.
+N2_FLOOR_IOMEGA2 = 0.0          !   [nondim] default = 1.0
+                                ! The floor applied to N2(k) scaled by Omega^2:
+                                !   If =0., N2(k) is simply positive definite.
+                                !   If =1., N2(k) > Omega^2 everywhere.
+KD_TANH_LAT_FN = False          !   [Boolean] default = False
+                                ! If true, use a tanh dependence of Kd_sfc on latitude,
+                                ! like CM2.1/CM2M.  There is no physical justification
+                                ! for this form, and it can not be used with
+                                ! HENYEY_IGW_BACKGROUND.
+KD = 1.5E-05                    !   [m2 s-1]
+                                ! The background diapycnal diffusivity of density in the
+                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
+                                ! may be used.
+KD_MIN = 2.0E-06                !   [m2 s-1] default = 1.5E-07
+                                ! The minimum diapycnal diffusivity.
+KD_MAX = 0.1                    !   [m2 s-1] default = -1.0
+                                ! The maximum permitted increment for the diapycnal
+                                ! diffusivity from TKE-based parameterizations, or a
+                                ! negative value for no limit.
+KD_ADD = 0.0                    !   [m2 s-1] default = 0.0
+                                ! A uniform diapycnal diffusivity that is added
+                                ! everywhere without any filtering or scaling.
+KDML = 1.5E-05                  !   [m2 s-1] default = 1.5E-05
+                                ! If BULKMIXEDLAYER is false, KDML is the elevated
+                                ! diapycnal diffusivity in the topmost HMIX of fluid.
+                                ! KDML is only used if BULKMIXEDLAYER is false.
+INT_TIDE_DISSIPATION = True     !   [Boolean] default = False
+                                ! If true, use an internal tidal dissipation scheme to
+                                ! drive diapycnal mixing, along the lines of St. Laurent
+                                ! et al. (2002) and Simmons et al. (2004).
+INT_TIDE_PROFILE = "POLZIN_09"  ! default = "STLAURENT_02"
+                                ! INT_TIDE_PROFILE selects the vertical profile of energy
+                                ! dissipation with INT_TIDE_DISSIPATION. Valid values are:
+                                !    STLAURENT_02 - Use the St. Laurent et al exponential
+                                !                   decay profile.
+                                !    POLZIN_09 - Use the Polzin WKB-streched algebraic
+                                !                   decay profile.
+LEE_WAVE_DISSIPATION = False    !   [Boolean] default = False
+                                ! If true, use an lee wave driven dissipation scheme to
+                                ! drive diapycnal mixing, along the lines of Nikurashin
+                                ! (2010) and using the St. Laurent et al. (2002)
+                                ! and Simmons et al. (2004) vertical profile
+INT_TIDE_LOWMODE_DISSIPATION = False !   [Boolean] default = False
+                                ! If true, consider mixing due to breaking low modes that
+                                ! have been remotely generated; as with itidal drag on the
+                                ! barotropic tide, use an internal tidal dissipation scheme to
+                                ! drive diapycnal mixing, along the lines of St. Laurent
+                                ! et al. (2002) and Simmons et al. (2004).
+NU_POLZIN = 0.0697              !   [nondim] default = 0.0697
+                                ! When the Polzin decay profile is used, this is a
+                                ! non-dimensional constant in the expression for the
+                                ! vertical scale of decay for the tidal energy dissipation.
+NBOTREF_POLZIN = 9.61E-04       !   [s-1] default = 9.61E-04
+                                ! When the Polzin decay profile is used, this is the
+                                ! Rreference value of the buoyancy frequency at the ocean
+                                ! bottom in the Polzin formulation for the vertical
+                                ! scale of decay for the tidal energy dissipation.
+POLZIN_DECAY_SCALE_FACTOR = 1.0 !   [nondim] default = 1.0
+                                ! When the Polzin decay profile is used, this is a
+                                ! scale factor for the vertical scale of decay of the tidal
+                                ! energy dissipation.
+POLZIN_SCALE_MAX_FACTOR = 1.0   !   [nondim] default = 1.0
+                                ! When the Polzin decay profile is used, this is a factor
+                                ! to limit the vertical scale of decay of the tidal
+                                ! energy dissipation to POLZIN_DECAY_SCALE_MAX_FACTOR
+                                ! times the depth of the ocean.
+POLZIN_MIN_DECAY_SCALE = 0.0    !   [m] default = 0.0
+                                ! When the Polzin decay profile is used, this is the
+                                ! minimum vertical decay scale for the vertical profile
+                                ! of internal tide dissipation with the Polzin (2009) formulation
+USER_CHANGE_DIFFUSIVITY = False !   [Boolean] default = False
+                                ! If true, call user-defined code to change the diffusivity.
+DISSIPATION_MIN = 0.0           !   [W m-3] default = 0.0
+                                ! The minimum dissipation by which to determine a lower
+                                ! bound of Kd (a floor).
+DISSIPATION_N0 = 0.0            !   [W m-3] default = 0.0
+                                ! The intercept when N=0 of the N-dependent expression
+                                ! used to set a minimum dissipation by which to determine
+                                ! a lower bound of Kd (a floor): A in eps_min = A + B*N.
+DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
+                                ! The coefficient multiplying N, following Gargett, used to
+                                ! set a minimum dissipation by which to determine a lower
+                                ! bound of Kd (a floor): B in eps_min = A + B*N
+DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
+                                ! The minimum vertical diffusivity applied as a floor.
+INT_TIDE_DECAY_SCALE = 300.3003003003003 !   [m] default = 0.0
+                                ! The decay scale away from the bottom for tidal TKE with
+                                ! the new coding when INT_TIDE_DISSIPATION is used.
+MU_ITIDES = 0.2                 !   [nondim] default = 0.2
+                                ! A dimensionless turbulent mixing efficiency used with
+                                ! INT_TIDE_DISSIPATION, often 0.2.
+GAMMA_ITIDES = 0.3333           !   [nondim] default = 0.3333
+                                ! The fraction of the internal tidal energy that is
+                                ! dissipated locally with INT_TIDE_DISSIPATION.
+                                ! THIS NAME COULD BE BETTER.
+MIN_ZBOT_ITIDES = 0.0           !   [m] default = 0.0
+                                ! Turn off internal tidal dissipation when the total
+                                ! ocean depth is less than this value.
+KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
+                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
+                                ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
+UTIDE = 0.0                     !   [m s-1] default = 0.0
+                                ! The constant tidal amplitude used with INT_TIDE_DISSIPATION.
+KAPPA_H2_FACTOR = 0.84          !   [nondim] default = 1.0
+                                ! A scaling factor for the roughness amplitude with nINT_TIDE_DISSIPATION.
+TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
+                                ! The maximum internal tide energy source availble to mix
+                                ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
+READ_TIDEAMP = True             !   [Boolean] default = False
+                                ! If true, read a file (given by TIDEAMP_FILE) containing
+                                ! the tidal amplitude with INT_TIDE_DISSIPATION.
+TIDEAMP_FILE = "tidal_amplitude.v2015.12.03.nc" ! default = "tideamp.nc"
+                                ! The path to the file containing the spatially varying
+                                ! tidal amplitudes with INT_TIDE_DISSIPATION.
+H2_FILE = "ocean_topog.nc"      !
+                                ! The path to the file containing the sub-grid-scale
+                                ! topographic roughness amplitude with INT_TIDE_DISSIPATION.
+
+! === module MOM_kappa_shear ===
+! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
+USE_JACKSON_PARAM = True        !   [Boolean] default = False
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
+                                ! shear mixing parameterization.
+RINO_CRIT = 0.25                !   [nondim] default = 0.25
+                                ! The critical Richardson number for shear mixing.
+SHEARMIX_RATE = 0.089           !   [nondim] default = 0.089
+                                ! A nondimensional rate scale for shear-driven entrainment.
+                                ! Jackson et al find values in the range of 0.085-0.089.
+MAX_RINO_IT = 25                !   [nondim] default = 50
+                                ! The maximum number of iterations that may be used to
+                                ! estimate the Richardson number driven mixing.
+KD_KAPPA_SHEAR_0 = 1.5E-05      !   [m2 s-1] default = 1.5E-05
+                                ! The background diffusivity that is used to smooth the
+                                ! density and shear profiles before solving for the
+                                ! diffusivities. Defaults to value of KD.
+FRI_CURVATURE = -0.97           !   [nondim] default = -0.97
+                                ! The nondimensional curvature of the function of the
+                                ! Richardson number in the kappa source term in the
+                                ! Jackson et al. scheme.
+TKE_N_DECAY_CONST = 0.24        !   [nondim] default = 0.24
+                                ! The coefficient for the decay of TKE due to
+                                ! stratification (i.e. proportional to N*tke).
+                                ! The values found by Jackson et al. are 0.24-0.28.
+TKE_SHEAR_DECAY_CONST = 0.14    !   [nondim] default = 0.14
+                                ! The coefficient for the decay of TKE due to shear (i.e.
+                                ! proportional to |S|*tke). The values found by Jackson
+                                ! et al. are 0.14-0.12.
+KAPPA_BUOY_SCALE_COEF = 0.82    !   [nondim] default = 0.82
+                                ! The coefficient for the buoyancy length scale in the
+                                ! kappa equation.  The values found by Jackson et al. are
+                                ! in the range of 0.81-0.86.
+KAPPA_N_OVER_S_SCALE_COEF2 = 0.0 !   [nondim] default = 0.0
+                                ! The square of the ratio of the coefficients of the
+                                ! buoyancy and shear scales in the diffusivity equation,
+                                ! Set this to 0 (the default) to eliminate the shear scale.
+                                ! This is only used if USE_JACKSON_PARAM is true.
+KAPPA_SHEAR_TOL_ERR = 0.1       !   [nondim] default = 0.1
+                                ! The fractional error in kappa that is tolerated.
+                                ! Iteration stops when changes between subsequent
+                                ! iterations are smaller than this everywhere in a
+                                ! column.  The peak diffusivities usually converge most
+                                ! rapidly, and have much smaller errors than this.
+TKE_BACKGROUND = 0.0            !   [m2 s-2] default = 0.0
+                                ! A background level of TKE used in the first iteration
+                                ! of the kappa equation.  TKE_BACKGROUND could be 0.
+KAPPA_SHEAR_ELIM_MASSLESS = True !   [Boolean] default = True
+                                ! If true, massless layers are merged with neighboring
+                                ! massive layers in this calculation.  The default is
+                                ! true and I can think of no good reason why it should
+                                ! be false. This is only used if USE_JACKSON_PARAM is true.
+MAX_KAPPA_SHEAR_IT = 13         !   [nondim] default = 13
+                                ! The maximum number of iterations that may be used to
+                                ! estimate the time-averaged diffusivity.
+DEBUG_KAPPA_SHEAR = False       !   [Boolean] default = False
+                                ! If true, write debugging data for the kappa-shear code.
+                                ! Caution: this option is _very_ verbose and should only
+                                ! be used in single-column mode!
+
+! === module MOM_CVMix_shear ===
+! Parameterization of shear-driven turbulence via CVMix (various options)
+USE_LMD94 = False               !   [Boolean] default = False
+                                ! If true, use the Large-McWilliams-Doney (JGR 1994)
+                                ! shear mixing parameterization.
+USE_PP81 = False                !   [Boolean] default = False
+                                ! If true, use the Pacanowski and Philander (JPO 1981)
+                                ! shear mixing parameterization.
+
+! === module MOM_diabatic_aux ===
+! The following parameters are used for auxiliary diabatic processes.
+RECLAIM_FRAZIL = True           !   [Boolean] default = True
+                                ! If true, try to use any frazil heat deficit to cool any
+                                ! overlying layers down to the freezing point, thereby
+                                ! avoiding the creation of thin ice when the SST is above
+                                ! the freezing point.
+PRESSURE_DEPENDENT_FRAZIL = True !   [Boolean] default = False
+                                ! If true, use a pressure dependent freezing temperature
+                                ! when making frazil. The default is false, which will be
+                                ! faster but is inappropriate with ice-shelf cavities.
+IGNORE_FLUXES_OVER_LAND = False !   [Boolean] default = False
+                                ! If true, the model does not check if fluxes are being applied
+                                ! over land points. This is needed when the ocean is coupled
+                                ! with ice shelves and sea ice, since the sea ice mask needs to
+                                ! be different than the ocean mask to avoid sea ice formation
+                                ! under ice shelves. This flag only works when use_ePBL = True.
+DO_RIVERMIX = False             !   [Boolean] default = False
+                                ! If true, apply additional mixing whereever there is
+                                ! runoff, so that it is mixed down to RIVERMIX_DEPTH
+                                ! if the ocean is that deep.
+USE_RIVER_HEAT_CONTENT = True   !   [Boolean] default = False
+                                ! If true, use the fluxes%runoff_Hflx field to set the
+                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+USE_CALVING_HEAT_CONTENT = True !   [Boolean] default = False
+                                ! If true, use the fluxes%calving_Hflx field to set the
+                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+
+! === module MOM_energetic_PBL ===
+MSTAR_MODE = 2                  !   [units=nondim] default = 0
+                                ! An integer switch for how to compute MSTAR.
+                                !     0 for constant MSTAR
+                                !     1 for MSTAR w/ MLD in stabilizing limit
+                                !     2 for MSTAR w/ L_E/L_O in stabilizing limit.
+MSTAR = 0.0                     !   [units=nondim] default = 1.2
+                                ! The ratio of the friction velocity cubed to the TKE
+                                ! input to the mixed layer.
+MIX_LEN_EXPONENT = 1.0          !   [units=nondim] default = 2.0
+                                ! The exponent applied to the ratio of the distance to the MLD
+                                ! and the MLD depth which determines the shape of the mixing length.
+MSTAR_CAP = 10.0                !   [units=nondim] default = -1.0
+                                ! Maximum value of mstar allowed in model if non-negative
+                                ! (used if MSTAR_MODE>0).
+MSTAR_CONV_ADJ = 0.667          !   [units=nondim] default = 0.0
+                                ! Factor used for reducing mstar during convection
+                                !  due to reduction of stable density gradient.
+MSTAR_SLOPE = 0.85              !   [units=nondim] default = 0.85
+                                ! The slope of the linear relationship between mstar
+                                ! and the length scale ratio (used if MSTAR_MODE=1).
+MSTAR_XINT = -0.3               !   [units=nondim] default = -0.3
+                                ! The value of the length scale ratio where the mstar
+                                ! is linear above (used if MSTAR_MODE=1).
+MSTAR_AT_XINT = 0.095           !   [units=nondim] default = 0.095
+                                ! The value of mstar at MSTAR_XINT
+                                ! (used if MSTAR_MODE=1).
+MSTAR_FLATCAP = True            !   [units=nondim] default = True
+                                ! Set false to use asymptotic cap, defaults to true.
+                                ! (used only if MSTAR_MODE=1)
+MSTAR2_COEF1 = 0.29             !   [units=nondim] default = 0.3
+                                ! Coefficient in computing mstar when rotation and
+                                !  stabilizing effects are both important (used if MSTAR_MODE=2)
+MSTAR2_COEF2 = 0.152            !   [units=nondim] default = 0.085
+                                ! Coefficient in computing mstar when only rotation limits
+                                !  the total mixing. (used only if MSTAR_MODE=2)
+NSTAR = 0.06                    !   [nondim] default = 0.2
+                                ! The portion of the buoyant potential energy imparted by
+                                ! surface fluxes that is available to drive entrainment
+                                ! at the base of mixed layer when that energy is positive.
+MKE_TO_TKE_EFFIC = 0.0          !   [nondim] default = 0.0
+                                ! The efficiency with which mean kinetic energy released
+                                ! by mechanically forced entrainment of the mixed layer
+                                ! is converted to turbulent kinetic energy.
+TKE_DECAY = 0.01                !   [nondim] default = 2.5
+                                ! TKE_DECAY relates the vertical rate of decay of the
+                                ! TKE available for mechanical entrainment to the natural
+                                ! Ekman depth.
+ML_OMEGA_FRAC = 0.001           !   [nondim] default = 0.0
+                                ! When setting the decay scale for turbulence, use this
+                                ! fraction of the absolute rotation rate blended with the
+                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+WSTAR_USTAR_COEF = 1.0          !   [nondim] default = 1.0
+                                ! A ratio relating the efficiency with which convectively
+                                ! released energy is converted to a turbulent velocity,
+                                ! relative to mechanically forced TKE. Making this larger
+                                ! increases the BL diffusivity
+VSTAR_SCALE_FACTOR = 1.0        !   [nondim] default = 1.0
+                                ! An overall nondimensional scaling factor for v*.
+                                ! Making this larger decreases the PBL diffusivity.
+EKMAN_SCALE_COEF = 1.0          !   [nondim] default = 1.0
+                                ! A nondimensional scaling factor controlling the inhibition
+                                ! of the diffusive length scale by rotation. Making this larger
+                                ! decreases the PBL diffusivity.
+USE_MLD_ITERATION = True        !   [Boolean] default = False
+                                ! A logical that specifies whether or not to use the
+                                ! distance to the bottom of the actively turblent boundary
+                                ! layer to help set the EPBL length scale.
+ORIG_MLD_ITERATION = False      !   [Boolean] default = True
+                                ! A logical that specifies whether or not to use the
+                                ! old method for determining MLD depth in iteration, which
+                                ! is limited to resolution.
+MLD_ITERATION_GUESS = False     !   [Boolean] default = False
+                                ! A logical that specifies whether or not to use the
+                                ! previous timestep MLD as a first guess in the MLD iteration.
+                                ! The default is false to facilitate reproducibility.
+EPBL_MLD_TOLERANCE = 1.0        !   [meter] default = 1.0
+                                ! The tolerance for the iteratively determined mixed
+                                ! layer depth.  This is only used with USE_MLD_ITERATION.
+EPBL_MIN_MIX_LEN = 0.0          !   [meter] default = 0.0
+                                ! The minimum mixing length scale that will be used
+                                ! by ePBL.  The default (0) does not set a minimum.
+EPBL_ORIGINAL_PE_CALC = True    !   [Boolean] default = True
+                                ! If true, the ePBL code uses the original form of the
+                                ! potential energy change code.  Otherwise, the newer
+                                ! version that can work with successive increments to the
+                                ! diffusivity in upward or downward passes is used.
+EPBL_TRANSITION_SCALE = 0.01    !   [nondim] default = 0.1
+                                ! A scale for the mixing length in the transition layer
+                                ! at the edge of the boundary layer as a fraction of the
+                                ! boundary layer thickness.  The default is 0.1.
+N2_DISSIPATION_POS = 0.0        !   [nondim] default = 0.0
+                                ! A scale for the dissipation of TKE due to stratification
+                                ! in the boundary layer, applied when local stratification
+                                ! is positive.  The default is 0, but should probably be ~0.4.
+N2_DISSIPATION_NEG = 0.0        !   [nondim] default = 0.0
+                                ! A scale for the dissipation of TKE due to stratification
+                                ! in the boundary layer, applied when local stratification
+                                ! is negative.  The default is 0, but should probably be ~1.
+USE_LA_LI2016 = True            !   [nondim] default = False
+                                ! A logical to use the Li et al. 2016 (submitted) formula to
+                                !  determine the Langmuir number.
+LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
+                                ! The depth (normalized by BLD) to average Stokes drift over in
+                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+LT_ENHANCE = 3                  !   [nondim] default = 0
+                                ! Integer for Langmuir number mode.
+                                !  *Requires USE_LA_LI2016 to be set to True.
+                                ! Options: 0 - No Langmuir
+                                !          1 - Van Roekel et al. 2014/Li et al., 2016
+                                !          2 - Multiplied w/ adjusted La.
+                                !          3 - Added w/ adjusted La.
+LT_ENHANCE_COEF = 0.044         !   [nondim] default = 0.447
+                                ! Coefficient for Langmuir enhancement if LT_ENHANCE > 1
+LT_ENHANCE_EXP = -1.5           !   [nondim] default = -1.33
+                                ! Exponent for Langmuir enhancement if LT_ENHANCE > 1
+LT_MOD_LAC1 = 0.0               !   [nondim] default = -0.87
+                                ! Coefficient for modification of Langmuir number due to
+                                !  MLD approaching Ekman depth if LT_ENHANCE=2.
+LT_MOD_LAC2 = 0.0               !   [nondim] default = 0.0
+                                ! Coefficient for modification of Langmuir number due to
+                                !  MLD approaching stable Obukhov depth if LT_ENHANCE=2.
+LT_MOD_LAC3 = 0.0               !   [nondim] default = 0.0
+                                ! Coefficient for modification of Langmuir number due to
+                                !  MLD approaching unstable Obukhov depth if LT_ENHANCE=2.
+LT_MOD_LAC4 = 0.0               !   [nondim] default = 0.95
+                                ! Coefficient for modification of Langmuir number due to
+                                !  ratio of Ekman to stable Obukhov depth if LT_ENHANCE=2.
+LT_MOD_LAC5 = 0.22              !   [nondim] default = 0.95
+                                ! Coefficient for modification of Langmuir number due to
+                                !  ratio of Ekman to unstable Obukhov depth if LT_ENHANCE=2.
+EPBL_USTAR_MIN = 1.45842E-18    !   [m s-1]
+                                ! The (tiny) minimum friction velocity used within the
+                                ! ePBL code, derived from OMEGA and ANGSTROM.
+
+! === module MOM_regularize_layers ===
+REGULARIZE_SURFACE_LAYERS = False !   [Boolean] default = False
+                                ! If defined, vertically restructure the near-surface
+                                ! layers when they have too much lateral variations to
+                                ! allow for sensible lateral barotropic transports.
+HMIX_MIN = 0.0                  !   [m] default = 0.0
+                                ! The minimum mixed layer depth if the mixed layer depth
+                                ! is determined dynamically.
+REG_SFC_DEFICIT_TOLERANCE = 0.5 !   [nondim] default = 0.5
+                                ! The value of the relative thickness deficit at which
+                                ! to start modifying the layer structure when
+                                ! REGULARIZE_SURFACE_LAYERS is true.
+ALLOW_CLOCKS_IN_OMP_LOOPS = True !   [Boolean] default = True
+                                ! If true, clocks can be called from inside loops that can
+                                ! be threaded. To run with multiple threads, set to False.
+
+! === module MOM_opacity ===
+VAR_PEN_SW = True               !   [Boolean] default = False
+                                ! If true, use one of the CHL_A schemes specified by
+                                ! OPACITY_SCHEME to determine the e-folding depth of
+                                ! incoming short wave radiation.
+OPACITY_SCHEME = "MANIZZA_05"   ! default = "MANIZZA_05"
+                                ! This character string specifies how chlorophyll
+                                ! concentrations are translated into opacities. Currently
+                                ! valid options include:
+                                !        MANIZZA_05 - Use Manizza et al., GRL, 2005.
+                                !        MOREL_88 - Use Morel, JGR, 1988.
+CHL_FROM_FILE = True            !   [Boolean] default = True
+                                ! If true, chl_a is read from a file.
+CHL_FILE = "seawifs_1998-2006_smoothed_2X.v2015.12.03.nc" !
+                                ! CHL_FILE is the file containing chl_a concentrations in
+                                ! the variable CHL_A. It is used when VAR_PEN_SW and
+                                ! CHL_FROM_FILE are true.
+BLUE_FRAC_SW = 0.5              !   [nondim] default = 0.5
+                                ! The fraction of the penetrating shortwave radiation
+                                ! that is in the blue band.
+PEN_SW_NBANDS = 3               ! default = 1
+                                ! The number of bands of penetrating shortwave radiation.
+OPACITY_LAND_VALUE = 10.0       !   [m-1] default = 10.0
+                                ! The value to use for opacity over land. The default is
+                                ! 10 m-1 - a value for muddy water.
+
+! === module MOM_tracer_advect ===
+TRACER_ADVECTION_SCHEME = "PPM:H3" ! default = "PLM"
+                                ! The horizontal transport scheme for tracers:
+                                !   PLM    - Piecewise Linear Method
+                                !   PPM:H3 - Piecewise Parabolic Method (Huyhn 3rd order)
+                                !   PPM    - Piecewise Parabolic Method (Colella-Woodward)
+
+! === module MOM_tracer_hor_diff ===
+KHTR = 200.0                    !   [m2 s-1] default = 0.0
+                                ! The background along-isopycnal tracer diffusivity.
+KHTR_MIN = 0.0                  !   [m2 s-1] default = 0.0
+                                ! The minimum along-isopycnal tracer diffusivity.
+KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
+                                ! The maximum along-isopycnal tracer diffusivity.
+KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
+                                ! The coefficient that scales deformation radius over
+                                ! grid-spacing in passivity, where passiviity is the ratio
+                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! A non-zero value enables this parameterization.
+KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
+                                ! The minimum passivity which is the ratio between
+                                ! along isopycnal mxiing of tracers to thickness mixing.
+DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
+                                ! If true, enable epipycnal mixing between the surface
+                                ! boundary layer and the interior.
+CHECK_DIFFUSIVE_CFL = True      !   [Boolean] default = False
+                                ! If true, use enough iterations the diffusion to ensure
+                                ! that the diffusive equivalent of the CFL limit is not
+                                ! violated.  If false, always use 1 iteration.
+
+! === module MOM_neutral_diffusion ===
+! This module implements neutral diffusion of tracers
+USE_NEUTRAL_DIFFUSION = True    !   [Boolean] default = False
+                                ! If true, enables the neutral diffusion module.
+NDIFF_CONTINUOUS = True         !   [Boolean] default = True
+                                ! If true, uses a continuous reconstruction of T and S when
+                                ! finding neutral surfaces along which diffusion will happen.
+                                ! If false, a PPM discontinuous reconstruction of T and S
+                                ! is done which results in a higher order routine but exacts
+                                ! a higher computational cost.
+NDIFF_REF_PRES = -1.0           !   [not defined] default = -1.0
+                                ! The reference pressure (Pa) used for the derivatives of
+                                ! the equation of state. If negative (default), local
+                                ! pressure is used.
+OBSOLETE_DIAGNOSTIC_IS_FATAL = True !   [Boolean] default = True
+                                ! If an obsolete diagnostic variable appears in the diag_table
+                                ! then cause a FATAL error rather than issue a WARNING.
+
+! === module ocean_model_init ===
+RESTART_CONTROL = 1             ! default = 1
+                                ! An integer whose bits encode which restart files are
+                                ! written. Add 2 (bit 1) for a time-stamped file, and odd
+                                ! (bit 0) for a non-time-stamped file.  A restart file
+                                ! will be saved at the end of the run segment for any
+                                ! non-negative value.
+TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
+                                ! The time unit for ENERGYSAVEDAYS.
+ENERGYSAVEDAYS = 0.5            !   [days] default = 1.0
+                                ! The interval in units of TIMEUNIT between saves of the
+                                ! energies of the run and other globally summed diagnostics.
+ENERGYSAVEDAYS_GEOMETRIC = 0.0  !   [days] default = 0.0
+                                ! The starting interval in units of TIMEUNIT for the first call
+                                ! to save the energies of the run and other globally summed diagnostics.
+                                ! The interval increases by a factor of 2. after each call to write_energy.
+OCEAN_SURFACE_STAGGER = "C"     ! default = "C"
+                                ! A case-insensitive character string to indicate the
+                                ! staggering of the surface velocity field that is
+                                ! returned to the coupler.  Valid values include
+                                ! 'A', 'B', or 'C'.
+RESTORE_SALINITY = True         !   [Boolean] default = False
+                                ! If true, the coupled driver will add a globally-balanced
+                                ! fresh-water flux that drives sea-surface salinity
+                                ! toward specified values.
+RESTORE_TEMPERATURE = False     !   [Boolean] default = False
+                                ! If true, the coupled driver will add a
+                                ! heat flux that drives sea-surface temperauture
+                                ! toward specified values.
+ICE_SHELF = False               !   [Boolean] default = False
+                                ! If true, enables the ice shelf model.
+ICEBERGS_APPLY_RIGID_BOUNDARY = False !   [Boolean] default = False
+                                ! If true, allows icebergs to change boundary condition felt by ocean
+
+! === module MOM_surface_forcing ===
+LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
+                                ! The latent heat of fusion.
+LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
+                                ! The latent heat of fusion.
+MAX_P_SURF = 0.0                !   [Pa] default = -1.0
+                                ! The maximum surface pressure that can be exerted by the
+                                ! atmosphere and floating sea-ice or ice shelves. This is
+                                ! needed because the FMS coupling structure does not
+                                ! limit the water that can be frozen out of the ocean and
+                                ! the ice-ocean heat fluxes are treated explicitly.  No
+                                ! limit is applied if a negative value is used.
+ADJUST_NET_SRESTORE_TO_ZERO = True !   [Boolean] default = True
+                                ! If true, adjusts the salinity restoring seen to zero
+                                ! whether restoring is via a salt flux or virtual precip.
+ADJUST_NET_SRESTORE_BY_SCALING = False !   [Boolean] default = False
+                                ! If true, adjustments to salt restoring to achieve zero net are
+                                ! made by scaling values without moving the zero contour.
+ADJUST_NET_FRESH_WATER_TO_ZERO = True !   [Boolean] default = False
+                                ! If true, adjusts the net fresh-water forcing seen
+                                ! by the ocean (including restoring) to zero.
+ADJUST_NET_FRESH_WATER_BY_SCALING = False !   [Boolean] default = False
+                                ! If true, adjustments to net fresh water to achieve zero net are
+                                ! made by scaling values without moving the zero contour.
+ICE_SALT_CONCENTRATION = 0.005  !   [kg/kg] default = 0.005
+                                ! The assumed sea-ice salinity needed to reverse engineer the
+                                ! melt flux (or ice-ocean fresh-water flux).
+USE_LIMITED_PATM_SSH = True     !   [Boolean] default = True
+                                ! If true, return the sea surface height with the
+                                ! correction for the atmospheric (and sea-ice) pressure
+                                ! limited by max_p_surf instead of the full atmospheric
+                                ! pressure.
+WIND_STAGGER = "C"              ! default = "C"
+                                ! A case-insensitive character string to indicate the
+                                ! staggering of the input wind stress field.  Valid
+                                ! values are 'A', 'B', or 'C'.
+WIND_STRESS_MULTIPLIER = 1.0    !   [not defined] default = 1.0
+                                ! A factor multiplying the wind-stress given to the ocean by the
+                                ! coupler. This is used for testing and should be =1.0 for any
+                                ! production runs.
+FLUXCONST = 0.1667              !   [m day-1]
+                                ! The constant that relates the restoring surface fluxes
+                                ! to the relative surface anomalies (akin to a piston
+                                ! velocity).  Note the non-MKS units.
+SALT_RESTORE_FILE = "salt_restore.v2015.12.03.nc" ! default = "salt_restore.nc"
+                                ! A file in which to find the surface salinity to use for restoring.
+SALT_RESTORE_VARIABLE = "salt"  ! default = "salt"
+                                ! The name of the surface salinity variable to read from SALT_RESTORE_FILE for restoring salinity.
+SRESTORE_AS_SFLUX = True        !   [Boolean] default = False
+                                ! If true, the restoring of salinity is applied as a salt
+                                ! flux instead of as a freshwater flux.
+MAX_DELTA_SRESTORE = 5.0        !   [PSU or g kg-1] default = 999.0
+                                ! The maximum salinity difference used in restoring terms.
+MASK_SRESTORE_UNDER_ICE = False !   [Boolean] default = False
+                                ! If true, disables SSS restoring under sea-ice based on a frazil
+                                ! criteria (SST<=Tf). Only used when RESTORE_SALINITY is True.
+MASK_SRESTORE_MARGINAL_SEAS = False !   [Boolean] default = False
+                                ! If true, disable SSS restoring in marginal seas. Only used when
+                                ! RESTORE_SALINITY is True.
+BASIN_FILE = "basin.nc"         ! default = "basin.nc"
+                                ! A file in which to find the basin masks, in variable 'basin'.
+MASK_SRESTORE = False           !   [Boolean] default = False
+                                ! If true, read a file (salt_restore_mask) containing
+                                ! a mask for SSS restoring.
+CD_TIDES = 0.0018               !   [nondim] default = 1.0E-04
+                                ! The drag coefficient that applies to the tides.
+READ_GUST_2D = False            !   [Boolean] default = False
+                                ! If true, use a 2-dimensional gustiness supplied from
+                                ! an input file
+GUST_CONST = 0.0                !   [Pa] default = 0.02
+                                ! The background gustiness in the winds.
+USE_RIGID_SEA_ICE = True        !   [Boolean] default = False
+                                ! If true, sea-ice is rigid enough to exert a
+                                ! nonhydrostatic pressure that resist vertical motion.
+SEA_ICE_MEAN_DENSITY = 900.0    !   [kg m-3] default = 900.0
+                                ! A typical density of sea ice, used with the kinematic
+                                ! viscosity, when USE_RIGID_SEA_ICE is true.
+SEA_ICE_VISCOSITY = 1.0E+09     !   [m2 s-1] default = 1.0E+09
+                                ! The kinematic viscosity of sufficiently thick sea ice
+                                ! for use in calculating the rigidity of sea ice.
+SEA_ICE_RIGID_MASS = 100.0      !   [kg m-2] default = 1000.0
+                                ! The mass of sea-ice per unit area at which the sea-ice
+                                ! starts to exhibit rigidity
+ALLOW_ICEBERG_FLUX_DIAGNOSTICS = False !   [Boolean] default = False
+                                ! If true, makes available diagnostics of fluxes from icebergs
+                                ! as seen by MOM6.
+ALLOW_FLUX_ADJUSTMENTS = False  !   [Boolean] default = False
+                                ! If true, allows flux adjustments to specified via the
+                                ! data_table using the component name 'OCN'.
+
+! === module MOM_restart ===
+
+! === module MOM_sum_output ===
+CALCULATE_APE = True            !   [Boolean] default = True
+                                ! If true, calculate the available potential energy of
+                                ! the interfaces.  Setting this to false reduces the
+                                ! memory footprint of high-PE-count models dramatically.
+WRITE_STOCKS = True             !   [Boolean] default = True
+                                ! If true, write the integrated tracer amounts to stdout
+                                ! when the energy files are written.
+MAXTRUNC = 100000               !   [truncations save_interval-1] default = 0
+                                ! The run will be stopped, and the day set to a very
+                                ! large value if the velocity is truncated more than
+                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! to stop if there is any truncation of velocities.
+MAX_ENERGY = 0.0                !   [m2 s-2] default = 0.0
+                                ! The maximum permitted average energy per unit mass; the
+                                ! model will be stopped if there is more energy than
+                                ! this.  If zero or negative, this is set to 10*MAXVEL^2.
+ENERGYFILE = "ocean.stats"      ! default = "ocean.stats"
+                                ! The file to use to write the energies and globally
+                                ! summed diagnostics.
+DATE_STAMPED_STDOUT = True      !   [Boolean] default = True
+                                ! If true, use dates (not times) in messages to stdout
+READ_DEPTH_LIST = False         !   [Boolean] default = False
+                                ! Read the depth list from a file if it exists or
+                                ! create that file otherwise.
+DEPTH_LIST_MIN_INC = 1.0E-10    !   [m] default = 1.0E-10
+                                ! The minimum increment between the depths of the
+                                ! entries in the depth-list file.
+
+! === module MOM_file_parser ===
+SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
+                                ! If true, all log messages are also sent to stdout.
+REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
+                                ! If true, report any parameter lines that are not used
+                                ! in the run.
+FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
+                                ! If true, kill the run if there are any unused
+                                ! parameters.
+DOCUMENT_FILE = "MOM_parameter_doc" ! default = "MOM_parameter_doc"
+                                ! The basename for files where run-time parameters, their
+                                ! settings, units and defaults are documented. Blank will
+                                ! disable all parameter documentation.
+COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
+                                ! If true, all run-time parameters are
+                                ! documented in MOM_parameter_doc.all .
+MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
+                                ! If true, non-default run-time parameters are
+                                ! documented in MOM_parameter_doc.short .

--- a/ice_ocean_SIS2/Baltic_OM4_05/MOM_parameter_doc.debugging
+++ b/ice_ocean_SIS2/Baltic_OM4_05/MOM_parameter_doc.debugging
@@ -1,0 +1,4 @@
+! This file was written by the model and records the debugging parameters used at run-time.
+H_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of thickness.  Valid values range from -300 to 300.

--- a/ice_ocean_SIS2/Baltic_OM4_05/MOM_parameter_doc.layout
+++ b/ice_ocean_SIS2/Baltic_OM4_05/MOM_parameter_doc.layout
@@ -1,0 +1,73 @@
+! This file was written by the model and records the layout parameters used at run-time.
+GLOBAL_INDEXING = False         !   [Boolean] default = False
+                                ! If true, use a global lateral indexing convention, so
+                                ! that corresponding points on different processors have
+                                ! the same index. This does not work with static memory.
+!SYMMETRIC_MEMORY_ = False      !   [Boolean]
+                                ! If defined, the velocity point data domain includes
+                                ! every face of the thickness points. In other words,
+                                ! some arrays are larger than others, depending on where
+                                ! they are on the staggered grid.  Also, the starting
+                                ! index of the velocity-point arrays is usually 0, not 1.
+                                ! This can only be set at compile time.
+NONBLOCKING_UPDATES = False     !   [Boolean] default = False
+                                ! If true, non-blocking halo updates may be used.
+THIN_HALO_UPDATES = True        !   [Boolean] default = True
+                                ! If true, optional arguments may be used to specify the
+                                ! The width of the halos that are updated with each call.
+!STATIC_MEMORY_ = False         !   [Boolean]
+                                ! If STATIC_MEMORY_ is defined, the principle variables
+                                ! will have sizes that are statically determined at
+                                ! compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially
+                                ! faster, but does not allow the PE count to be changed
+                                ! at run time.  This can only be set at compile time.
+NIHALO = 4                      ! default = 4
+                                ! The number of halo points on each side in the
+                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
+                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
+                                ! the default is NIHALO_ in MOM_memory.h (if defined) or 2.
+NJHALO = 4                      ! default = 4
+                                ! The number of halo points on each side in the
+                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
+                                ! in MOM_memory.h at compile time; without STATIC_MEMORY_
+                                ! the default is NJHALO_ in MOM_memory.h (if defined) or 2.
+MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
+                                ! A text file to specify n_mask, layout and mask_list.
+                                ! This feature masks out processors that contain only land points.
+                                ! The first line of mask_table is the number of regions to be masked out.
+                                ! The second line is the layout of the model and must be
+                                ! consistent with the actual model layout.
+                                ! The following (n_mask) lines give the logical positions
+                                ! of the processors that are masked out. The mask_table
+                                ! can be created by tools like check_mask. The
+                                ! following example of mask_table masks out 2 processors,
+                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                !  2
+                                !  4,6
+                                !  1,2
+                                !  3,6
+NIPROC = 1                      !
+                                ! The number of processors in the x-direction. With
+                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+NJPROC = 1                      !
+                                ! The number of processors in the x-direction. With
+                                ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
+LAYOUT = 1, 1                   !
+                                ! The processor layout that was acutally used.
+IO_LAYOUT = 1, 1                ! default = 1
+                                ! The processor layout to be used, or 0,0 to automatically
+                                ! set the io_layout to be the same as the layout.
+NIBLOCK = 1                     ! default = 1
+                                ! The number of blocks in the x-direction on each processor (for openmp).
+NJBLOCK = 1                     ! default = 1
+                                ! The number of blocks in the y-direction on each processor (for openmp).
+BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
+                                ! If true, use wide halos and march in during the
+                                ! barotropic time stepping for efficiency.
+BTHALO = 0                      ! default = 0
+                                ! The minimum halo size for the barotropic solver.
+!BT x-halo = 0                  !
+                                ! The barotropic x-halo size that is actually used.
+!BT y-halo = 0                  !
+                                ! The barotropic y-halo size that is actually used.

--- a/ice_ocean_SIS2/Baltic_OM4_05/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/Baltic_OM4_05/MOM_parameter_doc.short
@@ -1,0 +1,886 @@
+! This file was written by the model and records the non-default parameters used at run-time.
+
+! === module MOM ===
+USE_REGRIDDING = True           !   [Boolean] default = False
+                                ! If True, use the ALE algorithm (regridding/remapping).
+                                ! If False, use the layered isopycnal algorithm.
+THICKNESSDIFFUSE = True         !   [Boolean] default = False
+                                ! If true, interface heights are diffused with a
+                                ! coefficient of KHTH.
+THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
+                                ! If true, do thickness diffusion before dynamics.
+                                ! This is only used if THICKNESSDIFFUSE is true.
+DT = 1800.0                     !   [s]
+                                ! The (baroclinic) dynamics time step.  The time-step that
+                                ! is actually used will be an integer fraction of the
+                                ! forcing time-step (DT_FORCING in ocean-only mode or the
+                                ! coupling timestep in coupled mode.)
+DT_THERM = 1.08E+04             !   [s] default = 1800.0
+                                ! The thermodynamic and tracer advection time step.
+                                ! Ideally DT_THERM should be an integer multiple of DT
+                                ! and less than the forcing or coupling time-step, unless
+                                ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
+                                ! can be an integer multiple of the coupling timestep.  By
+                                ! default DT_THERM is set to DT.
+THERMO_SPANS_COUPLING = True    !   [Boolean] default = False
+                                ! If true, the MOM will take thermodynamic and tracer
+                                ! timesteps that can be longer than the coupling timestep.
+                                ! The actual thermodynamic timestep that is used in this
+                                ! case is the largest integer multiple of the coupling
+                                ! timestep that is less than or equal to DT_THERM.
+MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
+                                ! The minimum amount of time in seconds between
+                                ! calculations of depth-space diagnostics. Making this
+                                ! larger than DT_THERM reduces the  performance penalty
+                                ! of regridding to depth online.
+FRAZIL = True                   !   [Boolean] default = False
+                                ! If true, water freezes if it gets too cold, and the
+                                ! the accumulated heat deficit is returned in the
+                                ! surface state.  FRAZIL is only used if
+                                ! ENABLE_THERMODYNAMICS is true.
+DO_GEOTHERMAL = True            !   [Boolean] default = False
+                                ! If true, apply geothermal heating.
+BOUND_SALINITY = True           !   [Boolean] default = False
+                                ! If true, limit salinity to being positive. (The sea-ice
+                                ! model may ask for more salt than is available and
+                                ! drive the salinity negative otherwise.)
+C_P = 3992.0                    !   [J kg-1 K-1] default = 3991.86795711963
+                                ! The heat capacity of sea water, approximated as a
+                                ! constant. This is only used if ENABLE_THERMODYNAMICS is
+                                ! true. The default value is from the TEOS-10 definition
+                                ! of conservative temperature.
+CHECK_BAD_SURFACE_VALS = True   !   [Boolean] default = False
+                                ! If true, check the surface state for ridiculous values.
+BAD_VAL_SSH_MAX = 50.0          !   [m] default = 20.0
+                                ! The value of SSH above which a bad value message is
+                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+BAD_VAL_SSS_MAX = 75.0          !   [PPT] default = 45.0
+                                ! The value of SSS above which a bad value message is
+                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+BAD_VAL_SST_MAX = 55.0          !   [deg C] default = 45.0
+                                ! The value of SST above which a bad value message is
+                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+BAD_VAL_SST_MIN = -3.0          !   [deg C] default = -2.1
+                                ! The value of SST below which a bad value message is
+                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+
+! === module MOM_domains ===
+REENTRANT_X = False             !   [Boolean] default = True
+                                ! If true, the domain is zonally reentrant.
+NIGLOBAL = 49                   !
+                                ! The total number of thickness grid points in the
+                                ! x-direction in the physical domain. With STATIC_MEMORY_
+                                ! this is set in MOM_memory.h at compile time.
+NJGLOBAL = 53                   !
+                                ! The total number of thickness grid points in the
+                                ! y-direction in the physical domain. With STATIC_MEMORY_
+                                ! this is set in MOM_memory.h at compile time.
+
+! === module MOM_hor_index ===
+! Sets the horizontal array index types.
+
+! === module MOM_verticalGrid ===
+! Parameters providing information about the vertical grid.
+NK = 75                         !   [nondim]
+                                ! The number of model layers.
+
+! === module MOM_fixed_initialization ===
+INPUTDIR = "INPUT"              ! default = "."
+                                ! The directory in which input files are found.
+
+! === module MOM_grid_init ===
+GRID_CONFIG = "mosaic"          !
+                                ! A character string that determines the method for
+                                ! defining the horizontal grid.  Current options are:
+                                !     mosaic - read the grid from a mosaic (supergrid)
+                                !              file set by GRID_FILE.
+                                !     cartesian - use a (flat) Cartesian grid.
+                                !     spherical - use a simple spherical grid.
+                                !     mercator - use a Mercator spherical grid.
+GRID_FILE = "ocean_hgrid.nc"    !
+                                ! Name of the file from which to read horizontal grid data.
+TOPO_CONFIG = "file"            !
+                                ! This specifies how bathymetry is specified:
+                                !     file - read bathymetric information from the file
+                                !       specified by (TOPO_FILE).
+                                !     flat - flat bottom set to MAXIMUM_DEPTH.
+                                !     bowl - an analytically specified bowl-shaped basin
+                                !       ranging between MAXIMUM_DEPTH and MINIMUM_DEPTH.
+                                !     spoon - a similar shape to 'bowl', but with an vertical
+                                !       wall at the southern face.
+                                !     halfpipe - a zonally uniform channel with a half-sine
+                                !       profile in the meridional direction.
+                                !     benchmark - use the benchmark test case topography.
+                                !     Neverland - use the Neverland test case topography.
+                                !     DOME - use a slope and channel configuration for the
+                                !       DOME sill-overflow test case.
+                                !     ISOMIP - use a slope and channel configuration for the
+                                !       ISOMIP test case.
+                                !     DOME2D - use a shelf and slope configuration for the
+                                !       DOME2D gravity current/overflow test case.
+                                !     Kelvin - flat but with rotated land mask.
+                                !     seamount - Gaussian bump for spontaneous motion test case.
+                                !     shelfwave - exponential slope for shelfwave test case.
+                                !     supercritical - flat but with 8.95 degree land mask.
+                                !     Phillips - ACC-like idealized topography used in the Phillips config.
+                                !     dense - Denmark Strait-like dense water formation and overflow.
+                                !     USER - call a user modified routine.
+TOPO_FILE = "ocean_topog.nc"    ! default = "topog.nc"
+                                ! The file from which the bathymetry is read.
+MAXIMUM_DEPTH = 6500.0          !   [m]
+                                ! The maximum depth of the ocean.
+MINIMUM_DEPTH = 9.5             !   [m] default = 0.0
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than
+                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
+                                ! If MASKING_DEPTH is specified, then all depths shallower than
+                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+
+! === module MOM_open_boundary ===
+! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+MASKING_DEPTH = 0.0             !   [m] default = -9999.0
+                                ! The depth below which to mask points as land points, for which all
+                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+CHANNEL_CONFIG = "list"         ! default = "none"
+                                ! A parameter that determines which set of channels are
+                                ! restricted to specific  widths.  Options are:
+                                !     none - All channels have the grid width.
+                                !     global_1deg - Sets 16 specific channels appropriate
+                                !       for a 1-degree model, as used in CM2G.
+                                !     list - Read the channel locations and widths from a
+                                !       text file, like MOM_channel_list in the MOM_SIS
+                                !       test case.
+                                !     file - Read open face widths everywhere from a
+                                !       NetCDF file on the model grid.
+CHANNEL_LIST_FILE = "MOM_channels_global_025" ! default = "MOM_channel_list"
+                                ! The file from which the list of narrowed channels is read.
+PARALLEL_RESTARTFILES = True    !   [Boolean] default = False
+                                ! If true, each processor writes its own restart file,
+                                ! otherwise a single restart file is generated
+
+! === module MOM_tracer_registry ===
+
+! === module MOM_EOS ===
+DTFREEZE_DP = -7.75E-08         !   [deg C Pa-1] default = 0.0
+                                ! When TFREEZE_FORM=LINEAR,
+                                ! this is the derivative of the freezing potential
+                                ! temperature with pressure.
+
+! === module MOM_restart ===
+
+! === module MOM_tracer_flow_control ===
+USE_IDEAL_AGE_TRACER = True     !   [Boolean] default = False
+                                ! If true, use the ideal_age_example tracer package.
+
+! === module ideal_age_example ===
+
+! === module MOM_coord_initialization ===
+COORD_CONFIG = "file"           !
+                                ! This specifies how layers are to be defined:
+                                !     ALE or none - used to avoid defining layers in ALE mode
+                                !     file - read coordinate information from the file
+                                !       specified by (COORD_FILE).
+                                !     BFB - Custom coords for buoyancy-forced basin case
+                                !       based on SST_S, T_BOT and DRHO_DT.
+                                !     linear - linear based on interfaces not layers
+                                !     layer_ref - linear based on layer densities
+                                !     ts_ref - use reference temperature and salinity
+                                !     ts_range - use range of temperature and salinity
+                                !       (T_REF and S_REF) to determine surface density
+                                !       and GINT calculate internal densities.
+                                !     gprime - use reference density (RHO_0) for surface
+                                !       density and GINT calculate internal densities.
+                                !     ts_profile - use temperature and salinity profiles
+                                !       (read from COORD_FILE) to set layer densities.
+                                !     USER - call a user modified routine.
+COORD_FILE = "layer_coord.nc"   !
+                                ! The file from which the coordinate densities are read.
+REGRIDDING_COORDINATE_MODE = "HYCOM1" ! default = "LAYER"
+                                ! Coordinate mode for vertical regridding.
+                                ! Choose among the following possibilities:
+                                !  LAYER - Isopycnal or stacked shallow water layers
+                                !  ZSTAR, Z* - stetched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  SIGMA - terrain following coordinates
+                                !  RHO   - continuous isopycnal
+                                !  HYCOM1 - HyCOM-like hybrid coordinate
+                                !  SLIGHT - stretched coordinates above continuous isopycnal
+                                !  ADAPTIVE - optimize for smooth neutral density surfaces
+BOUNDARY_EXTRAPOLATION = True   !   [Boolean] default = False
+                                ! When defined, a proper high-order reconstruction
+                                ! scheme is used within boundary cells rather
+                                ! than PCM. E.g., if PPM is used for remapping, a
+                                ! PPM reconstruction will also be used within
+                                ! boundary cells.
+ALE_COORDINATE_CONFIG = "HYBRID:hycom1_75_800m.nc,sigma2,FNC1:2,4000,4.5,.01" ! default = "UNIFORM"
+                                ! Determines how to specify the coordinate
+                                ! resolution. Valid options are:
+                                !  PARAM       - use the vector-parameter ALE_RESOLUTION
+                                !  UNIFORM[:N] - uniformly distributed
+                                !  FILE:string - read from a file. The string specifies
+                                !                the filename and variable name, separated
+                                !                by a comma or space, e.g. FILE:lev.nc,dz
+                                !                or FILE:lev.nc,interfaces=zw
+                                !  WOA09[:N]   - the WOA09 vertical grid (approximately)
+                                !  FNC1:string - FNC1:dz_min,H_total,power,precision
+                                !  HYBRID:string - read from a file. The string specifies
+                                !                the filename and two variable names, separated
+                                !                by a comma or space, for sigma-2 and dz. e.g.
+                                !                HYBRID:vgrid.nc,sigma2,dz
+!ALE_RESOLUTION = 7*2.0, 2*2.01, 2.02, 2.03, 2.05, 2.08, 2.11, 2.15, 2.21, 2.2800000000000002, 2.37, 2.48, 2.61, 2.77, 2.95, 3.17, 3.4299999999999997, 3.74, 4.09, 4.49, 4.95, 5.48, 6.07, 6.74, 7.5, 8.34, 9.280000000000001, 10.33, 11.49, 12.77, 14.19, 15.74, 17.450000000000003, 19.31, 21.35, 23.56, 25.97, 28.580000000000002, 31.41, 34.47, 37.77, 41.32, 45.14, 49.25, 53.65, 58.370000000000005, 63.42, 68.81, 74.56, 80.68, 87.21000000000001, 94.14, 101.51, 109.33, 117.62, 126.4, 135.68, 145.5, 155.87, 166.81, 178.35, 190.51, 203.31, 216.78, 230.93, 245.8, 261.42, 277.83 !   [m]
+                                ! The distribution of vertical resolution for the target
+                                ! grid used for Eulerian-like coordinates. For example,
+                                ! in z-coordinate mode, the parameter is a list of level
+                                ! thicknesses (in m). In sigma-coordinate mode, the list
+                                ! is of non-dimensional fractions of the water column.
+!TARGET_DENSITIES = 1010.0, 1014.3034, 1017.8088, 1020.843, 1023.5566, 1025.813, 1027.0275, 1027.9114, 1028.6422, 1029.2795, 1029.852, 1030.3762, 1030.8626, 1031.3183, 1031.7486, 1032.1572, 1032.5471, 1032.9207, 1033.2798, 1033.6261, 1033.9608, 1034.2519, 1034.4817, 1034.6774, 1034.8508, 1035.0082, 1035.1533, 1035.2886, 1035.4159, 1035.5364, 1035.6511, 1035.7608, 1035.8661, 1035.9675, 1036.0645, 1036.1554, 1036.2411, 1036.3223, 1036.3998, 1036.4739, 1036.5451, 1036.6137, 1036.68, 1036.7441, 1036.8062, 1036.8526, 1036.8874, 1036.9164, 1036.9418, 1036.9647, 1036.9857, 1037.0052, 1037.0236, 1037.0409, 1037.0574, 1037.0738, 1037.0902, 1037.1066, 1037.123, 1037.1394, 1037.1558, 1037.1722, 1037.1887, 1037.206, 1037.2241, 1037.2435, 1037.2642, 1037.2866, 1037.3112, 1037.3389, 1037.3713, 1037.4118, 1037.475, 1037.6332, 1037.8104, 1038.0 !   [m]
+                                ! HYBRID target densities for itnerfaces
+REGRID_COMPRESSIBILITY_FRACTION = 0.01 !   [not defined] default = 0.0
+                                ! When interpolating potential density profiles we can add
+                                ! some artificial compressibility solely to make homogenous
+                                ! regions appear stratified.
+MAXIMUM_INT_DEPTH_CONFIG = "FNC1:5,8000.0,1.0,.01" ! default = "NONE"
+                                ! Determines how to specify the maximum interface depths.
+                                ! Valid options are:
+                                !  NONE        - there are no maximum interface depths
+                                !  PARAM       - use the vector-parameter MAXIMUM_INTERFACE_DEPTHS
+                                !  FILE:string - read from a file. The string specifies
+                                !                the filename and variable name, separated
+                                !                by a comma or space, e.g. FILE:lev.nc,Z
+                                !  FNC1:string - FNC1:dz_min,H_total,power,precision
+!MAXIMUM_INT_DEPTHS = 0.0, 5.0, 12.75, 23.25, 36.49, 52.480000000000004, 71.22, 92.71000000000001, 116.94000000000001, 143.92000000000002, 173.65, 206.13, 241.36, 279.33000000000004, 320.05000000000007, 363.5200000000001, 409.7400000000001, 458.7000000000001, 510.4100000000001, 564.8700000000001, 622.0800000000002, 682.0300000000002, 744.7300000000002, 810.1800000000003, 878.3800000000003, 949.3300000000004, 1023.0200000000004, 1099.4600000000005, 1178.6500000000005, 1260.5900000000006, 1345.2700000000007, 1432.7000000000007, 1522.8800000000008, 1615.8100000000009, 1711.490000000001, 1809.910000000001, 1911.080000000001, 2015.0000000000011, 2121.670000000001, 2231.080000000001, 2343.2400000000007, 2458.1500000000005, 2575.8100000000004, 2696.2200000000003, 2819.3700000000003, 2945.2700000000004, 3073.9200000000005, 3205.3200000000006, 3339.4600000000005, 3476.3500000000004, 3615.9900000000002, 3758.38, 3903.52, 4051.4, 4202.03, 4355.41, 4511.54, 4670.41, 4832.03, 4996.4, 5163.5199999999995, 5333.379999999999, 5505.989999999999, 5681.3499999999985, 5859.459999999998, 6040.319999999998, 6223.919999999998, 6410.269999999999, 6599.369999999999, 6791.219999999999, 6985.8099999999995, 7183.15, 7383.24, 7586.08, 7791.67, 8000.0
+                                ! The list of maximum depths for each interface.
+MAX_LAYER_THICKNESS_CONFIG = "FNC1:400,31000.0,0.1,.01" ! default = "NONE"
+                                ! Determines how to specify the maximum layer thicknesses.
+                                ! Valid options are:
+                                !  NONE        - there are no maximum layer thicknesses
+                                !  PARAM       - use the vector-parameter MAX_LAYER_THICKNESS
+                                !  FILE:string - read from a file. The string specifies
+                                !                the filename and variable name, separated
+                                !                by a comma or space, e.g. FILE:lev.nc,Z
+                                !  FNC1:string - FNC1:dz_min,H_total,power,precision
+!MAX_LAYER_THICKNESS = 400.0, 409.63, 410.32, 410.75, 411.07, 411.32, 411.52, 411.7, 411.86, 412.0, 412.13, 412.24, 412.35, 412.45, 412.54, 412.63, 412.71, 412.79, 412.86, 412.93, 413.0, 413.06, 413.12, 413.18, 413.24, 413.29, 413.34, 413.39, 413.44, 413.49, 413.54, 413.58, 413.62, 413.67, 413.71, 413.75, 413.78, 413.82, 413.86, 413.9, 413.93, 413.97, 414.0, 414.03, 414.06, 414.1, 414.13, 414.16, 414.19, 414.22, 414.24, 414.27, 414.3, 414.33, 414.35, 414.38, 414.41, 414.43, 414.46, 414.48, 414.51, 414.53, 414.55, 414.58, 414.6, 414.62, 414.65, 414.67, 414.69, 414.71, 414.73, 414.75, 414.77, 414.79, 414.83 !   [m]
+                                ! The list of maximum thickness for each layer.
+REMAPPING_SCHEME = "PPM_H4"     ! default = "PLM"
+                                ! This sets the reconstruction scheme used
+                                ! for vertical remapping for all variables.
+                                ! It can be one of the following schemes:
+                                ! PCM         (1st-order accurate)
+                                ! PLM         (2nd-order accurate)
+                                ! PPM_H4      (3rd-order accurate)
+                                ! PPM_IH4     (3rd-order accurate)
+                                ! PQM_IH4IH3  (4th-order accurate)
+                                ! PQM_IH6IH5  (5th-order accurate)
+REMAP_AFTER_INITIALIZATION = False !   [Boolean] default = True
+                                ! If true, applies regridding and remapping immediately after
+                                ! initialization so that the state is ALE consistent. This is a
+                                ! legacy step and should not be needed if the initialization is
+                                ! consistent with the coordinate mode.
+
+! === module MOM_grid ===
+! Parameters providing information about the lateral grid.
+
+! === module MOM_state_initialization ===
+INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
+                                ! If true, intialize the layer thicknesses, temperatures,
+                                ! and salnities from a Z-space file on a latitude-
+                                ! longitude grid.
+
+! === module MOM_initialize_layers_from_Z ===
+TEMP_SALT_Z_INIT_FILE = "WOA05_pottemp_salt.nc" ! default = "temp_salt_z.nc"
+                                ! The name of the z-space input file used to initialize
+                                ! temperatures (T) and salinities (S). If T and S are not
+                                ! in the same file, TEMP_Z_INIT_FILE and SALT_Z_INIT_FILE
+                                ! must be set.
+Z_INIT_FILE_PTEMP_VAR = "PTEMP" ! default = "ptemp"
+                                ! The name of the potential temperature variable in
+                                ! TEMP_Z_INIT_FILE.
+Z_INIT_FILE_SALT_VAR = "SALT"   ! default = "salt"
+                                ! The name of the salinity variable in
+                                ! SALT_Z_INIT_FILE.
+Z_INIT_ALE_REMAPPING = True     !   [Boolean] default = False
+                                ! If True, then remap straight to model coordinate from file.
+Z_INIT_REMAP_GENERAL = True     !   [Boolean] default = False
+                                ! If false, only initializes to z* coordinates.
+                                ! If true, allows initialization directly to general coordinates.
+
+! === module MOM_diag_mediator ===
+NUM_DIAG_COORDS = 2             ! default = 1
+                                ! The number of diagnostic vertical coordinates to use.
+                                ! For each coordinate, an entry in DIAG_COORDS must be provided.
+DIAG_COORDS = "z Z ZSTAR", "rho2 RHO2 RHO" !
+                                ! A list of string tuples associating diag_table modules to
+                                ! a coordinate definition used for diagnostics. Each string
+                                ! is of the form "MODULE_SUFFIX,PARAMETER_SUFFIX,COORDINATE_NAME".
+DIAG_COORD_DEF_RHO2 = "RFNC1:35,999.5,1028,1028.5,8.,1038.,0.0078125" ! default = "WOA09"
+                                ! Determines how to specify the coordinate
+                                ! resolution. Valid options are:
+                                !  PARAM       - use the vector-parameter DIAG_COORD_RES_RHO2
+                                !  UNIFORM[:N] - uniformly distributed
+                                !  FILE:string - read from a file. The string specifies
+                                !                the filename and variable name, separated
+                                !                by a comma or space, e.g. FILE:lev.nc,dz
+                                !                or FILE:lev.nc,interfaces=zw
+                                !  WOA09[:N]   - the WOA09 vertical grid (approximately)
+                                !  FNC1:string - FNC1:dz_min,H_total,power,precision
+                                !  HYBRID:string - read from a file. The string specifies
+                                !                the filename and two variable names, separated
+                                !                by a comma or space, for sigma-2 and dz. e.g.
+                                !                HYBRID:vgrid.nc,sigma2,dz
+
+! === module MOM_MEKE ===
+USE_MEKE = True                 !   [Boolean] default = False
+                                ! If true, turns on the MEKE scheme which calculates
+                                ! a sub-grid mesoscale eddy kinetic energy budget.
+MEKE_GMCOEFF = 1.0              !   [nondim] default = -1.0
+                                ! The efficiency of the conversion of potential energy
+                                ! into MEKE by the thickness mixing parameterization.
+                                ! If MEKE_GMCOEFF is negative, this conversion is not
+                                ! used or calculated.
+MEKE_BGSRC = 1.0E-13            !   [W kg-1] default = 0.0
+                                ! A background energy source for MEKE.
+MEKE_KHTH_FAC = 1.0             !   [nondim] default = 0.0
+                                ! A factor that maps MEKE%Kh to KhTh.
+MEKE_KHMEKE_FAC = 1.0           !   [nondim] default = 0.0
+                                ! A factor that maps MEKE%Kh to Kh for MEKE itself.
+MEKE_ALPHA_RHINES = 0.15        !   [nondim] default = 0.05
+                                ! If positive, is a coefficient weighting the Rhines scale
+                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+MEKE_ALPHA_EADY = 0.15          !   [nondim] default = 0.05
+                                ! If positive, is a coefficient weighting the Eady length scale
+                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+
+! === module MOM_lateral_mixing_coeffs ===
+USE_VARIABLE_MIXING = True      !   [Boolean] default = False
+                                ! If true, the variable mixing code will be called.  This
+                                ! allows diagnostics to be created even if the scheme is
+                                ! not used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,
+                                ! this is set to true regardless of what is in the
+                                ! parameter file.
+RESOLN_SCALED_KH = True         !   [Boolean] default = False
+                                ! If true, the Laplacian lateral viscosity is scaled away
+                                ! when the first baroclinic deformation radius is well
+                                ! resolved.
+RESOLN_SCALED_KHTH = True       !   [Boolean] default = False
+                                ! If true, the interface depth diffusivity is scaled away
+                                ! when the first baroclinic deformation radius is well
+                                ! resolved.
+KHTH_USE_EBT_STRUCT = True      !   [Boolean] default = False
+                                ! If true, uses the equivalent barotropic structure
+                                ! as the vertical structure of thickness diffusivity.
+KHTR_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
+                                ! The nondimensional coefficient in the Visbeck formula
+                                ! for the epipycnal tracer diffusivity
+USE_STORED_SLOPES = True        !   [Boolean] default = False
+                                ! If true, the isopycnal slopes are calculated once and
+                                ! stored for re-use. This uses more memory but avoids calling
+                                ! the equation of state more times than should be necessary.
+KH_RES_FN_POWER = 100           !   [nondim] default = 2
+                                ! The power of dx/Ld in the Kh resolution function.  Any
+                                ! positive integer may be used, although even integers
+                                ! are more efficient to calculate.  Setting this greater
+                                ! than 100 results in a step-function being used.
+INTERPOLATE_RES_FN = False      !   [Boolean] default = True
+                                ! If true, interpolate the resolution function to the
+                                ! velocity points from the thickness points; otherwise
+                                ! interpolate the wave speed and calculate the resolution
+                                ! function independently at each point.
+GILL_EQUATORIAL_LD = True       !   [Boolean] default = False
+                                ! If true, uses Gill's definition of the baroclinic
+                                ! equatorial deformation radius, otherwise, if false, use
+                                ! Pedlosky's definition. These definitions differ by a factor
+                                ! of 2 infront of the beta term in the denominator. Gill'sis the more appropriate definition.
+
+! === module MOM_set_visc ===
+CHANNEL_DRAG = True             !   [Boolean] default = False
+                                ! If true, the bottom drag is exerted directly on each
+                                ! layer proportional to the fraction of the bottom it
+                                ! overlies.
+PRANDTL_TURB = 1.25             !   [nondim] default = 1.0
+                                ! The turbulent Prandtl number applied to shear
+                                ! instability.
+HBBL = 10.0                     !   [m]
+                                ! The thickness of a bottom boundary layer with a
+                                ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
+                                ! the thickness over which near-bottom velocities are
+                                ! averaged for the drag law if BOTTOMDRAGLAW is defined
+                                ! but LINEAR_DRAG is not.
+DRAG_BG_VEL = 0.1               !   [m s-1] default = 0.0
+                                ! DRAG_BG_VEL is either the assumed bottom velocity (with
+                                ! LINEAR_DRAG) or an unresolved  velocity that is
+                                ! combined with the resolved velocity to estimate the
+                                ! velocity magnitude.  DRAG_BG_VEL is only used when
+                                ! BOTTOMDRAGLAW is defined.
+BBL_USE_EOS = True              !   [Boolean] default = False
+                                ! If true, use the equation of state in determining the
+                                ! properties of the bottom boundary layer.  Otherwise use
+                                ! the layer target potential densities.
+BBL_THICK_MIN = 0.1             !   [m] default = 0.0
+                                ! The minimum bottom boundary layer thickness that can be
+                                ! used with BOTTOMDRAGLAW. This might be
+                                ! Kv / (cdrag * drag_bg_vel) to give Kv as the minimum
+                                ! near-bottom viscosity.
+KV = 1.0E-04                    !   [m2 s-1]
+                                ! The background kinematic viscosity in the interior.
+                                ! The molecular value, ~1e-6 m2 s-1, may be used.
+KV_BBL_MIN = 0.0                !   [m2 s-1] default = 1.0E-04
+                                ! The minimum viscosities in the bottom boundary layer.
+KV_TBL_MIN = 0.0                !   [m2 s-1] default = 1.0E-04
+                                ! The minimum viscosities in the top boundary layer.
+
+! === module MOM_continuity ===
+
+! === module MOM_continuity_PPM ===
+ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.75E-09
+                                ! The tolerance for the differences between the
+                                ! barotropic and baroclinic estimates of the sea surface
+                                ! height due to the fluxes through each face.  The total
+                                ! tolerance for SSH is 4 times this value.  The default
+                                ! is 0.5*NK*ANGSTROM, and this should not be set less x
+                                ! than about 10^-15*MAXIMUM_DEPTH.
+ETA_TOLERANCE_AUX = 0.001       !   [m] default = 1.0E-06
+                                ! The tolerance for free-surface height discrepancies
+                                ! between the barotropic solution and the sum of the
+                                ! layer thicknesses when calculating the auxiliary
+                                ! corrected velocities. By default, this is the same as
+                                ! ETA_TOLERANCE, but can be made larger for efficiency.
+
+! === module MOM_CoriolisAdv ===
+CORIOLIS_SCHEME = "SADOURNY75_ENSTRO" ! default = "SADOURNY75_ENERGY"
+                                ! CORIOLIS_SCHEME selects the discretization for the
+                                ! Coriolis terms. Valid values are:
+                                !    SADOURNY75_ENERGY - Sadourny, 1975; energy cons.
+                                !    ARAKAWA_HSU90     - Arakawa & Hsu, 1990
+                                !    SADOURNY75_ENSTRO - Sadourny, 1975; enstrophy cons.
+                                !    ARAKAWA_LAMB81    - Arakawa & Lamb, 1981; En. + Enst.
+                                !    ARAKAWA_LAMB_BLEND - A blend of Arakawa & Lamb with
+                                !                         Arakawa & Hsu and Sadourny energy
+BOUND_CORIOLIS = True           !   [Boolean] default = False
+                                ! If true, the Coriolis terms at u-points are bounded by
+                                ! the four estimates of (f+rv)v from the four neighboring
+                                ! v-points, and similarly at v-points.  This option would
+                                ! have no effect on the SADOURNY Coriolis scheme if it
+                                ! were possible to use centered difference thickness fluxes.
+
+! === module MOM_PressureForce ===
+
+! === module MOM_PressureForce_AFV ===
+MASS_WEIGHT_IN_PRESSURE_GRADIENT = True !   [Boolean] default = False
+                                ! If true, use mass weighting when interpolation T/S for
+                                ! top/bottom integrals in AFV pressure gradient calculation.
+
+! === module MOM_hor_visc ===
+LAPLACIAN = True                !   [Boolean] default = False
+                                ! If true, use a Laplacian horizontal viscosity.
+KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
+                                ! The velocity scale which is multiplied by the grid
+                                ! spacing to calculate the Laplacian viscosity.
+                                ! The final viscosity is the largest of this scaled
+                                ! viscosity, the Smagorinsky and Leith viscosities, and KH.
+AH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
+                                ! The velocity scale which is multiplied by the cube of
+                                ! the grid spacing to calculate the biharmonic viscosity.
+                                ! The final viscosity is the largest of this scaled
+                                ! viscosity, the Smagorinsky and Leith viscosities, and AH.
+SMAGORINSKY_AH = True           !   [Boolean] default = False
+                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
+                                ! viscosity.
+SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
+                                ! The nondimensional biharmonic Smagorinsky constant,
+                                ! typically 0.015 - 0.06.
+
+! === module MOM_vert_friction ===
+U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
+                                ! The absolute path to a file into which the accelerations
+                                ! leading to zonal velocity truncations are written.
+                                ! Undefine this for efficiency if this diagnostic is not
+                                ! needed.
+V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
+                                ! The absolute path to a file into which the accelerations
+                                ! leading to meridional velocity truncations are written.
+                                ! Undefine this for efficiency if this diagnostic is not
+                                ! needed.
+HMIX_FIXED = 0.5                !   [m]
+                                ! The prescribed depth over which the near-surface
+                                ! viscosity and diffusivity are elevated when the bulk
+                                ! mixed layer is not used.
+MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
+                                ! The maximum velocity allowed before the velocity
+                                ! components are truncated.
+
+! === module MOM_PointAccel ===
+
+! === module MOM_barotropic ===
+BOUND_BT_CORRECTION = True      !   [Boolean] default = False
+                                ! If true, the corrective pseudo mass-fluxes into the
+                                ! barotropic solver are limited to values that require
+                                ! less than maxCFL_BT_cont to be accommodated.
+BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
+                                ! If true, step the barotropic velocity first and project
+                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! transport.  The default (false) is to use a predictor
+                                ! continuity step to find the pressure field, and then
+                                ! to do a corrector continuity step using a weighted
+                                ! average of the old and new velocities, with weights
+                                ! of (1-BEBT) and BEBT.
+DYNAMIC_SURFACE_PRESSURE = True !   [Boolean] default = False
+                                ! If true, add a dynamic pressure due to a viscous ice
+                                ! shelf, for instance.
+BEBT = 0.2                      !   [nondim] default = 0.1
+                                ! BEBT determines whether the barotropic time stepping
+                                ! uses the forward-backward time-stepping scheme or a
+                                ! backward Euler scheme. BEBT is valid in the range from
+                                ! 0 (for a forward-backward treatment of nonrotating
+                                ! gravity waves) to 1 (for a backward Euler treatment).
+                                ! In practice, BEBT must be greater than about 0.05.
+DTBT = -0.9                     !   [s or nondim] default = -0.98
+                                ! The barotropic time step, in s. DTBT is only used with
+                                ! the split explicit time stepping. To set the time step
+                                ! automatically based the maximum stable value use 0, or
+                                ! a negative value gives the fraction of the stable value.
+                                ! Setting DTBT to 0 is the same as setting it to -0.98.
+                                ! The value of DTBT that will actually be used is an
+                                ! integer fraction of DT, rounding down.
+BT_USE_OLD_CORIOLIS_BRACKET_BUG = True !   [Boolean] default = False
+                                ! If True, use an order of operations that is not bitwise
+                                ! rotationally symmetric in the meridional Coriolis term of
+                                ! the barotropic solver.
+
+! === module MOM_thickness_diffuse ===
+KHTH_MAX_CFL = 0.1              !   [nondimensional] default = 0.8
+                                ! The maximum value of the local diffusive CFL ratio that
+                                ! is permitted for the thickness diffusivity. 1.0 is the
+                                ! marginally unstable value in a pure layered model, but
+                                ! much smaller numbers (e.g. 0.1) seem to work better for
+                                ! ALE-based models.
+KHTH_USE_FGNV_STREAMFUNCTION = True !   [Boolean] default = False
+                                ! If true, use the streamfunction formulation of
+                                ! Ferrari et al., 2010, which effectively emphasizes
+                                ! graver vertical modes by smoothing in the vertical.
+FGNV_FILTER_SCALE = 0.1         !   [not defined] default = 1.0
+                                ! A coefficient scaling the vertical smoothing term in the
+                                ! Ferrari et al., 2010, streamfunction formulation.
+
+! === module MOM_mixed_layer_restrat ===
+MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
+                                ! If true, a density-gradient dependent re-stratifying
+                                ! flow is imposed in the mixed layer. Can be used in ALE mode
+                                ! without restriction but in layer mode can only be used if
+                                ! BULKMIXEDLAYER is true.
+FOX_KEMPER_ML_RESTRAT_COEF = 1.0 !   [nondim] default = 0.0
+                                ! A nondimensional coefficient that is proportional to
+                                ! the ratio of the deformation radius to the dominant
+                                ! lengthscale of the submesoscale mixed layer
+                                ! instabilities, times the minimum of the ratio of the
+                                ! mesoscale eddy kinetic energy to the large-scale
+                                ! geostrophic kinetic energy or 1 plus the square of the
+                                ! grid spacing over the deformation radius, as detailed
+                                ! by Fox-Kemper et al. (2010)
+MLE_FRONT_LENGTH = 200.0        !   [m] default = 0.0
+                                ! If non-zero, is the frontal-length scale used to calculate the
+                                ! upscaling of buoyancy gradients that is otherwise represented
+                                ! by the parameter FOX_KEMPER_ML_RESTRAT_COEF. If MLE_FRONT_LENGTH is
+                                ! non-zero, it is recommended to set FOX_KEMPER_ML_RESTRAT_COEF=1.0.
+MLE_USE_PBL_MLD = True          !   [Boolean] default = False
+                                ! If true, the MLE parameterization will use the mixed-layer
+                                ! depth provided by the active PBL parameterization. If false,
+                                ! MLE will estimate a MLD based on a density difference with the
+                                ! surface using the parameter MLE_DENSITY_DIFF.
+MLE_MLD_DECAY_TIME = 2.592E+06  !   [s] default = 0.0
+                                ! The time-scale for a running-mean filter applied to the mixed-layer
+                                ! depth used in the MLE restratification parameterization. When
+                                ! the MLD deepens below the current running-mean the running-mean
+                                ! is instantaneously set to the current MLD.
+
+! === module MOM_diag_to_Z ===
+Z_OUTPUT_GRID_FILE = "analysis_vgrid_lev35.v1.nc" ! default = ""
+                                ! The file that specifies the vertical grid for
+                                ! depth-space diagnostics, or blank to disable
+                                ! depth-space output.
+!NK_ZSPACE (from file) = 35     !   [nondim]
+                                ! The number of depth-space levels.  This is determined
+                                ! from the size of the variable zw in the output grid file.
+
+! === module MOM_diabatic_driver ===
+! The following parameters are used for diabatic processes.
+ENERGETICS_SFC_PBL = True       !   [Boolean] default = False
+                                ! If true, use an implied energetics planetary boundary
+                                ! layer scheme to determine the diffusivity and viscosity
+                                ! in the surface boundary layer.
+EPBL_IS_ADDITIVE = False        !   [Boolean] default = True
+                                ! If true, the diffusivity from ePBL is added to all
+                                ! other diffusivities. Otherwise, the larger of kappa-
+                                ! shear and ePBL diffusivities are used.
+
+! === module MOM_KPP ===
+! This is the MOM wrapper to CVmix:KPP
+! See http://code.google.com/p/cvmix/
+
+! === module MOM_diffConvection ===
+! This module implements enhanced diffusivity as a
+! function of static stability, N^2.
+CONVECTION%
+%CONVECTION
+
+! === module MOM_entrain_diffusive ===
+
+! === module MOM_geothermal ===
+GEOTHERMAL_SCALE = 1.0          !   [W m-2 or various] default = 0.0
+                                ! The constant geothermal heat flux, a rescaling
+                                ! factor for the heat flux read from GEOTHERMAL_FILE, or
+                                ! 0 to disable the geothermal heating.
+GEOTHERMAL_FILE = "geothermal_davies2013_v1.nc" ! default = ""
+                                ! The file from which the geothermal heating is to be
+                                ! read, or blank to use a constant heating rate.
+GEOTHERMAL_VARNAME = "geothermal_hf" ! default = "geo_heat"
+                                ! The name of the geothermal heating variable in
+                                ! GEOTHERMAL_FILE.
+
+! === module MOM_set_diffusivity ===
+BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
+                                ! If true, take the maximum of the diffusivity from the
+                                ! BBL mixing and the other diffusivities. Otherwise,
+                                ! diffusiviy from the BBL_mixing is simply added.
+USE_LOTW_BBL_DIFFUSIVITY = True !   [Boolean] default = False
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model
+                                ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
+                                ! the original BBL scheme.
+SIMPLE_TKE_TO_KD = True         !   [Boolean] default = False
+                                ! If true, uses a simple estimate of Kd/TKE that will
+                                ! work for arbitrary vertical coordinates. If false,
+                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+HENYEY_IGW_BACKGROUND = True    !   [Boolean] default = False
+                                ! If true, use a latitude-dependent scaling for the near
+                                ! surface background diffusivity, as described in
+                                ! Harrison & Hallberg, JPO 2008.
+N2_FLOOR_IOMEGA2 = 0.0          !   [nondim] default = 1.0
+                                ! The floor applied to N2(k) scaled by Omega^2:
+                                !   If =0., N2(k) is simply positive definite.
+                                !   If =1., N2(k) > Omega^2 everywhere.
+KD = 1.5E-05                    !   [m2 s-1]
+                                ! The background diapycnal diffusivity of density in the
+                                ! interior. Zero or the molecular value, ~1e-7 m2 s-1,
+                                ! may be used.
+KD_MIN = 2.0E-06                !   [m2 s-1] default = 1.5E-07
+                                ! The minimum diapycnal diffusivity.
+KD_MAX = 0.1                    !   [m2 s-1] default = -1.0
+                                ! The maximum permitted increment for the diapycnal
+                                ! diffusivity from TKE-based parameterizations, or a
+                                ! negative value for no limit.
+INT_TIDE_DISSIPATION = True     !   [Boolean] default = False
+                                ! If true, use an internal tidal dissipation scheme to
+                                ! drive diapycnal mixing, along the lines of St. Laurent
+                                ! et al. (2002) and Simmons et al. (2004).
+INT_TIDE_PROFILE = "POLZIN_09"  ! default = "STLAURENT_02"
+                                ! INT_TIDE_PROFILE selects the vertical profile of energy
+                                ! dissipation with INT_TIDE_DISSIPATION. Valid values are:
+                                !    STLAURENT_02 - Use the St. Laurent et al exponential
+                                !                   decay profile.
+                                !    POLZIN_09 - Use the Polzin WKB-streched algebraic
+                                !                   decay profile.
+INT_TIDE_DECAY_SCALE = 300.3003003003003 !   [m] default = 0.0
+                                ! The decay scale away from the bottom for tidal TKE with
+                                ! the new coding when INT_TIDE_DISSIPATION is used.
+KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
+                                ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
+                                ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
+KAPPA_H2_FACTOR = 0.84          !   [nondim] default = 1.0
+                                ! A scaling factor for the roughness amplitude with nINT_TIDE_DISSIPATION.
+TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
+                                ! The maximum internal tide energy source availble to mix
+                                ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
+READ_TIDEAMP = True             !   [Boolean] default = False
+                                ! If true, read a file (given by TIDEAMP_FILE) containing
+                                ! the tidal amplitude with INT_TIDE_DISSIPATION.
+TIDEAMP_FILE = "tidal_amplitude.v2015.12.03.nc" ! default = "tideamp.nc"
+                                ! The path to the file containing the spatially varying
+                                ! tidal amplitudes with INT_TIDE_DISSIPATION.
+H2_FILE = "ocean_topog.nc"      !
+                                ! The path to the file containing the sub-grid-scale
+                                ! topographic roughness amplitude with INT_TIDE_DISSIPATION.
+
+! === module MOM_kappa_shear ===
+! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
+USE_JACKSON_PARAM = True        !   [Boolean] default = False
+                                ! If true, use the Jackson-Hallberg-Legg (JPO 2008)
+                                ! shear mixing parameterization.
+MAX_RINO_IT = 25                !   [nondim] default = 50
+                                ! The maximum number of iterations that may be used to
+                                ! estimate the Richardson number driven mixing.
+
+! === module MOM_CVMix_shear ===
+! Parameterization of shear-driven turbulence via CVMix (various options)
+
+! === module MOM_diabatic_aux ===
+! The following parameters are used for auxiliary diabatic processes.
+PRESSURE_DEPENDENT_FRAZIL = True !   [Boolean] default = False
+                                ! If true, use a pressure dependent freezing temperature
+                                ! when making frazil. The default is false, which will be
+                                ! faster but is inappropriate with ice-shelf cavities.
+USE_RIVER_HEAT_CONTENT = True   !   [Boolean] default = False
+                                ! If true, use the fluxes%runoff_Hflx field to set the
+                                ! heat carried by runoff, instead of using SST*CP*liq_runoff.
+USE_CALVING_HEAT_CONTENT = True !   [Boolean] default = False
+                                ! If true, use the fluxes%calving_Hflx field to set the
+                                ! heat carried by runoff, instead of using SST*CP*froz_runoff.
+
+! === module MOM_energetic_PBL ===
+MSTAR_MODE = 2                  !   [units=nondim] default = 0
+                                ! An integer switch for how to compute MSTAR.
+                                !     0 for constant MSTAR
+                                !     1 for MSTAR w/ MLD in stabilizing limit
+                                !     2 for MSTAR w/ L_E/L_O in stabilizing limit.
+MSTAR = 0.0                     !   [units=nondim] default = 1.2
+                                ! The ratio of the friction velocity cubed to the TKE
+                                ! input to the mixed layer.
+MIX_LEN_EXPONENT = 1.0          !   [units=nondim] default = 2.0
+                                ! The exponent applied to the ratio of the distance to the MLD
+                                ! and the MLD depth which determines the shape of the mixing length.
+MSTAR_CAP = 10.0                !   [units=nondim] default = -1.0
+                                ! Maximum value of mstar allowed in model if non-negative
+                                ! (used if MSTAR_MODE>0).
+MSTAR_CONV_ADJ = 0.667          !   [units=nondim] default = 0.0
+                                ! Factor used for reducing mstar during convection
+                                !  due to reduction of stable density gradient.
+MSTAR2_COEF1 = 0.29             !   [units=nondim] default = 0.3
+                                ! Coefficient in computing mstar when rotation and
+                                !  stabilizing effects are both important (used if MSTAR_MODE=2)
+MSTAR2_COEF2 = 0.152            !   [units=nondim] default = 0.085
+                                ! Coefficient in computing mstar when only rotation limits
+                                !  the total mixing. (used only if MSTAR_MODE=2)
+NSTAR = 0.06                    !   [nondim] default = 0.2
+                                ! The portion of the buoyant potential energy imparted by
+                                ! surface fluxes that is available to drive entrainment
+                                ! at the base of mixed layer when that energy is positive.
+TKE_DECAY = 0.01                !   [nondim] default = 2.5
+                                ! TKE_DECAY relates the vertical rate of decay of the
+                                ! TKE available for mechanical entrainment to the natural
+                                ! Ekman depth.
+ML_OMEGA_FRAC = 0.001           !   [nondim] default = 0.0
+                                ! When setting the decay scale for turbulence, use this
+                                ! fraction of the absolute rotation rate blended with the
+                                ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
+USE_MLD_ITERATION = True        !   [Boolean] default = False
+                                ! A logical that specifies whether or not to use the
+                                ! distance to the bottom of the actively turblent boundary
+                                ! layer to help set the EPBL length scale.
+ORIG_MLD_ITERATION = False      !   [Boolean] default = True
+                                ! A logical that specifies whether or not to use the
+                                ! old method for determining MLD depth in iteration, which
+                                ! is limited to resolution.
+EPBL_TRANSITION_SCALE = 0.01    !   [nondim] default = 0.1
+                                ! A scale for the mixing length in the transition layer
+                                ! at the edge of the boundary layer as a fraction of the
+                                ! boundary layer thickness.  The default is 0.1.
+USE_LA_LI2016 = True            !   [nondim] default = False
+                                ! A logical to use the Li et al. 2016 (submitted) formula to
+                                !  determine the Langmuir number.
+LT_ENHANCE = 3                  !   [nondim] default = 0
+                                ! Integer for Langmuir number mode.
+                                !  *Requires USE_LA_LI2016 to be set to True.
+                                ! Options: 0 - No Langmuir
+                                !          1 - Van Roekel et al. 2014/Li et al., 2016
+                                !          2 - Multiplied w/ adjusted La.
+                                !          3 - Added w/ adjusted La.
+LT_ENHANCE_COEF = 0.044         !   [nondim] default = 0.447
+                                ! Coefficient for Langmuir enhancement if LT_ENHANCE > 1
+LT_ENHANCE_EXP = -1.5           !   [nondim] default = -1.33
+                                ! Exponent for Langmuir enhancement if LT_ENHANCE > 1
+LT_MOD_LAC1 = 0.0               !   [nondim] default = -0.87
+                                ! Coefficient for modification of Langmuir number due to
+                                !  MLD approaching Ekman depth if LT_ENHANCE=2.
+LT_MOD_LAC4 = 0.0               !   [nondim] default = 0.95
+                                ! Coefficient for modification of Langmuir number due to
+                                !  ratio of Ekman to stable Obukhov depth if LT_ENHANCE=2.
+LT_MOD_LAC5 = 0.22              !   [nondim] default = 0.95
+                                ! Coefficient for modification of Langmuir number due to
+                                !  ratio of Ekman to unstable Obukhov depth if LT_ENHANCE=2.
+EPBL_USTAR_MIN = 1.45842E-18    !   [m s-1]
+                                ! The (tiny) minimum friction velocity used within the
+                                ! ePBL code, derived from OMEGA and ANGSTROM.
+
+! === module MOM_regularize_layers ===
+
+! === module MOM_opacity ===
+VAR_PEN_SW = True               !   [Boolean] default = False
+                                ! If true, use one of the CHL_A schemes specified by
+                                ! OPACITY_SCHEME to determine the e-folding depth of
+                                ! incoming short wave radiation.
+CHL_FILE = "seawifs_1998-2006_smoothed_2X.v2015.12.03.nc" !
+                                ! CHL_FILE is the file containing chl_a concentrations in
+                                ! the variable CHL_A. It is used when VAR_PEN_SW and
+                                ! CHL_FROM_FILE are true.
+PEN_SW_NBANDS = 3               ! default = 1
+                                ! The number of bands of penetrating shortwave radiation.
+
+! === module MOM_tracer_advect ===
+TRACER_ADVECTION_SCHEME = "PPM:H3" ! default = "PLM"
+                                ! The horizontal transport scheme for tracers:
+                                !   PLM    - Piecewise Linear Method
+                                !   PPM:H3 - Piecewise Parabolic Method (Huyhn 3rd order)
+                                !   PPM    - Piecewise Parabolic Method (Colella-Woodward)
+
+! === module MOM_tracer_hor_diff ===
+KHTR = 200.0                    !   [m2 s-1] default = 0.0
+                                ! The background along-isopycnal tracer diffusivity.
+CHECK_DIFFUSIVE_CFL = True      !   [Boolean] default = False
+                                ! If true, use enough iterations the diffusion to ensure
+                                ! that the diffusive equivalent of the CFL limit is not
+                                ! violated.  If false, always use 1 iteration.
+
+! === module MOM_neutral_diffusion ===
+! This module implements neutral diffusion of tracers
+USE_NEUTRAL_DIFFUSION = True    !   [Boolean] default = False
+                                ! If true, enables the neutral diffusion module.
+
+! === module ocean_model_init ===
+ENERGYSAVEDAYS = 0.5            !   [days] default = 1.0
+                                ! The interval in units of TIMEUNIT between saves of the
+                                ! energies of the run and other globally summed diagnostics.
+RESTORE_SALINITY = True         !   [Boolean] default = False
+                                ! If true, the coupled driver will add a globally-balanced
+                                ! fresh-water flux that drives sea-surface salinity
+                                ! toward specified values.
+
+! === module MOM_surface_forcing ===
+MAX_P_SURF = 0.0                !   [Pa] default = -1.0
+                                ! The maximum surface pressure that can be exerted by the
+                                ! atmosphere and floating sea-ice or ice shelves. This is
+                                ! needed because the FMS coupling structure does not
+                                ! limit the water that can be frozen out of the ocean and
+                                ! the ice-ocean heat fluxes are treated explicitly.  No
+                                ! limit is applied if a negative value is used.
+ADJUST_NET_FRESH_WATER_TO_ZERO = True !   [Boolean] default = False
+                                ! If true, adjusts the net fresh-water forcing seen
+                                ! by the ocean (including restoring) to zero.
+FLUXCONST = 0.1667              !   [m day-1]
+                                ! The constant that relates the restoring surface fluxes
+                                ! to the relative surface anomalies (akin to a piston
+                                ! velocity).  Note the non-MKS units.
+SALT_RESTORE_FILE = "salt_restore.v2015.12.03.nc" ! default = "salt_restore.nc"
+                                ! A file in which to find the surface salinity to use for restoring.
+SRESTORE_AS_SFLUX = True        !   [Boolean] default = False
+                                ! If true, the restoring of salinity is applied as a salt
+                                ! flux instead of as a freshwater flux.
+MAX_DELTA_SRESTORE = 5.0        !   [PSU or g kg-1] default = 999.0
+                                ! The maximum salinity difference used in restoring terms.
+CD_TIDES = 0.0018               !   [nondim] default = 1.0E-04
+                                ! The drag coefficient that applies to the tides.
+GUST_CONST = 0.0                !   [Pa] default = 0.02
+                                ! The background gustiness in the winds.
+USE_RIGID_SEA_ICE = True        !   [Boolean] default = False
+                                ! If true, sea-ice is rigid enough to exert a
+                                ! nonhydrostatic pressure that resist vertical motion.
+SEA_ICE_RIGID_MASS = 100.0      !   [kg m-2] default = 1000.0
+                                ! The mass of sea-ice per unit area at which the sea-ice
+                                ! starts to exhibit rigidity
+
+! === module MOM_restart ===
+
+! === module MOM_sum_output ===
+MAXTRUNC = 100000               !   [truncations save_interval-1] default = 0
+                                ! The run will be stopped, and the day set to a very
+                                ! large value if the velocity is truncated more than
+                                ! MAXTRUNC times between energy saves.  Set MAXTRUNC to 0
+                                ! to stop if there is any truncation of velocities.
+
+! === module MOM_file_parser ===

--- a/ice_ocean_SIS2/Baltic_OM4_05/MOM_saltrestore
+++ b/ice_ocean_SIS2/Baltic_OM4_05/MOM_saltrestore
@@ -1,0 +1,1 @@
+../OM4_05/MOM_saltrestore

--- a/ice_ocean_SIS2/Baltic_OM4_05/SIS_input
+++ b/ice_ocean_SIS2/Baltic_OM4_05/SIS_input
@@ -1,0 +1,1 @@
+../OM4_05/SIS_input

--- a/ice_ocean_SIS2/Baltic_OM4_05/SIS_override
+++ b/ice_ocean_SIS2/Baltic_OM4_05/SIS_override
@@ -1,0 +1,7 @@
+! Blank file in which we can put "overrides" for parameters
+ADD_DIURNAL_SW = True ! This must ONLY be used in the ice-ocean mode, NOT fully coupled mode.
+#override NIGLOBAL = 49
+#override NJGLOBAL = 53
+#override REENTRANT_X = False
+#override TRIPOLAR_N = False
+#override DO_ICEBERGS = False

--- a/ice_ocean_SIS2/Baltic_OM4_05/SIS_parameter_doc.all
+++ b/ice_ocean_SIS2/Baltic_OM4_05/SIS_parameter_doc.all
@@ -1,0 +1,514 @@
+! This file was written by the model and records all non-layout or debugging parameters used at run-time.
+
+! === module ice_model ===
+SPECIFIED_ICE = False           !   [Boolean] default = False
+                                ! If true, the ice is specified and there is no dynamics.
+CGRID_ICE_DYNAMICS = True       !   [Boolean] default = False
+                                ! If true, use a C-grid discretization of the sea-ice
+                                ! dynamics; if false use a B-grid discretization.
+USE_SLAB_ICE = False            !   [Boolean] default = False
+                                ! If true, use the very old slab-style ice.
+SINGLE_ICE_STATE_TYPE = True    !   [Boolean] default = True
+                                ! If true, the fast and slow portions of the ice use a
+                                ! single common ice_state_type.  Otherwise they point to
+                                ! different ice_state_types that need to be explicitly
+                                ! copied back and forth.
+EULERIAN_TSURF = True           !   [Boolean] default = True
+                                ! If true, use previous calculations of the ice-top surface
+                                ! skin temperature for tsurf at the start of atmospheric
+                                ! time stepping, including interpolating between tsurf
+                                ! values from other categories in the same location.
+ICE_OCEAN_STRESS_STAGGER = "C"  ! default = "C"
+                                ! A case-insensitive character string to indicate the
+                                ! staggering of the stress field on the ocean that is
+                                ! returned to the coupler.  Valid values include
+                                ! 'A', 'B', or 'C', with a default that follows the
+                                ! value of CGRID_ICE_DYNAMICS.
+RHO_OCEAN = 1030.0              !   [kg m-3] default = 1030.0
+                                ! The nominal density of sea water as used by SIS.
+RHO_ICE = 905.0                 !   [kg m-3] default = 905.0
+                                ! The nominal density of sea ice as used by SIS.
+RHO_SNOW = 330.0                !   [kg m-3] default = 330.0
+                                ! The nominal density of snow as used by SIS.
+G_EARTH = 9.8                   !   [m s-2] default = 9.8
+                                ! The gravitational acceleration of the Earth.
+MOMENTUM_ROUGH_ICE = 1.0E-04    !   [m] default = 1.0E-04
+                                ! The default momentum roughness length scale for the ocean.
+HEAT_ROUGH_ICE = 1.0E-04        !   [m] default = 1.0E-04
+                                ! The default roughness length scale for the turbulent
+                                ! transfer of heat into the ocean.
+CONSTANT_COSZEN_IC = 0.0        !   [nondim] default = -1.0
+                                ! A constant value to use to initialize the cosine of
+                                ! the solar zenith angle for the first radiation step,
+                                ! or a negative number to use the current time and astronomy.
+DT_RADIATION = 7200.0           !   [s] default = 7200.0
+                                ! The time step with which the shortwave radiation and
+                                ! fields like albedos are updated.  Currently this is only
+                                ! used to initialize albedos when there is no restart file.
+ICE_KMELT = 240.0               !   [W m-2 K-1] default = 240.0
+                                ! A constant giving the proportionality of the ocean/ice
+                                ! base heat flux to the tempature difference, given by
+                                ! the product of the heat capacity per unit volume of sea
+                                ! water times a molecular diffusive piston velocity.
+SNOW_CONDUCT = 0.31             !   [W m-1 K-1] default = 0.31
+                                ! The conductivity of heat in snow.
+COLUMN_CHECK = False            !   [Boolean] default = False
+                                ! If true, add code to allow debugging of conservation
+                                ! column-by-column.  This does not change answers, but
+                                ! can increase model run time.
+IMBALANCE_TOLERANCE = 1.0E-09   !   [nondim] default = 1.0E-09
+                                ! The tolerance for imbalances to be flagged by COLUMN_CHECK.
+ICE_BOUNDS_CHECK = True         !   [Boolean] default = True
+                                ! If true, periodically check the values of ice and snow
+                                ! temperatures and thicknesses to ensure that they are
+                                ! sensible, and issue warnings if they are not.  This
+                                ! does not change answers, but can increase model run time.
+DEBUG = False                   !   [Boolean] default = False
+                                ! If true, write out verbose debugging data.
+DEBUG_SLOW_ICE = False          !   [Boolean] default = False
+                                ! If true, write out verbose debugging data on the slow ice PEs.
+DEBUG_FAST_ICE = False          !   [Boolean] default = False
+                                ! If true, write out verbose debugging data on the fast ice PEs.
+FIRST_DIRECTION = 0             ! default = 0
+                                ! An integer that indicates which direction goes first
+                                ! in parts of the code that use directionally split
+                                ! updates, with even numbers (or 0) used for x- first
+                                ! and odd numbers used for y-first.
+ICE_SEES_ATMOS_WINDS = True     !   [Boolean] default = True
+                                ! If true, the sea ice is being given wind stresses with
+                                ! the atmospheric sign convention, and need to have their
+                                ! sign changed.
+APPLY_SLP_TO_OCEAN = False      !   [Boolean] default = False
+                                ! If true, apply the atmospheric sea level pressure to
+                                ! the ocean.
+MIN_H_FOR_TEMP_CALC = 0.0       !   [m] default = 0.0
+                                ! The minimum ice thickness at which to do temperature
+                                ! calculations.
+DO_ICEBERGS = False             !   [Boolean] default = False
+                                ! If true, call the iceberg module.
+ADD_DIURNAL_SW = True           !   [Boolean] default = False
+                                ! If true, add a synthetic diurnal cycle to the shortwave
+                                ! radiation.
+DO_SUN_ANGLE_FOR_ALB = False    !   [Boolean] default = False
+                                ! If true, find the sun angle for calculating the ocean
+                                ! albedo within the sea ice model.
+DO_RIDGING = False              !   [Boolean] default = False
+                                ! If true, call the ridging routines.
+RESTARTFILE = "ice_model.res.nc" ! default = "ice_model.res.nc"
+                                ! The name of the restart file.
+FAST_ICE_RESTARTFILE = "ice_model.res.nc" ! default = "ice_model.res.nc"
+                                ! The name of the restart file for those elements of the
+                                ! the sea ice that are handled by the fast ice PEs.
+WRITE_GEOM = 1                  ! default = 1
+                                ! If =0, never write the geometry and vertical grid files.
+                                ! If =1, write the geometry and vertical grid files only for
+                                ! a new simulation. If =2, always write the geometry and
+                                ! vertical grid files. Other values are invalid.
+INTERPOLATE_FLUXES = True       !   [Boolean] default = True
+                                ! If true, interpolate a linearized version of the fast
+                                ! fluxes into arealess categories.
+REDO_FAST_ICE_UPDATE = False    !   [Boolean] default = False
+                                ! If true, recalculate the thermal updates from the fast
+                                ! dynamics on the slowly evolving ice state, rather than
+                                ! copying over the slow ice state to the fast ice state.
+DEBUG_CHKSUMS = False           !   [Boolean] default = False
+                                ! If true, checksums are performed on arrays in the
+                                ! various vec_chksum routines.
+DEBUG_REDUNDANT = False         !   [Boolean] default = False
+                                ! If true, debug redundant data points during calls to
+                                ! the various vec_chksum routines.
+NCAT_ICE = 5                    !   [nondim] default = 5
+                                ! The number of sea ice thickness categories.
+NK_ICE = 4                      !   [nondim] default = 4
+                                ! The number of layers within the sea ice.
+NK_SNOW = 1                     !   [nondim] default = 1
+                                ! The number of layers within the snow atop the sea ice.
+H_TO_KG_M2 = 1.0                !   [kg m-2 H-1] default = 1.0
+                                ! A constant that translates thicknesses from the model's
+                                ! internal units of thickness to kg m-2.
+MIN_OCEAN_PARTSIZE = 0.0        !   [nondim] default = 0.0
+                                ! The minimum value for the fractional open-ocean area.
+                                ! This can be 0, but for some purposes it may be useful
+                                ! to set this to a miniscule value (like 1e-40) that will
+                                ! be lost to roundoff during any sums so that the open
+                                ! ocean fluxes can be used in with new categories.
+
+! === module MOM_domains ===
+REENTRANT_X = False             !   [Boolean] default = True
+                                ! If true, the domain is zonally reentrant.
+REENTRANT_Y = False             !   [Boolean] default = False
+                                ! If true, the domain is meridionally reentrant.
+TRIPOLAR_N = False              !   [Boolean] default = False
+                                ! Use tripolar connectivity at the northern edge of the
+                                ! domain.  With TRIPOLAR_N, NIGLOBAL must be even.
+NIGLOBAL = 49                   !
+                                ! The total number of thickness grid points in the
+                                ! x-direction in the physical domain. With STATIC_MEMORY_
+                                ! this is set in SIS2_memory.h at compile time.
+NJGLOBAL = 53                   !
+                                ! The total number of thickness grid points in the
+                                ! y-direction in the physical domain. With STATIC_MEMORY_
+                                ! this is set in SIS2_memory.h at compile time.
+
+! === module MOM_hor_index ===
+! Sets the horizontal array index types.
+
+! === module SIS_initialize_fixed ===
+INPUTDIR = "INPUT"              ! default = "."
+                                ! The directory in which input files are found.
+
+! === module MOM_grid_init ===
+GRID_CONFIG = "mosaic"          !
+                                ! A character string that determines the method for
+                                ! defining the horizontal grid.  Current options are:
+                                !     mosaic - read the grid from a mosaic (supergrid)
+                                !              file set by GRID_FILE.
+                                !     cartesian - use a (flat) Cartesian grid.
+                                !     spherical - use a simple spherical grid.
+                                !     mercator - use a Mercator spherical grid.
+GRID_FILE = "ocean_hgrid.nc"    !
+                                ! Name of the file from which to read horizontal grid data.
+TOPO_CONFIG = "file"            ! default = "file"
+                                ! This specifies how bathymetry is specified:
+                                !     file - read bathymetric information from the file
+                                !       specified by (TOPO_FILE).
+                                !     flat - flat bottom set to MAXIMUM_DEPTH.
+                                !     bowl - an analytically specified bowl-shaped basin
+                                !       ranging between MAXIMUM_DEPTH and MINIMUM_DEPTH.
+                                !     spoon - a similar shape to 'bowl', but with an vertical
+                                !       wall at the southern face.
+                                !     halfpipe - a zonally uniform channel with a half-sine
+                                !       profile in the meridional direction.
+TOPO_FILE = "topog.nc"          ! default = "topog.nc"
+                                ! The file from which the bathymetry is read.
+TOPO_VARNAME = "depth"          ! default = "depth"
+                                ! The name of the bathymetry variable in TOPO_FILE.
+TOPO_EDITS_FILE = ""            ! default = ""
+                                ! The file from which to read a list of i,j,z topography overrides.
+!MAXIMUM_DEPTH = 588.986572265625 !   [m]
+                                ! The (diagnosed) maximum depth of the ocean.
+MINIMUM_DEPTH = 0.0             !   [m] default = 0.0
+                                ! If MASKING_DEPTH is unspecified, then anything shallower than
+                                ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
+                                ! If MASKING_DEPTH is specified, then all depths shallower than
+                                ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
+                                ! The depth below which to mask points as land points, for which all
+                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
+CHANNEL_CONFIG = "none"         ! default = "none"
+                                ! A parameter that determines which set of channels are
+                                ! restricted to specific  widths.  Options are:
+                                !     none - All channels have the grid width.
+                                !     global_1deg - Sets 16 specific channels appropriate
+                                !       for a 1-degree model, as used in CM2G.
+                                !     list - Read the channel locations and widths from a
+                                !       text file, like MOM_channel_list in the MOM_SIS
+                                !       test case.
+                                !     file - Read open face widths everywhere from a
+                                !       NetCDF file on the model grid.
+ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
+                                ! This specifies how the Coriolis parameter is specified:
+                                !     2omegasinlat - Use twice the planetary rotation rate
+                                !       times the sine of latitude.
+                                !     betaplane - Use a beta-plane or f-plane.
+                                !     USER - call a user modified routine.
+OMEGA = 7.292E-05               !   [s-1] default = 7.2921E-05
+                                ! The rotation rate of the earth.
+PARALLEL_RESTARTFILES = False   !   [Boolean] default = False
+                                ! If true, each processor writes its own restart file,
+                                ! otherwise a single restart file is generated
+
+! === module hor_grid ===
+! Parameters providing information about the lateral grid.
+
+! === module MOM_hor_index ===
+! Sets the horizontal array index types.
+SIS_AVAILABLE_DIAGS_FILE = "SIS.available_diags" ! default = "SIS.available_diags"
+                                ! A file into which to write a list of all available
+                                ! sea ice diagnostics that can be included in a diag_table.
+
+! === module SIS2_ice_thm (thermo) ===
+! This sub-module calculates ice thermodynamic quantities.
+LATENT_HEAT_FUSION = 3.34E+05   !   [J kg-1] default = 3.34E+05
+                                ! The latent heat of fusion as used by SIS.
+LATENT_HEAT_VAPOR = 2.5E+06     !   [J kg-1] default = 2.5E+06
+                                ! The latent heat of vaporization of water at 0C as used by SIS.
+CP_ICE = 2100.0                 !   [J kg-1 K-1] default = 2100.0
+                                ! The heat capacity of fresh ice, approximated as a
+                                ! constant.
+CP_SEAWATER = 4200.0            !   [J kg-1 K-1] default = 4200.0
+                                ! The heat capacity of sea water, approximated as a
+                                ! constant.
+CP_BRINE = 2100.0               !   [J kg-1 K-1] default = 4200.0
+                                ! The heat capacity of water in brine pockets within the
+                                ! sea-ice, approximated as a constant.  CP_BRINE and
+                                ! CP_SEAWATER should be equal, but for computational
+                                ! convenience CP_BRINE can be set equal to CP_ICE.
+DTFREEZE_DS = -0.054            !   [deg C PSU-1] default = -0.054
+                                ! The derivative of the freezing temperature with salinity.
+ENTHALPY_LIQUID_0 = 0.0         !   [J kg-1] default = 0.0
+                                ! The enthalpy of liquid fresh water at 0 C.  The solutions
+                                ! should be physically consistent when this is adjusted,
+                                ! because only the relative value is of physical meaning,
+                                ! but roundoff errors can change the solution.
+ENTHALPY_UNITS = 1.0            !   [J kg-1] default = 1.0
+                                ! A constant that rescales enthalpy from J/kg to a
+                                ! different scale in its internal representation.  Changing
+                                ! this by a power of 2 is useful for debugging, as answers
+                                ! should not change.  A negative values is taken as an inverse.
+SUBLIMATION_BUG = False         !   [Boolean] default = False
+                                ! If true use an older calculation that omits the latent
+                                ! heat of fusion from the latent heat of sublimation.
+                                ! This variable should be obsoleted as soon as possible.
+
+! === module SIS_tracer_registry ===
+
+! === module SIS_tracer_flow_control ===
+USE_ICE_AGE_TRACER = False      !   [Boolean] default = False
+                                ! If true, use the concentration based age tracer package.
+SIS_FAST_AVAILABLE_DIAGS_FILE = "SIS_fast.available_diags" ! default = "SIS_fast.available_diags"
+                                ! A file into which to write a list of all available
+                                ! sea ice diagnostics that can be included in a diag_table.
+
+! === module SIS_slow_thermo ===
+! This module calculates the slow evolution of the ice mass, heat, and salt budgets.
+ICE_BULK_SALINITY = 0.0         !   [g/kg] default = 4.0
+                                ! The fixed bulk salinity of sea ice.
+ICE_RELATIVE_SALINITY = 0.1     !   [nondim] default = 0.0
+                                ! The initial salinity of sea ice as a fraction of the
+                                ! salinity of the seawater from which it formed.
+SIS2_FILLING_FRAZIL = False     !   [Boolean] default = True
+                                ! If true, apply frazil to fill as many categories as
+                                ! possible to fill in a uniform (minimum) amount of ice
+                                ! in all the thinnest categories. Otherwise the frazil is
+                                ! always assigned to a single category.
+APPLY_ICE_LIMIT = False         !   [Boolean] default = False
+                                ! If true, restore the sea ice state toward climatology.
+DO_ICE_RESTORE = False          !   [Boolean] default = False
+                                ! If true, restore the sea ice state toward climatology.
+NUDGE_SEA_ICE = False           !   [Boolean] default = False
+                                ! If true, constrain the sea ice concentrations using observations.
+
+! === module SIS2_ice_thm (updates) ===
+! This sub-module does updates of the sea-ice due to thermodynamic changes.
+SNOW_CONDUCTIVITY = 0.31        !   [W m-1 K-1] default = 0.31
+                                ! The conductivity of heat in snow.
+ICE_CONDUCTIVITY = 2.03         !   [W m-1 K-1] default = 2.03
+                                ! The conductivity of heat in ice.
+DO_POND = False                 !   [Boolean] default = False
+                                ! If true, calculate melt ponds and use them for
+                                ! shortwave radiation calculation.
+TDRAIN = -0.8                   !   [not defined] default = -0.8
+                                ! Melt ponds drain to sea level when ice average temp.
+                                ! exceeds TDRAIN (stand-in for mushy layer thermo)
+R_MIN_POND = 0.15               !   [not defined] default = 0.15
+                                ! Minimum retention rate of surface water sources in melt pond
+                                ! (retention scales linearly with ice cover)
+R_MAX_POND = 0.9                !   [not defined] default = 0.9
+                                ! Maximum retention rate of surface water sources in melt pond
+                                ! (retention scales linearly with ice cover)
+MIN_POND_FRAC = 0.2             !   [not defined] default = 0.2
+                                ! Minimum melt pond cover (by ponds at sea level)
+                                ! pond drains to this when ice is porous.
+MAX_POND_FRAC = 0.5             !   [not defined] default = 0.5
+                                ! Maximum melt pond cover - associated with pond volume
+                                ! that suppresses ice top to waterline
+ICE_TEMP_RANGE_ESTIMATE = 40.0  !   [degC] default = 40.0
+                                ! An estimate of the range of snow and ice temperatures
+                                ! that is used to evaluate whether an explicit diffusive
+                                ! form of the heat fluxes or an inversion based on the
+                                ! layer heat budget is more likely to be more accurate.
+                                ! Setting this to 0 causes the explicit diffusive form.
+                                ! to always be used.
+
+! === module SIS_dyn_trans ===
+! This module updates the ice momentum and does ice transport.
+DT_ICE_DYNAMICS = 1200.0        !   [seconds] default = -1.0
+                                ! The time step used for the slow ice dynamics, including
+                                ! stepping the continuity equation and interactions
+                                ! between the ice mass field and velocities.  If 0 or
+                                ! negative the coupling time step will be used.
+ICEBERG_WINDSTRESS_BUG = True   !   [Boolean] default = False
+                                ! If true, use older code that applied an old ice-ocean
+                                ! stress to the icebergs in place of the current air-ocean
+                                ! stress.  This option is here for backward compatibility,
+                                ! but should be avoided.
+TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
+                                ! The time unit for ICE_STATS_INTERVAL.
+ICE_STATS_INTERVAL = 0.25       !   [days] default = 1.0
+                                ! The interval in units of TIMEUNIT between writes of the
+                                ! globally summed ice statistics and conservation checks.
+VERBOSE = False                 !   [Boolean] default = False
+                                ! If true, write out verbose diagnostics.
+DT_RHEOLOGY = 50.0              !   [seconds] default = -1.0
+                                ! The sub-cycling time step for iterating the rheology
+                                ! and ice momentum equations. If DT_RHEOLOGY is negative,
+                                ! the time step is set via NSTEPS_DYN.
+ICE_TDAMP_ELASTIC = -0.2        !   [s or nondim] default = -0.2
+                                ! The damping timescale associated with the elastic terms
+                                ! in the sea-ice dynamics equations (if positive) or the
+                                ! fraction of DT_ICE_DYNAMICS (if negative).
+WEAK_LOW_SHEAR_ICE = False      !   [Boolean] default = False
+                                ! If true, the divergent stresses go toward 0 in the C-grid
+                                ! dynamics when the shear magnitudes are very weak.
+                                ! Otherwise they go to -P_ice.  This setting is temporary.
+PROJECT_ICE_DRAG_VEL = True     !   [Boolean] default = True
+                                ! If true, project forward the ice velocity used in the
+                                ! drag calculation to avoid an instability that can occur
+                                ! when an finite stress is applied to thin ice moving with
+                                ! the velocity of the ocean.
+ICE_YIELD_ELLIPTICITY = 2.0     !   [Nondim] default = 2.0
+                                ! The ellipticity coefficient for the plastic yield curve
+                                ! in the sea-ice rheology.  For an infinite ellipticity
+                                ! (i.e., a cavitating fluid rheology), use 0.
+ICE_STRENGTH_PSTAR = 2.75E+04   !   [Pa] default = 2.75E+04
+                                ! A constant in the expression for the ice strength,
+                                ! P* in Hunke & Dukowicz 1997.
+ICE_STRENGTH_CSTAR = 20.0       !   [nondim] default = 20.0
+                                ! A constant in the exponent of the expression for the
+                                ! ice strength, c* in Hunke & Dukowicz 1997.
+ICE_CDRAG_WATER = 0.00324       !   [nondim] default = 0.00324
+                                ! The drag coefficient between the sea ice and water.
+MIN_OCN_INTERTIAL_H = 2.0       !   [m] default = 0.0
+                                ! A minimum ocean thickness used to limit the viscous coupling rate
+                                ! implied for the ocean by the ice-ocean stress. Only used if positive.
+ICE_DEL_SH_MIN_SCALE = 2.0      !   [nondim] default = 2.0
+                                ! A scaling factor for the lower bound on the shear rates
+                                ! used in the denominator of the stress calculation. This
+                                ! probably needs to be greater than 1.
+PROJECT_ICE_CONCENTRATION = True !   [Boolean] default = True
+                                ! If true, project the evolution of the ice concentration
+                                ! due to the convergence or divergence of the ice flow.
+CFL_TRUNCATE = 0.5              !   [nondim] default = 0.5
+                                ! The value of the CFL number that will cause ice velocity
+                                ! components to be truncated; instability can occur past 0.5.
+CFL_TRUNC_DYN_ITS = False       !   [Boolean] default = False
+                                ! If true, check the CFL number for every iteration of the
+                                ! rheology solver; otherwise only the final velocities that
+                                ! are used for transport are checked.
+DEBUG_EVP_SUBSTEPS = False      !   [Boolean] default = False
+                                ! If true, write out verbose debugging data for each of the
+                                ! steps within the EVP solver.
+U_TRUNC_FILE = ""               ! default = ""
+                                ! The absolute path to the file where the accelerations
+                                ! leading to zonal velocity truncations are written.
+                                ! Leave this empty for efficiency if this diagnostic is
+                                ! not needed.
+V_TRUNC_FILE = ""               ! default = ""
+                                ! The absolute path to the file where the accelerations
+                                ! leading to meridional velocity truncations are written.
+                                ! Leave this empty for efficiency if this diagnostic is
+                                ! not needed.
+MAX_TRUNC_FILE_SIZE_PER_PE = 50 ! default = 50
+                                ! The maximum number of colums of truncations that any PE
+                                ! will write out during a run.
+NSTEPS_ADV = 1                  ! default = 1
+                                ! The number of advective iterations for each slow time
+                                ! step.
+RECATEGORIZE_ICE = True         !   [Boolean] default = True
+                                ! If true, readjust the distribution into ice thickness
+                                ! categories after advection.
+SEA_ICE_ROLL_FACTOR = 1.0       !   [Nondim] default = 1.0
+                                ! A factor by which the propensity of small amounts of
+                                ! thick sea-ice to become thinner by rolling is increased
+                                ! or 0 to disable rolling.  This can be thought of as the
+                                ! minimum number of ice floes in a grid cell divided by
+                                ! the horizontal floe aspect ratio.  Sensible values are
+                                ! 0 (no rolling) or larger than 1.
+CHECK_ICE_TRANSPORT_CONSERVATION = False !   [Boolean] default = False
+                                ! If true, use add multiple diagnostics of ice and snow
+                                ! mass conservation in the sea-ice transport code.  This
+                                ! is expensive and should be used sparingly.
+SIS_THICKNESS_ADVECTION_SCHEME = "PCM" ! default = "UPWIND_2D"
+                                ! The horizontal transport scheme for thickness:
+                                !   UPWIND_2D - Non-directionally split upwind
+                                !   PCM    - Directionally split piecewise constant
+                                !   PLM    - Piecewise Linear Method
+                                !   PPM:H3 - Piecewise Parabolic Method (Huyhn 3rd order)
+SIS_CONTINUITY_SCHEME = "PCM"   ! default = "UPWIND_2D"
+                                ! The horizontal transport scheme used in continuity:
+                                !   UPWIND_2D - Non-directionally split upwind
+                                !   PCM       - Directionally split piecewise constant
+                                !   PPM:C2PD  - Positive definite PPM with 2nd order edge values
+                                !   PPM:C2MO  - Monotonic PPM with 2nd order edge values
+CONT_PPM_VOLUME_BASED_CFL = False !   [Boolean] default = False
+                                ! If true, use the ratio of the open face lengths to the
+                                ! tracer cell areas when estimating CFL numbers.
+
+! === module SIS_tracer_advect ===
+SIS_TRACER_ADVECTION_SCHEME = "PPM:H3" ! default = "UPWIND_2D"
+                                ! The horizontal transport scheme for tracers:
+                                !   UPWIND_2D - Non-directionally split upwind
+                                !   PCM    - Directionally split piecewise constant
+                                !   PLM    - Piecewise Linear Method
+                                !   PPM:H3 - Piecewise Parabolic Method (Huyhn 3rd order)
+
+! === module SIS_sum_output ===
+WRITE_STOCKS = True             !   [Boolean] default = True
+                                ! If true, write the integrated tracer amounts to stdout
+                                ! when the statistics files are written.
+STDOUT_HEARTBEAT = True         !   [Boolean] default = True
+                                ! If true, periodically write sea ice statistics to
+                                ! stdout to allow the progress to be seen.
+MAXTRUNC = 0                    !   [truncations save_interval-1] default = 0
+                                ! The run will be stopped, and the day set to a very
+                                ! large value if the velocity is truncated more than
+                                ! MAXTRUNC times between  writing ice statistics.
+                                ! Set MAXTRUNC to 0 to stop if there is any truncation
+                                ! of sea ice velocities.
+STATISTICS_FILE = "seaice.stats" ! default = "seaice.stats"
+                                ! The file to use to write the globally integrated
+                                ! statistics.
+
+! === module SIS_fast_thermo ===
+! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.
+REORDER_0C_HEATFLUX = False     !   [Boolean] default = False
+                                ! If true, rearrange the calculation of the heat fluxes
+                                ! projected back to 0C to work on each contribution
+                                ! separately, so that they can be indentically replicated
+                                ! if there is a single fast timestep per coupled timestep
+                                ! and REDO_FAST_ICE_UPDATE=True.
+MAX_TSKIN_ITT = 10              ! default = 10
+                                ! The maximum number of iterations of the skin temperature
+                                ! and optical properties during redo_update_ice_model_fast.
+
+! === module SIS2_ice_thm (updates) ===
+! This sub-module does updates of the sea-ice due to thermodynamic changes.
+
+! === module SIS_optics ===
+! This module calculates the albedo and absorption profiles for shortwave radiation.
+DO_DELTA_EDDINGTON_SW = True    !   [Boolean] default = True
+                                ! If true, a delta-Eddington radiative transfer calculation
+                                ! for the shortwave radiation within the sea-ice.
+ICE_DELTA_EDD_R_ICE = 1.0       !   [nondimensional] default = 0.0
+                                ! A dreadfully documented tuning parameter for the radiative
+                                ! propeties of sea ice with the delta-Eddington radiative
+                                ! transfer calculation.
+ICE_DELTA_EDD_R_SNOW = 1.0      !   [nondimensional] default = 0.0
+                                ! A dreadfully documented tuning parameter for the radiative
+                                ! propeties of snow on sea ice with the delta-Eddington
+                                ! radiative transfer calculation.
+ICE_DELTA_EDD_R_POND = 1.0      !   [nondimensional] default = 0.0
+                                ! A dreadfully documented tuning parameter for the radiative
+                                ! propeties of meltwater ponds on sea ice with the delta-Eddington
+                                ! radiative transfer calculation.
+
+! === module MOM_file_parser ===
+SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
+                                ! If true, all log messages are also sent to stdout.
+REPORT_UNUSED_PARAMS = True     !   [Boolean] default = False
+                                ! If true, report any parameter lines that are not used
+                                ! in the run.
+FATAL_UNUSED_PARAMS = True      !   [Boolean] default = False
+                                ! If true, kill the run if there are any unused
+                                ! parameters.
+DOCUMENT_FILE = "SIS_parameter_doc" ! default = "MOM_parameter_doc"
+                                ! The basename for files where run-time parameters, their
+                                ! settings, units and defaults are documented. Blank will
+                                ! disable all parameter documentation.
+COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
+                                ! If true, all run-time parameters are
+                                ! documented in SIS_parameter_doc.all .
+MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
+                                ! If true, non-default run-time parameters are
+                                ! documented in SIS_parameter_doc.short .

--- a/ice_ocean_SIS2/Baltic_OM4_05/SIS_parameter_doc.debugging
+++ b/ice_ocean_SIS2/Baltic_OM4_05/SIS_parameter_doc.debugging
@@ -1,0 +1,1 @@
+! This file was written by the model and records the debugging parameters used at run-time.

--- a/ice_ocean_SIS2/Baltic_OM4_05/SIS_parameter_doc.layout
+++ b/ice_ocean_SIS2/Baltic_OM4_05/SIS_parameter_doc.layout
@@ -1,0 +1,69 @@
+! This file was written by the model and records the layout parameters used at run-time.
+GLOBAL_INDEXING = False         !   [Boolean] default = False
+                                ! If true, use a global lateral indexing convention, so
+                                ! that corresponding points on different processors have
+                                ! the same index. This does not work with static memory.
+! VERONA_COUPLER = True         !   [Boolean]
+                                ! If true, carry out all of the sea ice calls so that SIS2
+                                ! will work with the Verona and earlier releases of the
+                                ! FMS coupler code in configurations that use the exchange
+                                ! grid to communicate with the atmosphere or land.
+!SYMMETRIC_MEMORY_ = False      !   [Boolean]
+                                ! If defined, the velocity point data domain includes
+                                ! every face of the thickness points. In other words,
+                                ! some arrays are larger than others, depending on where
+                                ! they are on the staggered grid.  Also, the starting
+                                ! index of the velocity-point arrays is usually 0, not 1.
+                                ! This can only be set at compile time.
+NONBLOCKING_UPDATES = False     !   [Boolean] default = False
+                                ! If true, non-blocking halo updates may be used.
+THIN_HALO_UPDATES = True        !   [Boolean] default = True
+                                ! If true, optional arguments may be used to specify the
+                                ! The width of the halos that are updated with each call.
+!STATIC_MEMORY_ = False         !   [Boolean]
+                                ! If STATIC_MEMORY_ is defined, the principle variables
+                                ! will have sizes that are statically determined at
+                                ! compile time.  Otherwise the sizes are not determined
+                                ! until run time. The STATIC option is substantially
+                                ! faster, but does not allow the PE count to be changed
+                                ! at run time.  This can only be set at compile time.
+NIHALO = 4                      ! default = 4
+                                ! The number of halo points on each side in the
+                                ! x-direction.  With STATIC_MEMORY_ this is set as NIHALO_
+                                ! in SIS2_memory.h at compile time; without STATIC_MEMORY_
+                                ! the default is NIHALO_ in SIS2_memory.h (if defined) or 2.
+NJHALO = 4                      ! default = 4
+                                ! The number of halo points on each side in the
+                                ! y-direction.  With STATIC_MEMORY_ this is set as NJHALO_
+                                ! in SIS2_memory.h at compile time; without STATIC_MEMORY_
+                                ! the default is NJHALO_ in SIS2_memory.h (if defined) or 2.
+MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
+                                ! A text file to specify n_mask, layout and mask_list.
+                                ! This feature masks out processors that contain only land points.
+                                ! The first line of mask_table is the number of regions to be masked out.
+                                ! The second line is the layout of the model and must be
+                                ! consistent with the actual model layout.
+                                ! The following (n_mask) lines give the logical positions
+                                ! of the processors that are masked out. The mask_table
+                                ! can be created by tools like check_mask. The
+                                ! following example of mask_table masks out 2 processors,
+                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                !  2
+                                !  4,6
+                                !  1,2
+                                !  3,6
+NIPROC = 1                      !
+                                ! The number of processors in the x-direction. With
+                                ! STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
+NJPROC = 1                      !
+                                ! The number of processors in the x-direction. With
+                                ! STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
+LAYOUT = 1, 1                   !
+                                ! The processor layout that was acutally used.
+IO_LAYOUT = 1, 1                ! default = 1
+                                ! The processor layout to be used, or 0,0 to automatically
+                                ! set the io_layout to be the same as the layout.
+NIBLOCK = 1                     ! default = 1
+                                ! The number of blocks in the x-direction on each processor (for openmp).
+NJBLOCK = 1                     ! default = 1
+                                ! The number of blocks in the y-direction on each processor (for openmp).

--- a/ice_ocean_SIS2/Baltic_OM4_05/SIS_parameter_doc.short
+++ b/ice_ocean_SIS2/Baltic_OM4_05/SIS_parameter_doc.short
@@ -1,0 +1,160 @@
+! This file was written by the model and records the non-default parameters used at run-time.
+
+! === module ice_model ===
+CGRID_ICE_DYNAMICS = True       !   [Boolean] default = False
+                                ! If true, use a C-grid discretization of the sea-ice
+                                ! dynamics; if false use a B-grid discretization.
+CONSTANT_COSZEN_IC = 0.0        !   [nondim] default = -1.0
+                                ! A constant value to use to initialize the cosine of
+                                ! the solar zenith angle for the first radiation step,
+                                ! or a negative number to use the current time and astronomy.
+ADD_DIURNAL_SW = True           !   [Boolean] default = False
+                                ! If true, add a synthetic diurnal cycle to the shortwave
+                                ! radiation.
+
+! === module MOM_domains ===
+REENTRANT_X = False             !   [Boolean] default = True
+                                ! If true, the domain is zonally reentrant.
+NIGLOBAL = 49                   !
+                                ! The total number of thickness grid points in the
+                                ! x-direction in the physical domain. With STATIC_MEMORY_
+                                ! this is set in SIS2_memory.h at compile time.
+NJGLOBAL = 53                   !
+                                ! The total number of thickness grid points in the
+                                ! y-direction in the physical domain. With STATIC_MEMORY_
+                                ! this is set in SIS2_memory.h at compile time.
+
+! === module MOM_hor_index ===
+! Sets the horizontal array index types.
+
+! === module SIS_initialize_fixed ===
+INPUTDIR = "INPUT"              ! default = "."
+                                ! The directory in which input files are found.
+
+! === module MOM_grid_init ===
+GRID_CONFIG = "mosaic"          !
+                                ! A character string that determines the method for
+                                ! defining the horizontal grid.  Current options are:
+                                !     mosaic - read the grid from a mosaic (supergrid)
+                                !              file set by GRID_FILE.
+                                !     cartesian - use a (flat) Cartesian grid.
+                                !     spherical - use a simple spherical grid.
+                                !     mercator - use a Mercator spherical grid.
+GRID_FILE = "ocean_hgrid.nc"    !
+                                ! Name of the file from which to read horizontal grid data.
+!MAXIMUM_DEPTH = 588.986572265625 !   [m]
+                                ! The (diagnosed) maximum depth of the ocean.
+OMEGA = 7.292E-05               !   [s-1] default = 7.2921E-05
+                                ! The rotation rate of the earth.
+
+! === module hor_grid ===
+! Parameters providing information about the lateral grid.
+
+! === module MOM_hor_index ===
+! Sets the horizontal array index types.
+
+! === module SIS2_ice_thm (thermo) ===
+! This sub-module calculates ice thermodynamic quantities.
+CP_BRINE = 2100.0               !   [J kg-1 K-1] default = 4200.0
+                                ! The heat capacity of water in brine pockets within the
+                                ! sea-ice, approximated as a constant.  CP_BRINE and
+                                ! CP_SEAWATER should be equal, but for computational
+                                ! convenience CP_BRINE can be set equal to CP_ICE.
+
+! === module SIS_tracer_registry ===
+
+! === module SIS_tracer_flow_control ===
+
+! === module SIS_slow_thermo ===
+! This module calculates the slow evolution of the ice mass, heat, and salt budgets.
+ICE_BULK_SALINITY = 0.0         !   [g/kg] default = 4.0
+                                ! The fixed bulk salinity of sea ice.
+ICE_RELATIVE_SALINITY = 0.1     !   [nondim] default = 0.0
+                                ! The initial salinity of sea ice as a fraction of the
+                                ! salinity of the seawater from which it formed.
+SIS2_FILLING_FRAZIL = False     !   [Boolean] default = True
+                                ! If true, apply frazil to fill as many categories as
+                                ! possible to fill in a uniform (minimum) amount of ice
+                                ! in all the thinnest categories. Otherwise the frazil is
+                                ! always assigned to a single category.
+
+! === module SIS2_ice_thm (updates) ===
+! This sub-module does updates of the sea-ice due to thermodynamic changes.
+
+! === module SIS_dyn_trans ===
+! This module updates the ice momentum and does ice transport.
+DT_ICE_DYNAMICS = 1200.0        !   [seconds] default = -1.0
+                                ! The time step used for the slow ice dynamics, including
+                                ! stepping the continuity equation and interactions
+                                ! between the ice mass field and velocities.  If 0 or
+                                ! negative the coupling time step will be used.
+ICEBERG_WINDSTRESS_BUG = True   !   [Boolean] default = False
+                                ! If true, use older code that applied an old ice-ocean
+                                ! stress to the icebergs in place of the current air-ocean
+                                ! stress.  This option is here for backward compatibility,
+                                ! but should be avoided.
+ICE_STATS_INTERVAL = 0.25       !   [days] default = 1.0
+                                ! The interval in units of TIMEUNIT between writes of the
+                                ! globally summed ice statistics and conservation checks.
+DT_RHEOLOGY = 50.0              !   [seconds] default = -1.0
+                                ! The sub-cycling time step for iterating the rheology
+                                ! and ice momentum equations. If DT_RHEOLOGY is negative,
+                                ! the time step is set via NSTEPS_DYN.
+MIN_OCN_INTERTIAL_H = 2.0       !   [m] default = 0.0
+                                ! A minimum ocean thickness used to limit the viscous coupling rate
+                                ! implied for the ocean by the ice-ocean stress. Only used if positive.
+SIS_THICKNESS_ADVECTION_SCHEME = "PCM" ! default = "UPWIND_2D"
+                                ! The horizontal transport scheme for thickness:
+                                !   UPWIND_2D - Non-directionally split upwind
+                                !   PCM    - Directionally split piecewise constant
+                                !   PLM    - Piecewise Linear Method
+                                !   PPM:H3 - Piecewise Parabolic Method (Huyhn 3rd order)
+SIS_CONTINUITY_SCHEME = "PCM"   ! default = "UPWIND_2D"
+                                ! The horizontal transport scheme used in continuity:
+                                !   UPWIND_2D - Non-directionally split upwind
+                                !   PCM       - Directionally split piecewise constant
+                                !   PPM:C2PD  - Positive definite PPM with 2nd order edge values
+                                !   PPM:C2MO  - Monotonic PPM with 2nd order edge values
+
+! === module SIS_tracer_advect ===
+SIS_TRACER_ADVECTION_SCHEME = "PPM:H3" ! default = "UPWIND_2D"
+                                ! The horizontal transport scheme for tracers:
+                                !   UPWIND_2D - Non-directionally split upwind
+                                !   PCM    - Directionally split piecewise constant
+                                !   PLM    - Piecewise Linear Method
+                                !   PPM:H3 - Piecewise Parabolic Method (Huyhn 3rd order)
+
+! === module SIS_sum_output ===
+
+! === module SIS_fast_thermo ===
+! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.
+
+! === module SIS2_ice_thm (updates) ===
+! This sub-module does updates of the sea-ice due to thermodynamic changes.
+
+! === module SIS_optics ===
+! This module calculates the albedo and absorption profiles for shortwave radiation.
+ICE_DELTA_EDD_R_ICE = 1.0       !   [nondimensional] default = 0.0
+                                ! A dreadfully documented tuning parameter for the radiative
+                                ! propeties of sea ice with the delta-Eddington radiative
+                                ! transfer calculation.
+ICE_DELTA_EDD_R_SNOW = 1.0      !   [nondimensional] default = 0.0
+                                ! A dreadfully documented tuning parameter for the radiative
+                                ! propeties of snow on sea ice with the delta-Eddington
+                                ! radiative transfer calculation.
+ICE_DELTA_EDD_R_POND = 1.0      !   [nondimensional] default = 0.0
+                                ! A dreadfully documented tuning parameter for the radiative
+                                ! propeties of meltwater ponds on sea ice with the delta-Eddington
+                                ! radiative transfer calculation.
+
+! === module MOM_file_parser ===
+REPORT_UNUSED_PARAMS = True     !   [Boolean] default = False
+                                ! If true, report any parameter lines that are not used
+                                ! in the run.
+FATAL_UNUSED_PARAMS = True      !   [Boolean] default = False
+                                ! If true, kill the run if there are any unused
+                                ! parameters.
+DOCUMENT_FILE = "SIS_parameter_doc" ! default = "MOM_parameter_doc"
+                                ! The basename for files where run-time parameters, their
+                                ! settings, units and defaults are documented. Blank will
+                                ! disable all parameter documentation.

--- a/ice_ocean_SIS2/Baltic_OM4_05/data_table
+++ b/ice_ocean_SIS2/Baltic_OM4_05/data_table
@@ -1,0 +1,42 @@
+"ATM" , "p_surf"        , "SLP"         , "./INPUT/slp.clim.nc"          , "bilinear" ,  1.0
+"ATM" , "p_bot"         , "SLP"         , "./INPUT/slp.clim.nc"          , "bilinear" ,  1.0
+"ATM" , "t_bot"         , "T_10_MOD"    , "./INPUT/t_10_mod.clim.nc"     , "bilinear" ,  1.0
+"ATM" , "sphum_bot"     , "Q_10_MOD"    , "./INPUT/q_10_mod.clim.nc"     , "bilinear" ,  1.0
+"ATM" , "u_bot"         , "U_10_MOD"    , "./INPUT/u_10_mod.clim.nc"     , "bicubic",   1.0
+"ATM" , "v_bot"         , "V_10_MOD"    , "./INPUT/v_10_mod.clim.nc"     , "bicubic",   1.0
+"ATM" , "z_bot"         , ""            , ""                             , "bilinear" , 10.0
+"ATM" , "gust"          , ""            , ""                             , "bilinear" ,  1.0e-4
+"ICE" , "lw_flux_dn"    , "LWDN_MOD"    , "./INPUT/ncar_rad.clim.nc"     , "bilinear" ,  1.0
+"ICE" , "sw_flux_vis_dir_dn", "SWDN_MOD", "./INPUT/ncar_rad.clim.nc"     , "bilinear" ,  0.285
+"ICE" , "sw_flux_vis_dif_dn", "SWDN_MOD", "./INPUT/ncar_rad.clim.nc"     , "bilinear" ,  0.285
+"ICE" , "sw_flux_nir_dir_dn", "SWDN_MOD", "./INPUT/ncar_rad.clim.nc"     , "bilinear" ,  0.215
+"ICE" , "sw_flux_nir_dif_dn", "SWDN_MOD", "./INPUT/ncar_rad.clim.nc"     , "bilinear" ,  0.215
+"ICE" , "lprec"         , "RAIN"        , "./INPUT/ncar_precip.clim.nc"  , "bilinear" ,  0.9933
+"ICE" , "fprec"         , "SNOW"        , "./INPUT/ncar_precip.clim.nc"  , "bilinear" ,  0.9933
+"ICE" , "runoff"        , "runoff"      , "./INPUT/runoff.nc",           "none", 1.0
+"ICE" , "calving"       , ""            , ""                             , "none"  ,  0.0
+"ICE" , "dhdt"          , ""            , ""                             , "none"  , 80.0
+"ICE" , "dedt"          , ""            , ""                             , "none"  ,  2.0e-6
+"ICE" , "drdt"          , ""            , ""                             , "none"  ,  10.0
+"LND" , "t_surf"        , ""            , ""                             , "none"  ,  273.0
+"LND" , "t_ca"          , ""            , ""                             , "none"  ,  273.0
+"LND" , "q_ca"          , ""            , ""                             , "none"  ,  0.0
+"LND" , "rough_mom"     , ""            , ""                             , "none"  ,  0.01
+"LND" , "rough_heat"    , ""            , ""                             , "none"  ,  0.1
+"LND" , "albedo"        , ""            , ""                             , "none"  ,  0.1
+#"LND" , "t_ca"         , ""            , ""                             , "none"  ,  273.0
+#"LND" , "t_surf"       , ""            , ""                             , "none"  ,  273.0
+"LND" , "sphum_surf"    , ""            , ""                             , "none"  ,  0.0
+"LND" , "sphum_ca"      , ""            , ""                             , "none"  ,  0.0
+"LND" , "t_flux"        , ""            , ""                             , "none"  ,  0.0
+"LND" , "sphum_flux"    , ""            , ""                             , "none"  ,  0.0
+"LND" , "lw_flux"       , ""            , ""                             , "none"  ,  0.0
+"LND" , "sw_flux"       , ""            , ""                             , "none"  ,  0.0
+"LND" , "lprec"         , ""            , ""                             , "none"  ,  0.0
+"LND" , "fprec"         , ""            , ""                             , "none"  ,  0.0
+"LND" , "dhdt"          , ""            , ""                             , "none"  ,  5.0
+"LND" , "dedt"          , ""            , ""                             , "none"  ,  2e-6
+"LND" , "dedq"          , ""            , ""                             , "none"  ,  0.0
+"LND" , "drdt"          , ""            , ""                             , "none"  ,  5.0
+"LND" , "drag_q"        , ""            , ""                             , "none"  ,  0.0
+"LND" , "p_surf"        , ""            , ""                             , "none"  ,  1.e5

--- a/ice_ocean_SIS2/Baltic_OM4_05/diag_table
+++ b/ice_ocean_SIS2/Baltic_OM4_05/diag_table
@@ -1,0 +1,1 @@
+../OM4_05/diag_table

--- a/ice_ocean_SIS2/Baltic_OM4_05/field_table
+++ b/ice_ocean_SIS2/Baltic_OM4_05/field_table
@@ -1,0 +1,25 @@
+# specific humidity for moist runs
+ "TRACER", "atmos_mod", "sphum" 
+           "longname",     "specific humidity"
+           "units",        "kg/kg" /
+##	   "profile_type", "fixed", "surface_value=3.e-6" /
+# prognostic cloud scheme tracers
+  "TRACER", "atmos_mod", "liq_wat"
+            "longname",     "cloud liquid specific humidity"
+            "units",        "kg/kg" /
+  "TRACER", "atmos_mod", "ice_wat"
+            "longname",     "cloud ice water specific humidity"
+            "units",        "kg/kg" /
+  "TRACER", "atmos_mod", "cld_amt"
+            "longname",     "cloud fraction"
+            "units",        "none" /
+# sphum must be present on land as well
+ "TRACER", "land_mod",     "sphum"
+           "longname",     "specific humidity"
+           "units",        "kg/kg" /
+# test tracer for radon
+#
+# "TRACER", "atmos_mod", "radon"
+#           "longname",     "radon test tracer"
+#           "units",        "kg/kg" /      
+###.................................................

--- a/ice_ocean_SIS2/Baltic_OM4_05/input.nml
+++ b/ice_ocean_SIS2/Baltic_OM4_05/input.nml
@@ -1,0 +1,124 @@
+ &MOM_input_nml
+         output_directory = '.',
+         input_filename = 'n'
+         restart_input_dir = 'INPUT',
+         restart_output_dir = 'RESTART',
+         parameter_filename = 'MOM_input',
+                              'MOM_saltrestore',
+                              'MOM_override'
+/
+
+ &SIS_input_nml
+        output_directory = './',
+        input_filename = 'n'
+        restart_input_dir = 'INPUT/',
+        restart_output_dir = 'RESTART/',
+        parameter_filename = 'SIS_input',
+                             'SIS_override' /
+
+ &atmos_model_nml
+           layout = 0, 0
+/
+
+ &coupler_nml
+            months = 0,
+            days   = 1,
+            hours  = 0,
+            current_date = 1900,1,1,0,0,0,
+            calendar = 'NOLEAP',
+            dt_cpld = 7200,
+            dt_atmos = 7200,
+            do_atmos = .false.,
+            do_land = .false.,
+            do_ice = .true.,
+            do_ocean = .true.,
+            do_flux = .true.,
+            atmos_npes = 0, 
+            concurrent = .false.     
+            use_lag_fluxes=.false.    
+            check_stocks = 0
+/
+
+ &diag_manager_nml
+            max_axes = 100,
+            max_files = 63,
+            max_num_axis_sets = 100,
+            max_input_fields = 699
+            max_output_fields = 699
+            mix_snapshot_average_fields=.false.
+/
+
+ &flux_exchange_nml
+            debug_stocks = .FALSE.
+            divert_stocks_report = .TRUE.            
+            do_area_weighted_flux = .FALSE.
+/
+
+ &fms_io_nml
+            fms_netcdf_restart=.true.
+            threading_read='multi'
+            max_files_r = 200
+            max_files_w = 200
+            checksum_required = .false.
+/
+
+ &fms_nml
+            clock_grain='ROUTINE'
+            clock_flags='NONE'
+            domains_stack_size = 5000000
+            stack_size =0
+/
+
+ &ice_albedo_nml
+            t_range = 10.
+/
+
+ &ice_model_nml
+/
+
+ &icebergs_nml
+    verbose=.false.,
+    verbose_hrs=24,
+    traj_sample_hrs=24,
+    debug=.false.,
+    really_debug=.false.,
+    use_slow_find=.true.,
+    add_weight_to_ocean=.true.,
+    passive_mode=.false.,
+    generate_test_icebergs=.false.,
+    speed_limit=0.,
+    use_roundoff_fix=.true.,
+    make_calving_reproduce=.true.,
+ /
+
+ &monin_obukhov_nml
+            neutral = .true.
+/
+
+ &ocean_albedo_nml
+            ocean_albedo_option = 2
+/
+
+ &ocean_rough_nml
+            rough_scheme = 'beljaars'
+/
+
+ &sat_vapor_pres_nml
+            construct_table_wrt_liq = .true.
+            construct_table_wrt_liq_and_ice = .true.
+/
+
+ &surface_flux_nml
+            ncar_ocean_flux = .true.
+	    raoult_sat_vap = .true.
+/
+
+ &topography_nml
+            topog_file = 'INPUT/navy_topography.data.nc'
+/
+
+ &xgrid_nml
+            make_exchange_reproduce = .false.
+            interp_method = 'second_order'
+/
+

--- a/ice_ocean_SIS2/Baltic_OM4_05/static_input.nml
+++ b/ice_ocean_SIS2/Baltic_OM4_05/static_input.nml
@@ -1,0 +1,88 @@
+
+ &atmos_model_nml
+           layout = 0, 0
+/
+
+ &diag_manager_nml
+            max_axes = 100,
+            max_files = 63,
+            max_num_axis_sets = 100,
+            max_input_fields = 699
+            max_output_fields = 699
+            mix_snapshot_average_fields=.false.
+/
+
+ &flux_exchange_nml
+            debug_stocks = .FALSE.
+            divert_stocks_report = .TRUE.            
+            do_area_weighted_flux = .FALSE.
+/
+
+ &fms_io_nml
+            fms_netcdf_restart=.true.
+            threading_read='multi'
+            max_files_r = 200
+            max_files_w = 200
+            checksum_required = .false.
+/
+
+ &fms_nml
+            clock_grain='ROUTINE'
+            clock_flags='NONE'
+            domains_stack_size = 5000000
+            stack_size =0
+/
+
+ &ice_albedo_nml
+            t_range = 10.
+/
+
+ &ice_model_nml
+/
+
+ &icebergs_nml
+    verbose=.false.,
+    verbose_hrs=24,
+    traj_sample_hrs=24,
+    debug=.false.,
+    really_debug=.false.,
+    use_slow_find=.true.,
+    add_weight_to_ocean=.true.,
+    passive_mode=.false.,
+    generate_test_icebergs=.false.,
+    speed_limit=0.,
+    use_roundoff_fix=.true.,
+    make_calving_reproduce=.true.,
+ /
+
+ &monin_obukhov_nml
+            neutral = .true.
+/
+
+ &ocean_albedo_nml
+            ocean_albedo_option = 2
+/
+
+ &ocean_rough_nml
+            rough_scheme = 'beljaars'
+/
+
+ &sat_vapor_pres_nml
+            construct_table_wrt_liq = .true.
+            construct_table_wrt_liq_and_ice = .true.
+/
+
+ &surface_flux_nml
+            ncar_ocean_flux = .true.
+	    raoult_sat_vap = .true.
+/
+
+ &topography_nml
+            topog_file = 'INPUT/navy_topography.data.nc'
+/
+
+ &xgrid_nml
+            make_exchange_reproduce = .false.
+            interp_method = 'second_order'
+/
+


### PR DESCRIPTION
This test case is intended for development and testing (not for scientific
use). The model domain centers on the Baltic Sea and the grid has been cut
out of the global OM4_05 test case and uses the same MOM_input and
SIS_input. The model is small enough to be run relatively quickly on a
workstation. A script is included to update various input fields if they
change for OM4_05.

@adcroft, @Hallberg-NOAA : I don't have the write permissions to copy these inputs to archive, lustre, and the FTP site. Could you do this for me? The input files needed to run this test case can found at /archive/aes/MOM6_inputs/Baltic_OM4_05.