### PR TITLE
Removed Z_INIT_REMAP* overrides from OM4_05

### DIFF
--- a/ice_ocean_SIS2/OM4_025/MOM_saltrestore
+++ b/ice_ocean_SIS2/OM4_025/MOM_saltrestore
@@ -18,3 +18,6 @@ SRESTORE_AS_SFLUX = True        !   [Boolean] default = False
                                 ! flux instead of as a freshwater flux.
 MAX_DELTA_SRESTORE = 5.0        !   [PSU or g kg-1] default = 999.0
                                 ! The maximum salinity difference used in restoring terms.
+USE_NET_FW_ADJUSTMENT_SIGN_BUG = False !   [Boolean] default = True
+                                ! If true, use the wrong sign for the adjustment to
+                                ! the net fresh-water.

--- a/ice_ocean_SIS2/OM4_05/MOM_input
+++ b/ice_ocean_SIS2/OM4_05/MOM_input
@@ -281,11 +281,6 @@ REMAPPING_SCHEME = "PPM_H4"     ! default = "PLM"
                                 ! PPM_IH4     (3rd-order accurate)
                                 ! PQM_IH4IH3  (4th-order accurate)
                                 ! PQM_IH6IH5  (5th-order accurate)
-REMAP_AFTER_INITIALIZATION = False !   [Boolean] default = True
-                                ! If true, applies regridding and remapping immediately after
-                                ! initialization so that the state is ALE consistent. This is a
-                                ! legacy step and should not be needed if the initialization is
-                                ! consistent with the coordinate mode.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
@@ -316,9 +311,6 @@ Z_INIT_FILE_SALT_VAR = "s_an"   ! default = "salt"
                                 ! SALT_Z_INIT_FILE.
 Z_INIT_ALE_REMAPPING = True     !   [Boolean] default = False
                                 ! If True, then remap straight to model coordinate from file.
-Z_INIT_REMAP_GENERAL = True     !   [Boolean] default = False
-                                ! If false, only initializes to z* coordinates.
-                                ! If true, allows initialization directly to general coordinates.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 2             ! default = 1

--- a/ice_ocean_SIS2/OM4_05/MOM_saltrestore
+++ b/ice_ocean_SIS2/OM4_05/MOM_saltrestore
@@ -18,3 +18,6 @@ SRESTORE_AS_SFLUX = True        !   [Boolean] default = False
                                 ! flux instead of as a freshwater flux.
 MAX_DELTA_SRESTORE = 5.0        !   [PSU or g kg-1] default = 999.0
                                 ! The maximum salinity difference used in restoring terms.
+USE_NET_FW_ADJUSTMENT_SIGN_BUG = False !   [Boolean] default = True
+                                ! If true, use the wrong sign for the adjustment to
+                                ! the net fresh-water.


### PR DESCRIPTION
Edited MOM_input so that OM4_05 now uses the default
settings for:

  REMAP_AFTER_INITIALIZATION (default = True)
  Z_INIT_REMAP_GENERAL (default = False)