### PR TITLE
Changed precision for ocean_scalar* output

### DIFF
--- a/ice_ocean_SIS2/OM4_025/diag_table.MOM6
+++ b/ice_ocean_SIS2/OM4_025/diag_table.MOM6
@@ -81,14 +81,14 @@
  "ocean_model",   "pso",          "pso",              "ocean_month",         "all", "mean", "none",2
  "ocean_model",   "masscello",    "masscello",        "ocean_annual",        "all", "mean", "none",2
 #"ocean_model",   "masscello",    "masscello",        "ocean_month",         "all", "mean", "none",2
- "ocean_model",   "masso",        "masso",            "ocean_scalar_month",  "all", "mean", "none",2  # global sum masscello
- "ocean_model",   "masso",        "masso",            "ocean_scalar_annual", "all", "mean", "none",2  # global sum masscello
+ "ocean_model",   "masso",        "masso",            "ocean_scalar_month",  "all", "mean", "none",1  # global sum masscello
+ "ocean_model",   "masso",        "masso",            "ocean_scalar_annual", "all", "mean", "none",1  # global sum masscello
  "ocean_model",   "thkcello",     "thkcello",         "ocean_annual",        "all", "mean", "none",2  # Only needed in native space a static field needs to be provided for CMIP6
  "ocean_model_rho2", "thkcello",  "thkcello",         "ocean_annual_rho2",   "all", "mean", "none",2  # Only needed in native space a static field needs to be provided for CMIP6
  "ocean_model_rho2", "thkcello",  "thkcello",         "ocean_month_rho2",    "all", "mean", "none",2  # Only needed in native space a static field needs to be provided for CMIP6
 #"ocean_model",   "thkcello",     "thkcello",         "ocean_month",         "all", "mean", "none",2
- "ocean_model",   "volo",         "volo",             "ocean_scalar_month",  "all", "mean", "none",2  # global sum thkcello
- "ocean_model",   "volo",         "volo",             "ocean_scalar_annual", "all", "mean", "none",2  # global sum thkcello
+ "ocean_model",   "volo",         "volo",             "ocean_scalar_month",  "all", "mean", "none",1  # global sum thkcello
+ "ocean_model",   "volo",         "volo",             "ocean_scalar_annual", "all", "mean", "none",1  # global sum thkcello
  "ocean_model",   "zos",          "zos",              "ocean_annual",        "all", "mean", "none",2
  "ocean_model",   "zos",          "zos",              "ocean_month",         "all", "mean", "none",2
  "ocean_model",   "zos",          "zos",              "ocean_daily",         "all", "mean", "none",2
@@ -100,17 +100,17 @@
  "ocean_model_z", "thetao",       "thetao",           "ocean_annual_z",      "all", "mean", "none",2  # if use pre-TEOS10
  "ocean_model_z", "thetao",       "thetao",           "ocean_month_z",       "all", "mean", "none",2  # if use pre-TEOS10
  "ocean_model_z", "thetao_xyave", "thetao_xyave",     "ocean_annual_z",      "all", "mean", "none",2  # if use pre-TEOS10
- "ocean_model",   "thetaoga",     "thetaoga",         "ocean_scalar_month",  "all", "mean", "none",2  # global mean theta
- "ocean_model",   "thetaoga",     "thetaoga",         "ocean_scalar_annual", "all", "mean", "none",2  # global mean theta
+ "ocean_model",   "thetaoga",     "thetaoga",         "ocean_scalar_month",  "all", "mean", "none",1  # global mean theta
+ "ocean_model",   "thetaoga",     "thetaoga",         "ocean_scalar_annual", "all", "mean", "none",1  # global mean theta
 #"ocean_model",   "bigthetao",    "bigthetao",        "ocean_annual",        "all", "mean", "none",2  # if use TEOS10
 #"ocean_model",   "bigthetao",    "bigthetao",        "ocean_month",         "all", "mean", "none",2  # if use TEOS10
-#"ocean_model",   "bigthetaoga",  "bigthetaoga",      "ocean_scalar_annual", "all", "mean", "none",2  # if use TEOS10
-#"ocean_model",   "bigthetaoga",  "bigthetaoga",      "ocean_scalar_month",  "all", "mean", "none",2  # if use TEOS10
+#"ocean_model",   "bigthetaoga",  "bigthetaoga",      "ocean_scalar_annual", "all", "mean", "none",1  # if use TEOS10
+#"ocean_model",   "bigthetaoga",  "bigthetaoga",      "ocean_scalar_month",  "all", "mean", "none",1  # if use TEOS10
  "ocean_model",   "tos",          "tos",              "ocean_annual",        "all", "mean", "none",2
  "ocean_model",   "tos",          "tos",              "ocean_month",         "all", "mean", "none",2
  "ocean_model",   "tos",          "tos",              "ocean_daily",         "all", "mean", "none",2
- "ocean_model",   "tosga",        "tosga",            "ocean_scalar_annual", "all", "mean", "none",2
- "ocean_model",   "tosga",        "tosga",            "ocean_scalar_month",  "all", "mean", "none",2
+ "ocean_model",   "tosga",        "tosga",            "ocean_scalar_annual", "all", "mean", "none",1
+ "ocean_model",   "tosga",        "tosga",            "ocean_scalar_month",  "all", "mean", "none",1
  "ocean_model",   "tossq",        "tossq",            "ocean_annual",        "all", "mean", "none",2
  "ocean_model",   "tossq",        "tossq",            "ocean_month",         "all", "mean", "none",2
  "ocean_model",   "tossq",        "tossq",            "ocean_daily",         "all", "mean", "none",2
@@ -121,13 +121,13 @@
  "ocean_model_z", "so",           "so",               "ocean_annual_z",      "all", "mean", "none",2
  "ocean_model_z", "so",           "so",               "ocean_month_z",       "all", "mean", "none",2
  "ocean_model_z", "so_xyave",     "so_xyave",         "ocean_annual_z",      "all", "mean", "none",2
- "ocean_model",   "soga",         "soga",             "ocean_scalar_annual", "all", "mean", "none",2
- "ocean_model",   "soga",         "soga",             "ocean_scalar_month",  "all", "mean", "none",2
+ "ocean_model",   "soga",         "soga",             "ocean_scalar_annual", "all", "mean", "none",1
+ "ocean_model",   "soga",         "soga",             "ocean_scalar_month",  "all", "mean", "none",1
  "ocean_model",   "sos",          "sos",              "ocean_annual",        "all", "mean", "none",2
  "ocean_model",   "sos",          "sos",              "ocean_month",         "all", "mean", "none",2
  "ocean_model",   "sos",          "sos",              "ocean_daily",         "all", "mean", "none",2
- "ocean_model",   "sosga",        "sosga",            "ocean_scalar_annual", "all", "mean", "none",2
- "ocean_model",   "sosga",        "sosga",            "ocean_scalar_month",  "all", "mean", "none",2
+ "ocean_model",   "sosga",        "sosga",            "ocean_scalar_annual", "all", "mean", "none",1
+ "ocean_model",   "sosga",        "sosga",            "ocean_scalar_month",  "all", "mean", "none",1
  "ocean_model",   "sossq",        "sossq",            "ocean_annual",        "all", "mean", "none",2
  "ocean_model",   "sossq",        "sossq",            "ocean_month",         "all", "mean", "none",2
  "ocean_model",   "sossq",        "sossq",            "ocean_daily",         "all", "mean", "none",2
@@ -575,30 +575,30 @@
 
 # -----------------------------------------------------------------------------------------
 # Monthly time series
- "ocean_model", "ave_wfo",             "ave_wfo",            "ocean_scalar_month",  "all", "mean",  "none",2  # global mean prcme
- "ocean_model", "ave_evs",             "ave_evs",            "ocean_scalar_month",  "all", "mean",  "none",2  # global mean evaporation
- "ocean_model", "ave_hfsso",           "ave_hfsso",          "ocean_scalar_month",  "all", "mean",  "none",2  # global mean sensible heat
- "ocean_model", "ave_rsntds",          "ave_rsntds",         "ocean_scalar_month",  "all", "mean",  "none",2  # global mean SW
- "ocean_model", "ave_rlntds",          "ave_rlntds",         "ocean_scalar_month",  "all", "mean",  "none",2  # global mean LW
- "ocean_model", "ave_hflso",           "ave_hflso",          "ocean_scalar_month",  "all", "mean",  "none",2  # global mean latent
- "ocean_model", "ave_hfds",            "ave_hfds",           "ocean_scalar_month",  "all", "mean",  "none",2  # global mean net heat surf
- "ocean_model", "net_heat_coupler_ga", "net_heat_coupler_ga","ocean_scalar_month",  "all", "mean",  "none",2  # global mean net heat coupl
- "ocean_model", "LwLatSens_ga",        "LwLatSens_ga",       "ocean_scalar_month",  "all", "mean",  "none",2  # global mean LW+lat+sens
- "ocean_model", "ssh_ga",              "ssh_ga",             "ocean_scalar_month",  "all", "mean",  "none",2  # global mean ssh
- "ocean_model", "precip_ga",           "precip_ga",          "ocean_scalar_month",  "all", "mean",  "none",2  # global mean precip
+ "ocean_model", "ave_wfo",             "ave_wfo",            "ocean_scalar_month",  "all", "mean",  "none",1  # global mean prcme
+ "ocean_model", "ave_evs",             "ave_evs",            "ocean_scalar_month",  "all", "mean",  "none",1  # global mean evaporation
+ "ocean_model", "ave_hfsso",           "ave_hfsso",          "ocean_scalar_month",  "all", "mean",  "none",1  # global mean sensible heat
+ "ocean_model", "ave_rsntds",          "ave_rsntds",         "ocean_scalar_month",  "all", "mean",  "none",1  # global mean SW
+ "ocean_model", "ave_rlntds",          "ave_rlntds",         "ocean_scalar_month",  "all", "mean",  "none",1  # global mean LW
+ "ocean_model", "ave_hflso",           "ave_hflso",          "ocean_scalar_month",  "all", "mean",  "none",1  # global mean latent
+ "ocean_model", "ave_hfds",            "ave_hfds",           "ocean_scalar_month",  "all", "mean",  "none",1  # global mean net heat surf
+ "ocean_model", "net_heat_coupler_ga", "net_heat_coupler_ga","ocean_scalar_month",  "all", "mean",  "none",1  # global mean net heat coupl
+ "ocean_model", "LwLatSens_ga",        "LwLatSens_ga",       "ocean_scalar_month",  "all", "mean",  "none",1  # global mean LW+lat+sens
+ "ocean_model", "ssh_ga",              "ssh_ga",             "ocean_scalar_month",  "all", "mean",  "none",1  # global mean ssh
+ "ocean_model", "precip_ga",           "precip_ga",          "ocean_scalar_month",  "all", "mean",  "none",1  # global mean precip
 
 # Annual time series
- "ocean_model", "ave_wfo",             "ave_wfo",             "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean prcme
- "ocean_model", "ave_evs",             "ave_evs",             "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean evaporation
- "ocean_model", "ave_hfsso",           "ave_hfsso",           "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean sensible heat
- "ocean_model", "ave_rsntds",          "ave_rsntds",          "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean SW
- "ocean_model", "ave_rlntds",          "ave_rlntds",          "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean LW
- "ocean_model", "ave_hflso",           "ave_hflso",           "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean latent
- "ocean_model", "ave_hfds",            "ave_hfds",            "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean net heat surface
- "ocean_model", "net_heat_coupler_ga", "net_heat_coupler_ga", "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean net heat coupler
- "ocean_model", "LwLatSens_ga",        "LwLatSens_ga",        "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean LW + latent + sensible
- "ocean_model", "ssh_ga",              "ssh_ga",              "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean ssh
- "ocean_model", "precip_ga",           "precip_ga",           "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean precip
+ "ocean_model", "ave_wfo",             "ave_wfo",             "ocean_scalar_annual",  "all", "mean",  "none",1  # global mean prcme
+ "ocean_model", "ave_evs",             "ave_evs",             "ocean_scalar_annual",  "all", "mean",  "none",1  # global mean evaporation
+ "ocean_model", "ave_hfsso",           "ave_hfsso",           "ocean_scalar_annual",  "all", "mean",  "none",1  # global mean sensible heat
+ "ocean_model", "ave_rsntds",          "ave_rsntds",          "ocean_scalar_annual",  "all", "mean",  "none",1  # global mean SW
+ "ocean_model", "ave_rlntds",          "ave_rlntds",          "ocean_scalar_annual",  "all", "mean",  "none",1  # global mean LW
+ "ocean_model", "ave_hflso",           "ave_hflso",           "ocean_scalar_annual",  "all", "mean",  "none",1  # global mean latent
+ "ocean_model", "ave_hfds",            "ave_hfds",            "ocean_scalar_annual",  "all", "mean",  "none",1  # global mean net heat surface
+ "ocean_model", "net_heat_coupler_ga", "net_heat_coupler_ga", "ocean_scalar_annual",  "all", "mean",  "none",1  # global mean net heat coupler
+ "ocean_model", "LwLatSens_ga",        "LwLatSens_ga",        "ocean_scalar_annual",  "all", "mean",  "none",1  # global mean LW + latent + sensible
+ "ocean_model", "ssh_ga",              "ssh_ga",              "ocean_scalar_annual",  "all", "mean",  "none",1  # global mean ssh
+ "ocean_model", "precip_ga",           "precip_ga",           "ocean_scalar_annual",  "all", "mean",  "none",1  # global mean precip
 
 # -----------------------------------------------------------------------------------------
 # Monthly snapshots

--- a/ice_ocean_SIS2/OM4_025/diag_table.MOM6_spinup
+++ b/ice_ocean_SIS2/OM4_025/diag_table.MOM6_spinup
@@ -80,12 +80,12 @@
 #"ocean_model",   "pso",          "pso",              "ocean_month",         "all", "mean", "none",2
  "ocean_model",   "masscello",    "masscello",        "ocean_annual",        "all", "mean", "none",2
 #"ocean_model",   "masscello",    "masscello",        "ocean_month",         "all", "mean", "none",2
- "ocean_model",   "masso",        "masso",            "ocean_scalar_month",  "all", "mean", "none",2  # global sum masscello
- "ocean_model",   "masso",        "masso",            "ocean_scalar_annual", "all", "mean", "none",2  # global sum masscello
+ "ocean_model",   "masso",        "masso",            "ocean_scalar_month",  "all", "mean", "none",1  # global sum masscello
+ "ocean_model",   "masso",        "masso",            "ocean_scalar_annual", "all", "mean", "none",1  # global sum masscello
  "ocean_model",   "thkcello",     "thkcello",         "ocean_annual",        "all", "mean", "none",2  # Only needed in native space, a static field needs to be provided for CMIP6
 #"ocean_model",   "thkcello",     "thkcello",         "ocean_month",         "all", "mean", "none",2
- "ocean_model",   "volo",         "volo",             "ocean_scalar_month",  "all", "mean", "none",2  # global sum thkcello
- "ocean_model",   "volo",         "volo",             "ocean_scalar_annual", "all", "mean", "none",2  # global sum thkcello
+ "ocean_model",   "volo",         "volo",             "ocean_scalar_month",  "all", "mean", "none",1  # global sum thkcello
+ "ocean_model",   "volo",         "volo",             "ocean_scalar_annual", "all", "mean", "none",1  # global sum thkcello
  "ocean_model",   "zos",          "zos",              "ocean_annual",        "all", "mean", "none",2
  "ocean_model",   "zos",          "zos",              "ocean_month",         "all", "mean", "none",2
 #"ocean_model",   "zos",          "zos",              "ocean_daily",         "all", "mean", "none",2
@@ -97,17 +97,17 @@
  "ocean_model_z", "thetao",       "thetao",           "ocean_annual_z",      "all", "mean", "none",2  # if use pre-TEOS10
 #"ocean_model_z", "thetao",       "thetao",           "ocean_month_z",       "all", "mean", "none",2  # if use pre-TEOS10
  "ocean_model_z", "thetao_xyave", "thetao_xyave",     "ocean_annual_z",      "all", "mean", "none",2  # if use pre-TEOS10
- "ocean_model",   "thetaoga",     "thetaoga",         "ocean_scalar_month",  "all", "mean", "none",2  # global mean theta
- "ocean_model",   "thetaoga",     "thetaoga",         "ocean_scalar_annual", "all", "mean", "none",2  # global mean theta
+ "ocean_model",   "thetaoga",     "thetaoga",         "ocean_scalar_month",  "all", "mean", "none",1  # global mean theta
+ "ocean_model",   "thetaoga",     "thetaoga",         "ocean_scalar_annual", "all", "mean", "none",1  # global mean theta
 #"ocean_model",   "bigthetao",    "bigthetao",        "ocean_annual",        "all", "mean", "none",2  # if use TEOS10
 #"ocean_model",   "bigthetao",    "bigthetao",        "ocean_month",         "all", "mean", "none",2  # if use TEOS10
-#"ocean_model",   "bigthetaoga",  "bigthetaoga",      "ocean_scalar_annual", "all", "mean", "none",2  # if use TEOS10
-#"ocean_model",   "bigthetaoga",  "bigthetaoga",      "ocean_scalar_month",  "all", "mean", "none",2  # if use TEOS10
+#"ocean_model",   "bigthetaoga",  "bigthetaoga",      "ocean_scalar_annual", "all", "mean", "none",1  # if use TEOS10
+#"ocean_model",   "bigthetaoga",  "bigthetaoga",      "ocean_scalar_month",  "all", "mean", "none",1  # if use TEOS10
  "ocean_model",   "tos",          "tos",              "ocean_annual",        "all", "mean", "none",2
  "ocean_model",   "tos",          "tos",              "ocean_month",         "all", "mean", "none",2
 #"ocean_model",   "tos",          "tos",              "ocean_daily",         "all", "mean", "none",2
- "ocean_model",   "tosga",        "tosga",            "ocean_scalar_annual", "all", "mean", "none",2
- "ocean_model",   "tosga",        "tosga",            "ocean_scalar_month",  "all", "mean", "none",2
+ "ocean_model",   "tosga",        "tosga",            "ocean_scalar_annual", "all", "mean", "none",1
+ "ocean_model",   "tosga",        "tosga",            "ocean_scalar_month",  "all", "mean", "none",1
 #"ocean_model",   "tossq",        "tossq",            "ocean_annual",        "all", "mean", "none",2
 #"ocean_model",   "tossq",        "tossq",            "ocean_month",         "all", "mean", "none",2
 #"ocean_model",   "tossq",        "tossq",            "ocean_daily",         "all", "mean", "none",2
@@ -118,13 +118,13 @@
  "ocean_model_z", "so",           "so",               "ocean_annual_z",      "all", "mean", "none",2
 #"ocean_model_z", "so",           "so",               "ocean_month_z",       "all", "mean", "none",2
  "ocean_model_z", "so_xyave",     "so_xyave",         "ocean_annual_z",      "all", "mean", "none",2
- "ocean_model",   "soga",         "soga",             "ocean_scalar_annual", "all", "mean", "none",2
- "ocean_model",   "soga",         "soga",             "ocean_scalar_month",  "all", "mean", "none",2
+ "ocean_model",   "soga",         "soga",             "ocean_scalar_annual", "all", "mean", "none",1
+ "ocean_model",   "soga",         "soga",             "ocean_scalar_month",  "all", "mean", "none",1
  "ocean_model",   "sos",          "sos",              "ocean_annual",        "all", "mean", "none",2
  "ocean_model",   "sos",          "sos",              "ocean_month",         "all", "mean", "none",2
 #"ocean_model",   "sos",          "sos",              "ocean_daily",         "all", "mean", "none",2
- "ocean_model",   "sosga",        "sosga",            "ocean_scalar_annual", "all", "mean", "none",2
- "ocean_model",   "sosga",        "sosga",            "ocean_scalar_month",  "all", "mean", "none",2
+ "ocean_model",   "sosga",        "sosga",            "ocean_scalar_annual", "all", "mean", "none",1
+ "ocean_model",   "sosga",        "sosga",            "ocean_scalar_month",  "all", "mean", "none",1
 #"ocean_model",   "sossq",        "sossq",            "ocean_annual",        "all", "mean", "none",2
 #"ocean_model",   "sossq",        "sossq",            "ocean_month",         "all", "mean", "none",2
 #"ocean_model",   "sossq",        "sossq",            "ocean_daily",         "all", "mean", "none",2
@@ -546,30 +546,30 @@
 
 # -----------------------------------------------------------------------------------------
 # Monthly time series
- "ocean_model", "ave_wfo",             "ave_wfo",            "ocean_scalar_month",  "all", "mean",  "none",2  # global mean prcme
- "ocean_model", "ave_evs",             "ave_evs",            "ocean_scalar_month",  "all", "mean",  "none",2  # global mean evaporation
- "ocean_model", "ave_hfsso",           "ave_hfsso",          "ocean_scalar_month",  "all", "mean",  "none",2  # global mean sensible heat
- "ocean_model", "ave_rsntds",          "ave_rsntds",         "ocean_scalar_month",  "all", "mean",  "none",2  # global mean SW
- "ocean_model", "ave_rlntds",          "ave_rlntds",         "ocean_scalar_month",  "all", "mean",  "none",2  # global mean LW
- "ocean_model", "ave_hflso",           "ave_hflso",          "ocean_scalar_month",  "all", "mean",  "none",2  # global mean latent
- "ocean_model", "ave_hfds",            "ave_hfds",           "ocean_scalar_month",  "all", "mean",  "none",2  # global mean net heat surf
- "ocean_model", "net_heat_coupler_ga", "net_heat_coupler_ga","ocean_scalar_month",  "all", "mean",  "none",2  # global mean net heat coupl
- "ocean_model", "LwLatSens_ga",        "LwLatSens_ga",       "ocean_scalar_month",  "all", "mean",  "none",2  # global mean LW+lat+sens
- "ocean_model", "ssh_ga",              "ssh_ga",             "ocean_scalar_month",  "all", "mean",  "none",2  # global mean ssh
- "ocean_model", "precip_ga",           "precip_ga",          "ocean_scalar_month",  "all", "mean",  "none",2  # global mean precip
+ "ocean_model", "ave_wfo",             "ave_wfo",            "ocean_scalar_month",  "all", "mean",  "none",1  # global mean prcme
+ "ocean_model", "ave_evs",             "ave_evs",            "ocean_scalar_month",  "all", "mean",  "none",1  # global mean evaporation
+ "ocean_model", "ave_hfsso",           "ave_hfsso",          "ocean_scalar_month",  "all", "mean",  "none",1  # global mean sensible heat
+ "ocean_model", "ave_rsntds",          "ave_rsntds",         "ocean_scalar_month",  "all", "mean",  "none",1  # global mean SW
+ "ocean_model", "ave_rlntds",          "ave_rlntds",         "ocean_scalar_month",  "all", "mean",  "none",1  # global mean LW
+ "ocean_model", "ave_hflso",           "ave_hflso",          "ocean_scalar_month",  "all", "mean",  "none",1  # global mean latent
+ "ocean_model", "ave_hfds",            "ave_hfds",           "ocean_scalar_month",  "all", "mean",  "none",1  # global mean net heat surf
+ "ocean_model", "net_heat_coupler_ga", "net_heat_coupler_ga","ocean_scalar_month",  "all", "mean",  "none",1  # global mean net heat coupl
+ "ocean_model", "LwLatSens_ga",        "LwLatSens_ga",       "ocean_scalar_month",  "all", "mean",  "none",1  # global mean LW+lat+sens
+ "ocean_model", "ssh_ga",              "ssh_ga",             "ocean_scalar_month",  "all", "mean",  "none",1  # global mean ssh
+ "ocean_model", "precip_ga",           "precip_ga",          "ocean_scalar_month",  "all", "mean",  "none",1  # global mean precip
 
 # Annual time series
- "ocean_model", "ave_wfo",             "ave_wfo",             "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean prcme
- "ocean_model", "ave_evs",             "ave_evs",             "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean evaporation
- "ocean_model", "ave_hfsso",           "ave_hfsso",           "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean sensible heat
- "ocean_model", "ave_rsntds",          "ave_rsntds",          "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean SW
- "ocean_model", "ave_rlntds",          "ave_rlntds",          "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean LW
- "ocean_model", "ave_hflso",           "ave_hflso",           "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean latent
- "ocean_model", "ave_hfds",            "ave_hfds",            "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean net heat surface
- "ocean_model", "net_heat_coupler_ga", "net_heat_coupler_ga", "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean net heat coupler
- "ocean_model", "LwLatSens_ga",        "LwLatSens_ga",        "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean LW + latent + sensible
- "ocean_model", "ssh_ga",              "ssh_ga",              "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean ssh
- "ocean_model", "precip_ga",           "precip_ga",           "ocean_scalar_annual",  "all", "mean",  "none",2  # global mean precip
+ "ocean_model", "ave_wfo",             "ave_wfo",             "ocean_scalar_annual",  "all", "mean",  "none",1  # global mean prcme
+ "ocean_model", "ave_evs",             "ave_evs",             "ocean_scalar_annual",  "all", "mean",  "none",1  # global mean evaporation
+ "ocean_model", "ave_hfsso",           "ave_hfsso",           "ocean_scalar_annual",  "all", "mean",  "none",1  # global mean sensible heat
+ "ocean_model", "ave_rsntds",          "ave_rsntds",          "ocean_scalar_annual",  "all", "mean",  "none",1  # global mean SW
+ "ocean_model", "ave_rlntds",          "ave_rlntds",          "ocean_scalar_annual",  "all", "mean",  "none",1  # global mean LW
+ "ocean_model", "ave_hflso",           "ave_hflso",           "ocean_scalar_annual",  "all", "mean",  "none",1  # global mean latent
+ "ocean_model", "ave_hfds",            "ave_hfds",            "ocean_scalar_annual",  "all", "mean",  "none",1  # global mean net heat surface
+ "ocean_model", "net_heat_coupler_ga", "net_heat_coupler_ga", "ocean_scalar_annual",  "all", "mean",  "none",1  # global mean net heat coupler
+ "ocean_model", "LwLatSens_ga",        "LwLatSens_ga",        "ocean_scalar_annual",  "all", "mean",  "none",1  # global mean LW + latent + sensible
+ "ocean_model", "ssh_ga",              "ssh_ga",              "ocean_scalar_annual",  "all", "mean",  "none",1  # global mean ssh
+ "ocean_model", "precip_ga",           "precip_ga",           "ocean_scalar_annual",  "all", "mean",  "none",1  # global mean precip
 
 # -----------------------------------------------------------------------------------------
 # Monthly snapshots


### PR DESCRIPTION
  - updated diag_table to save all ocean_scalar*
    fields as double precision.
  - since these fields are single values, there will
    be little impact on data volumes.