### PR TITLE
SIS2: +Added ice_melt and fsitherm diagnostics

### DIFF
--- a/ice_ocean_SIS2/SIS2/SIS.available_diags
+++ b/ice_ocean_SIS2/SIS2/SIS.available_diags
@@ -139,6 +139,12 @@
 "ice_model", "SN2IC"  [Used]
     ! long_name: rate of snow to ice conversion
     ! units: kg/(m^2*s)
+"ice_model", "net_melt"  [Unused]
+    ! long_name: net mass flux from ice & snow to ocean due to melting & freezing
+    ! units: kg m-2 s-1
+"ice_model", "fsitherm"  [Unused]
+    ! long_name: water_flux_into_sea_water_due_to_sea_ice_thermodynamics
+    ! units: kg m-2 s-1
 "ice_model", "SIGI"  [Unused]
     ! long_name: first stress invariant
     ! units: none

--- a/ice_ocean_SIS2/SIS2_bergs_cgrid/SIS.available_diags
+++ b/ice_ocean_SIS2/SIS2_bergs_cgrid/SIS.available_diags
@@ -148,6 +148,12 @@
 "ice_model", "SN2IC"  [Used]
     ! long_name: rate of snow to ice conversion
     ! units: kg/(m^2*s)
+"ice_model", "net_melt"  [Unused]
+    ! long_name: net mass flux from ice & snow to ocean due to melting & freezing
+    ! units: kg m-2 s-1
+"ice_model", "fsitherm"  [Unused]
+    ! long_name: water_flux_into_sea_water_due_to_sea_ice_thermodynamics
+    ! units: kg m-2 s-1
 "ice_model", "SIGI"  [Unused]
     ! long_name: first stress invariant
     ! units: none

--- a/ice_ocean_SIS2/SIS2_cgrid/SIS.available_diags
+++ b/ice_ocean_SIS2/SIS2_cgrid/SIS.available_diags
@@ -139,6 +139,12 @@
 "ice_model", "SN2IC"  [Used]
     ! long_name: rate of snow to ice conversion
     ! units: kg/(m^2*s)
+"ice_model", "net_melt"  [Unused]
+    ! long_name: net mass flux from ice & snow to ocean due to melting & freezing
+    ! units: kg m-2 s-1
+"ice_model", "fsitherm"  [Unused]
+    ! long_name: water_flux_into_sea_water_due_to_sea_ice_thermodynamics
+    ! units: kg m-2 s-1
 "ice_model", "SIGI"  [Used]
     ! long_name: first stress invariant
     ! units: none


### PR DESCRIPTION
  Added new diagnostics of the net ice melt, using both the self-explanatory
name net_melt and the CMOR standard name fsitherm.  All answers are bitwise
identical, but there are new entries in the SIS.available_diags files.
NOAA-GFDL/SIS2@ff244b0 +Added ice_melt and fsitherm diagnostics