### PR TITLE
*Set VEL_UNDERFLOW in external_gwave

### DIFF
--- a/ocean_only/external_gwave/MOM_input
+++ b/ocean_only/external_gwave/MOM_input
@@ -279,6 +279,11 @@ HBBL = 0.001                    !   [m]
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity
                                 ! components are truncated.
+VEL_UNDERFLOW = 1.0E-50         !   [m s-1] default = 0.0
+                                ! A negligibly small velocity magnitude below which velocity
+                                ! components are set to 0.  A reasonable value might be
+                                ! 1e-30 m/s, which is less than an Angstrom divided by
+                                ! the age of the universe.
 
 ! === module MOM_PointAccel ===
 

--- a/ocean_only/external_gwave/MOM_parameter_doc.all
+++ b/ocean_only/external_gwave/MOM_parameter_doc.all
@@ -848,7 +848,7 @@ CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
                                 ! ramping up CFL_TRUNC.
-VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
+VEL_UNDERFLOW = 1.0E-50         !   [m s-1] default = 0.0
                                 ! A negligibly small velocity magnitude below which velocity
                                 ! components are set to 0.  A reasonable value might be
                                 ! 1e-30 m/s, which is less than an Angstrom divided by

--- a/ocean_only/external_gwave/MOM_parameter_doc.short
+++ b/ocean_only/external_gwave/MOM_parameter_doc.short
@@ -308,6 +308,11 @@ HMIX_FIXED = 1.0E-10            !   [m]
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity
                                 ! components are truncated.
+VEL_UNDERFLOW = 1.0E-50         !   [m s-1] default = 0.0
+                                ! A negligibly small velocity magnitude below which velocity
+                                ! components are set to 0.  A reasonable value might be
+                                ! 1e-30 m/s, which is less than an Angstrom divided by
+                                ! the age of the universe.
 
 ! === module MOM_PointAccel ===
 


### PR DESCRIPTION
  Set the underflow velocity to 1e-50 in the external_gwave test case.  This
changes answers minorly, but with this change the answers reproduce with changes
to H_RESCALE_POWER.