### PR TITLE
Use unit scaling type

### DIFF
--- a/coupled_AM2_LM3_SIS/CM2G63L/MOM_parameter_doc.all
+++ b/coupled_AM2_LM3_SIS/CM2G63L/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False

--- a/coupled_AM2_LM3_SIS/CM2G63L/MOM_parameter_doc.debugging
+++ b/coupled_AM2_LM3_SIS/CM2G63L/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/coupled_AM2_LM3_SIS/CM2G63L/MOM_parameter_doc.short
+++ b/coupled_AM2_LM3_SIS/CM2G63L/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
                                 ! If true, interface heights are diffused with a
                                 ! coefficient of KHTH.

--- a/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/MOM_parameter_doc.all
+++ b/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False

--- a/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/MOM_parameter_doc.debugging
+++ b/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/MOM_parameter_doc.short
+++ b/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
                                 ! If true, interface heights are diffused with a
                                 ! coefficient of KHTH.

--- a/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/MOM_parameter_doc.all
+++ b/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False

--- a/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/MOM_parameter_doc.debugging
+++ b/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/MOM_parameter_doc.short
+++ b/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
                                 ! If true, interface heights are diffused with a
                                 ! coefficient of KHTH.

--- a/ice_ocean_SIS2/Baltic/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/Baltic/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False

--- a/ice_ocean_SIS2/Baltic/MOM_parameter_doc.debugging
+++ b/ice_ocean_SIS2/Baltic/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ice_ocean_SIS2/Baltic/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/Baltic/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
                                 ! If true, interface heights are diffused with a
                                 ! coefficient of KHTH.

--- a/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False

--- a/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/MOM_parameter_doc.debugging
+++ b/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 USE_REGRIDDING = True           !   [Boolean] default = False
                                 ! If True, use the ALE algorithm (regridding/remapping).
                                 ! If False, use the layered isopycnal algorithm.

--- a/ice_ocean_SIS2/Baltic_OM4_025/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/Baltic_OM4_025/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False

--- a/ice_ocean_SIS2/Baltic_OM4_025/MOM_parameter_doc.debugging
+++ b/ice_ocean_SIS2/Baltic_OM4_025/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ice_ocean_SIS2/Baltic_OM4_025/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/Baltic_OM4_025/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 USE_REGRIDDING = True           !   [Boolean] default = False
                                 ! If True, use the ALE algorithm (regridding/remapping).
                                 ! If False, use the layered isopycnal algorithm.

--- a/ice_ocean_SIS2/Baltic_OM4_05/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/Baltic_OM4_05/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False

--- a/ice_ocean_SIS2/Baltic_OM4_05/MOM_parameter_doc.debugging
+++ b/ice_ocean_SIS2/Baltic_OM4_05/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ice_ocean_SIS2/Baltic_OM4_05/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/Baltic_OM4_05/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 USE_REGRIDDING = True           !   [Boolean] default = False
                                 ! If True, use the ALE algorithm (regridding/remapping).
                                 ! If False, use the layered isopycnal algorithm.

--- a/ice_ocean_SIS2/OM4_025/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/OM4_025/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False

--- a/ice_ocean_SIS2/OM4_025/MOM_parameter_doc.debugging
+++ b/ice_ocean_SIS2/OM4_025/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ice_ocean_SIS2/OM4_025/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/OM4_025/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 USE_REGRIDDING = True           !   [Boolean] default = False
                                 ! If True, use the ALE algorithm (regridding/remapping).
                                 ! If False, use the layered isopycnal algorithm.

--- a/ice_ocean_SIS2/OM4_05/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/OM4_05/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False

--- a/ice_ocean_SIS2/OM4_05/MOM_parameter_doc.debugging
+++ b/ice_ocean_SIS2/OM4_05/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ice_ocean_SIS2/OM4_05/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/OM4_05/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 USE_REGRIDDING = True           !   [Boolean] default = False
                                 ! If True, use the ALE algorithm (regridding/remapping).
                                 ! If False, use the layered isopycnal algorithm.

--- a/ice_ocean_SIS2/SIS2/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/SIS2/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False

--- a/ice_ocean_SIS2/SIS2/MOM_parameter_doc.debugging
+++ b/ice_ocean_SIS2/SIS2/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ice_ocean_SIS2/SIS2/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/SIS2/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
                                 ! If true, interface heights are diffused with a
                                 ! coefficient of KHTH.

--- a/ice_ocean_SIS2/SIS2_bergs_cgrid/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/SIS2_bergs_cgrid/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False

--- a/ice_ocean_SIS2/SIS2_bergs_cgrid/MOM_parameter_doc.debugging
+++ b/ice_ocean_SIS2/SIS2_bergs_cgrid/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ice_ocean_SIS2/SIS2_bergs_cgrid/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/SIS2_bergs_cgrid/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
                                 ! If true, interface heights are diffused with a
                                 ! coefficient of KHTH.

--- a/ice_ocean_SIS2/SIS2_cgrid/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/SIS2_cgrid/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False

--- a/ice_ocean_SIS2/SIS2_cgrid/MOM_parameter_doc.debugging
+++ b/ice_ocean_SIS2/SIS2_cgrid/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ice_ocean_SIS2/SIS2_cgrid/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/SIS2_cgrid/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
                                 ! If true, interface heights are diffused with a
                                 ! coefficient of KHTH.

--- a/land_ice_ocean_LM3_SIS2/OM_360x320_C180/MOM_parameter_doc.all
+++ b/land_ice_ocean_LM3_SIS2/OM_360x320_C180/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False

--- a/land_ice_ocean_LM3_SIS2/OM_360x320_C180/MOM_parameter_doc.debugging
+++ b/land_ice_ocean_LM3_SIS2/OM_360x320_C180/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/land_ice_ocean_LM3_SIS2/OM_360x320_C180/MOM_parameter_doc.short
+++ b/land_ice_ocean_LM3_SIS2/OM_360x320_C180/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 DIABATIC_FIRST = True           !   [Boolean] default = False
                                 ! If true, apply diabatic and thermodynamic processes,
                                 ! including buoyancy forcing and mass gain or loss,

--- a/ocean_only/CVmix_SCM_tests/cooling_only/BML/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/BML/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 USE_RK2 = False                 !   [Boolean] default = False

--- a/ocean_only/CVmix_SCM_tests/cooling_only/BML/MOM_parameter_doc.debugging
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/BML/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/CVmix_SCM_tests/cooling_only/BML/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/BML/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 DT = 1200.0                     !   [s]

--- a/ocean_only/CVmix_SCM_tests/cooling_only/EPBL/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/EPBL/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 USE_RK2 = False                 !   [Boolean] default = False

--- a/ocean_only/CVmix_SCM_tests/cooling_only/EPBL/MOM_parameter_doc.debugging
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/EPBL/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/CVmix_SCM_tests/cooling_only/EPBL/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/EPBL/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 USE_REGRIDDING = True           !   [Boolean] default = False

--- a/ocean_only/CVmix_SCM_tests/cooling_only/KPP/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/KPP/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 USE_RK2 = False                 !   [Boolean] default = False

--- a/ocean_only/CVmix_SCM_tests/cooling_only/KPP/MOM_parameter_doc.debugging
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/KPP/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/CVmix_SCM_tests/cooling_only/KPP/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/KPP/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 USE_REGRIDDING = True           !   [Boolean] default = False

--- a/ocean_only/CVmix_SCM_tests/mech_only/BML/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/mech_only/BML/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 USE_RK2 = False                 !   [Boolean] default = False

--- a/ocean_only/CVmix_SCM_tests/mech_only/BML/MOM_parameter_doc.debugging
+++ b/ocean_only/CVmix_SCM_tests/mech_only/BML/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/CVmix_SCM_tests/mech_only/BML/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/mech_only/BML/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 DT = 1200.0                     !   [s]

--- a/ocean_only/CVmix_SCM_tests/mech_only/EPBL/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/mech_only/EPBL/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 USE_RK2 = False                 !   [Boolean] default = False

--- a/ocean_only/CVmix_SCM_tests/mech_only/EPBL/MOM_parameter_doc.debugging
+++ b/ocean_only/CVmix_SCM_tests/mech_only/EPBL/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/CVmix_SCM_tests/mech_only/EPBL/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/mech_only/EPBL/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 USE_REGRIDDING = True           !   [Boolean] default = False

--- a/ocean_only/CVmix_SCM_tests/mech_only/KPP/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/mech_only/KPP/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 USE_RK2 = False                 !   [Boolean] default = False

--- a/ocean_only/CVmix_SCM_tests/mech_only/KPP/MOM_parameter_doc.debugging
+++ b/ocean_only/CVmix_SCM_tests/mech_only/KPP/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/CVmix_SCM_tests/mech_only/KPP/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/mech_only/KPP/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 USE_REGRIDDING = True           !   [Boolean] default = False

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/BML/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/BML/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 USE_RK2 = False                 !   [Boolean] default = False

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/BML/MOM_parameter_doc.debugging
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/BML/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/BML/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/BML/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 DT = 1200.0                     !   [s]

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/EPBL/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/EPBL/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 USE_RK2 = False                 !   [Boolean] default = False

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/EPBL/MOM_parameter_doc.debugging
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/EPBL/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/EPBL/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/EPBL/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 USE_REGRIDDING = True           !   [Boolean] default = False

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/KPP/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/KPP/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 USE_RK2 = False                 !   [Boolean] default = False

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/KPP/MOM_parameter_doc.debugging
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/KPP/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/KPP/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/KPP/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 USE_REGRIDDING = True           !   [Boolean] default = False

--- a/ocean_only/CVmix_SCM_tests/wind_only/BML/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/wind_only/BML/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 USE_RK2 = False                 !   [Boolean] default = False

--- a/ocean_only/CVmix_SCM_tests/wind_only/BML/MOM_parameter_doc.debugging
+++ b/ocean_only/CVmix_SCM_tests/wind_only/BML/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/CVmix_SCM_tests/wind_only/BML/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/wind_only/BML/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 DT = 1200.0                     !   [s]

--- a/ocean_only/CVmix_SCM_tests/wind_only/EPBL/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/wind_only/EPBL/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 USE_RK2 = False                 !   [Boolean] default = False

--- a/ocean_only/CVmix_SCM_tests/wind_only/EPBL/MOM_parameter_doc.debugging
+++ b/ocean_only/CVmix_SCM_tests/wind_only/EPBL/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/CVmix_SCM_tests/wind_only/EPBL/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/wind_only/EPBL/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 USE_REGRIDDING = True           !   [Boolean] default = False

--- a/ocean_only/CVmix_SCM_tests/wind_only/KPP/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/wind_only/KPP/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 USE_RK2 = False                 !   [Boolean] default = False

--- a/ocean_only/CVmix_SCM_tests/wind_only/KPP/MOM_parameter_doc.debugging
+++ b/ocean_only/CVmix_SCM_tests/wind_only/KPP/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/CVmix_SCM_tests/wind_only/KPP/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/wind_only/KPP/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 USE_REGRIDDING = True           !   [Boolean] default = False

--- a/ocean_only/DOME/MOM_parameter_doc.all
+++ b/ocean_only/DOME/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False

--- a/ocean_only/DOME/MOM_parameter_doc.debugging
+++ b/ocean_only/DOME/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = ""               ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/DOME/MOM_parameter_doc.short
+++ b/ocean_only/DOME/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 ENABLE_THERMODYNAMICS = False   !   [Boolean] default = True
                                 ! If true, Temperature and salinity are used as state
                                 ! variables.

--- a/ocean_only/Phillips_2layer/MOM_parameter_doc.all
+++ b/ocean_only/Phillips_2layer/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False

--- a/ocean_only/Phillips_2layer/MOM_parameter_doc.debugging
+++ b/ocean_only/Phillips_2layer/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = ""               ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/Phillips_2layer/MOM_parameter_doc.short
+++ b/ocean_only/Phillips_2layer/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 ENABLE_THERMODYNAMICS = False   !   [Boolean] default = True
                                 ! If true, Temperature and salinity are used as state
                                 ! variables.

--- a/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.all
+++ b/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 USE_RK2 = False                 !   [Boolean] default = False

--- a/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.debugging
+++ b/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.short
+++ b/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 USE_REGRIDDING = True           !   [Boolean] default = False

--- a/ocean_only/adjustment2d/layer/MOM_parameter_doc.all
+++ b/ocean_only/adjustment2d/layer/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False

--- a/ocean_only/adjustment2d/layer/MOM_parameter_doc.debugging
+++ b/ocean_only/adjustment2d/layer/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/adjustment2d/layer/MOM_parameter_doc.short
+++ b/ocean_only/adjustment2d/layer/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 BULKMIXEDLAYER = False          !   [Boolean] default = True
                                 ! If true, use a Kraus-Turner-like bulk mixed layer
                                 ! with transitional buffer layers.  Layers 1 through

--- a/ocean_only/adjustment2d/rho/MOM_parameter_doc.all
+++ b/ocean_only/adjustment2d/rho/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False

--- a/ocean_only/adjustment2d/rho/MOM_parameter_doc.debugging
+++ b/ocean_only/adjustment2d/rho/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/adjustment2d/rho/MOM_parameter_doc.short
+++ b/ocean_only/adjustment2d/rho/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 USE_REGRIDDING = True           !   [Boolean] default = False
                                 ! If True, use the ALE algorithm (regridding/remapping).
                                 ! If False, use the layered isopycnal algorithm.

--- a/ocean_only/adjustment2d/z/MOM_parameter_doc.all
+++ b/ocean_only/adjustment2d/z/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False

--- a/ocean_only/adjustment2d/z/MOM_parameter_doc.debugging
+++ b/ocean_only/adjustment2d/z/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/adjustment2d/z/MOM_parameter_doc.short
+++ b/ocean_only/adjustment2d/z/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 USE_REGRIDDING = True           !   [Boolean] default = False
                                 ! If True, use the ALE algorithm (regridding/remapping).
                                 ! If False, use the layered isopycnal algorithm.

--- a/ocean_only/benchmark/MOM_parameter_doc.all
+++ b/ocean_only/benchmark/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False

--- a/ocean_only/benchmark/MOM_parameter_doc.debugging
+++ b/ocean_only/benchmark/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/benchmark/MOM_parameter_doc.short
+++ b/ocean_only/benchmark/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
                                 ! If true, interface heights are diffused with a
                                 ! coefficient of KHTH.

--- a/ocean_only/circle_obcs/MOM_parameter_doc.all
+++ b/ocean_only/circle_obcs/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False

--- a/ocean_only/circle_obcs/MOM_parameter_doc.debugging
+++ b/ocean_only/circle_obcs/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/circle_obcs/MOM_parameter_doc.short
+++ b/ocean_only/circle_obcs/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 ENABLE_THERMODYNAMICS = False   !   [Boolean] default = True
                                 ! If true, Temperature and salinity are used as state
                                 ! variables.

--- a/ocean_only/double_gyre/MOM_parameter_doc.all
+++ b/ocean_only/double_gyre/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False

--- a/ocean_only/double_gyre/MOM_parameter_doc.debugging
+++ b/ocean_only/double_gyre/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = ""               ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/double_gyre/MOM_parameter_doc.short
+++ b/ocean_only/double_gyre/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 ENABLE_THERMODYNAMICS = False   !   [Boolean] default = True
                                 ! If true, Temperature and salinity are used as state
                                 ! variables.

--- a/ocean_only/external_gwave/MOM_parameter_doc.all
+++ b/ocean_only/external_gwave/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False

--- a/ocean_only/external_gwave/MOM_parameter_doc.debugging
+++ b/ocean_only/external_gwave/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/external_gwave/MOM_parameter_doc.short
+++ b/ocean_only/external_gwave/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 BULKMIXEDLAYER = False          !   [Boolean] default = True
                                 ! If true, use a Kraus-Turner-like bulk mixed layer
                                 ! with transitional buffer layers.  Layers 1 through

--- a/ocean_only/flow_downslope/layer/MOM_parameter_doc.all
+++ b/ocean_only/flow_downslope/layer/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False

--- a/ocean_only/flow_downslope/layer/MOM_parameter_doc.debugging
+++ b/ocean_only/flow_downslope/layer/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/flow_downslope/layer/MOM_parameter_doc.short
+++ b/ocean_only/flow_downslope/layer/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 BULKMIXEDLAYER = False          !   [Boolean] default = True
                                 ! If true, use a Kraus-Turner-like bulk mixed layer
                                 ! with transitional buffer layers.  Layers 1 through

--- a/ocean_only/flow_downslope/rho/MOM_parameter_doc.all
+++ b/ocean_only/flow_downslope/rho/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False

--- a/ocean_only/flow_downslope/rho/MOM_parameter_doc.debugging
+++ b/ocean_only/flow_downslope/rho/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/flow_downslope/rho/MOM_parameter_doc.short
+++ b/ocean_only/flow_downslope/rho/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 USE_REGRIDDING = True           !   [Boolean] default = False
                                 ! If True, use the ALE algorithm (regridding/remapping).
                                 ! If False, use the layered isopycnal algorithm.

--- a/ocean_only/flow_downslope/sigma/MOM_parameter_doc.all
+++ b/ocean_only/flow_downslope/sigma/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False

--- a/ocean_only/flow_downslope/sigma/MOM_parameter_doc.debugging
+++ b/ocean_only/flow_downslope/sigma/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/flow_downslope/sigma/MOM_parameter_doc.short
+++ b/ocean_only/flow_downslope/sigma/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 USE_REGRIDDING = True           !   [Boolean] default = False
                                 ! If True, use the ALE algorithm (regridding/remapping).
                                 ! If False, use the layered isopycnal algorithm.

--- a/ocean_only/flow_downslope/z/MOM_parameter_doc.all
+++ b/ocean_only/flow_downslope/z/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False

--- a/ocean_only/flow_downslope/z/MOM_parameter_doc.debugging
+++ b/ocean_only/flow_downslope/z/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/flow_downslope/z/MOM_parameter_doc.short
+++ b/ocean_only/flow_downslope/z/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 USE_REGRIDDING = True           !   [Boolean] default = False
                                 ! If True, use the ALE algorithm (regridding/remapping).
                                 ! If False, use the layered isopycnal algorithm.

--- a/ocean_only/global_ALE/hycom/MOM_parameter_doc.all
+++ b/ocean_only/global_ALE/hycom/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False

--- a/ocean_only/global_ALE/hycom/MOM_parameter_doc.debugging
+++ b/ocean_only/global_ALE/hycom/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/global_ALE/hycom/MOM_parameter_doc.short
+++ b/ocean_only/global_ALE/hycom/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 DIABATIC_FIRST = True           !   [Boolean] default = False
                                 ! If true, apply diabatic and thermodynamic processes,
                                 ! including buoyancy forcing and mass gain or loss,

--- a/ocean_only/global_ALE/layer/MOM_parameter_doc.all
+++ b/ocean_only/global_ALE/layer/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False

--- a/ocean_only/global_ALE/layer/MOM_parameter_doc.debugging
+++ b/ocean_only/global_ALE/layer/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/global_ALE/layer/MOM_parameter_doc.short
+++ b/ocean_only/global_ALE/layer/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 DIABATIC_FIRST = True           !   [Boolean] default = False
                                 ! If true, apply diabatic and thermodynamic processes,
                                 ! including buoyancy forcing and mass gain or loss,

--- a/ocean_only/global_ALE/z/MOM_parameter_doc.all
+++ b/ocean_only/global_ALE/z/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False

--- a/ocean_only/global_ALE/z/MOM_parameter_doc.debugging
+++ b/ocean_only/global_ALE/z/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/global_ALE/z/MOM_parameter_doc.short
+++ b/ocean_only/global_ALE/z/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 DIABATIC_FIRST = True           !   [Boolean] default = False
                                 ! If true, apply diabatic and thermodynamic processes,
                                 ! including buoyancy forcing and mass gain or loss,

--- a/ocean_only/lock_exchange/MOM_parameter_doc.all
+++ b/ocean_only/lock_exchange/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False

--- a/ocean_only/lock_exchange/MOM_parameter_doc.debugging
+++ b/ocean_only/lock_exchange/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/lock_exchange/MOM_parameter_doc.short
+++ b/ocean_only/lock_exchange/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 BULKMIXEDLAYER = False          !   [Boolean] default = True
                                 ! If true, use a Kraus-Turner-like bulk mixed layer
                                 ! with transitional buffer layers.  Layers 1 through

--- a/ocean_only/mixed_layer_restrat_2d/MOM_parameter_doc.all
+++ b/ocean_only/mixed_layer_restrat_2d/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False

--- a/ocean_only/mixed_layer_restrat_2d/MOM_parameter_doc.debugging
+++ b/ocean_only/mixed_layer_restrat_2d/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/mixed_layer_restrat_2d/MOM_parameter_doc.short
+++ b/ocean_only/mixed_layer_restrat_2d/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 USE_REGRIDDING = True           !   [Boolean] default = False
                                 ! If True, use the ALE algorithm (regridding/remapping).
                                 ! If False, use the layered isopycnal algorithm.

--- a/ocean_only/nonBous_global/MOM_parameter_doc.all
+++ b/ocean_only/nonBous_global/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False

--- a/ocean_only/nonBous_global/MOM_parameter_doc.debugging
+++ b/ocean_only/nonBous_global/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/nonBous_global/MOM_parameter_doc.short
+++ b/ocean_only/nonBous_global/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
                                 ! If true, interface heights are diffused with a
                                 ! coefficient of KHTH.

--- a/ocean_only/resting/layer/MOM_parameter_doc.all
+++ b/ocean_only/resting/layer/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False

--- a/ocean_only/resting/layer/MOM_parameter_doc.debugging
+++ b/ocean_only/resting/layer/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/resting/layer/MOM_parameter_doc.short
+++ b/ocean_only/resting/layer/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 BULKMIXEDLAYER = False          !   [Boolean] default = True
                                 ! If true, use a Kraus-Turner-like bulk mixed layer
                                 ! with transitional buffer layers.  Layers 1 through

--- a/ocean_only/resting/z/MOM_parameter_doc.all
+++ b/ocean_only/resting/z/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False

--- a/ocean_only/resting/z/MOM_parameter_doc.debugging
+++ b/ocean_only/resting/z/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/resting/z/MOM_parameter_doc.short
+++ b/ocean_only/resting/z/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 USE_REGRIDDING = True           !   [Boolean] default = False
                                 ! If True, use the ALE algorithm (regridding/remapping).
                                 ! If False, use the layered isopycnal algorithm.

--- a/ocean_only/seamount/layer/MOM_parameter_doc.all
+++ b/ocean_only/seamount/layer/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False

--- a/ocean_only/seamount/layer/MOM_parameter_doc.debugging
+++ b/ocean_only/seamount/layer/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/seamount/layer/MOM_parameter_doc.short
+++ b/ocean_only/seamount/layer/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 BULKMIXEDLAYER = False          !   [Boolean] default = True
                                 ! If true, use a Kraus-Turner-like bulk mixed layer
                                 ! with transitional buffer layers.  Layers 1 through

--- a/ocean_only/seamount/rho/MOM_parameter_doc.all
+++ b/ocean_only/seamount/rho/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False

--- a/ocean_only/seamount/rho/MOM_parameter_doc.debugging
+++ b/ocean_only/seamount/rho/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/seamount/rho/MOM_parameter_doc.short
+++ b/ocean_only/seamount/rho/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 USE_REGRIDDING = True           !   [Boolean] default = False
                                 ! If True, use the ALE algorithm (regridding/remapping).
                                 ! If False, use the layered isopycnal algorithm.

--- a/ocean_only/seamount/sigma/MOM_parameter_doc.all
+++ b/ocean_only/seamount/sigma/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False

--- a/ocean_only/seamount/sigma/MOM_parameter_doc.debugging
+++ b/ocean_only/seamount/sigma/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/seamount/sigma/MOM_parameter_doc.short
+++ b/ocean_only/seamount/sigma/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 USE_REGRIDDING = True           !   [Boolean] default = False
                                 ! If True, use the ALE algorithm (regridding/remapping).
                                 ! If False, use the layered isopycnal algorithm.

--- a/ocean_only/seamount/z/MOM_parameter_doc.all
+++ b/ocean_only/seamount/z/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False

--- a/ocean_only/seamount/z/MOM_parameter_doc.debugging
+++ b/ocean_only/seamount/z/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/seamount/z/MOM_parameter_doc.short
+++ b/ocean_only/seamount/z/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 USE_REGRIDDING = True           !   [Boolean] default = False
                                 ! If True, use the ALE algorithm (regridding/remapping).
                                 ! If False, use the layered isopycnal algorithm.

--- a/ocean_only/single_column/BML/MOM_parameter_doc.all
+++ b/ocean_only/single_column/BML/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 USE_RK2 = False                 !   [Boolean] default = False

--- a/ocean_only/single_column/BML/MOM_parameter_doc.debugging
+++ b/ocean_only/single_column/BML/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/single_column/BML/MOM_parameter_doc.short
+++ b/ocean_only/single_column/BML/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 DT = 3600.0                     !   [s]

--- a/ocean_only/single_column/EPBL/MOM_parameter_doc.all
+++ b/ocean_only/single_column/EPBL/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 USE_RK2 = False                 !   [Boolean] default = False

--- a/ocean_only/single_column/EPBL/MOM_parameter_doc.debugging
+++ b/ocean_only/single_column/EPBL/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/single_column/EPBL/MOM_parameter_doc.short
+++ b/ocean_only/single_column/EPBL/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 USE_REGRIDDING = True           !   [Boolean] default = False

--- a/ocean_only/single_column/KPP/MOM_parameter_doc.all
+++ b/ocean_only/single_column/KPP/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 USE_RK2 = False                 !   [Boolean] default = False

--- a/ocean_only/single_column/KPP/MOM_parameter_doc.debugging
+++ b/ocean_only/single_column/KPP/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/single_column/KPP/MOM_parameter_doc.short
+++ b/ocean_only/single_column/KPP/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 USE_REGRIDDING = True           !   [Boolean] default = False

--- a/ocean_only/sloshing/layer/MOM_parameter_doc.all
+++ b/ocean_only/sloshing/layer/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False

--- a/ocean_only/sloshing/layer/MOM_parameter_doc.debugging
+++ b/ocean_only/sloshing/layer/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/sloshing/layer/MOM_parameter_doc.short
+++ b/ocean_only/sloshing/layer/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 BULKMIXEDLAYER = False          !   [Boolean] default = True
                                 ! If true, use a Kraus-Turner-like bulk mixed layer
                                 ! with transitional buffer layers.  Layers 1 through

--- a/ocean_only/sloshing/rho/MOM_parameter_doc.all
+++ b/ocean_only/sloshing/rho/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False

--- a/ocean_only/sloshing/rho/MOM_parameter_doc.debugging
+++ b/ocean_only/sloshing/rho/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/sloshing/rho/MOM_parameter_doc.short
+++ b/ocean_only/sloshing/rho/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 USE_REGRIDDING = True           !   [Boolean] default = False
                                 ! If True, use the ALE algorithm (regridding/remapping).
                                 ! If False, use the layered isopycnal algorithm.

--- a/ocean_only/sloshing/z/MOM_parameter_doc.all
+++ b/ocean_only/sloshing/z/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False

--- a/ocean_only/sloshing/z/MOM_parameter_doc.debugging
+++ b/ocean_only/sloshing/z/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/sloshing/z/MOM_parameter_doc.short
+++ b/ocean_only/sloshing/z/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 USE_REGRIDDING = True           !   [Boolean] default = False
                                 ! If True, use the ALE algorithm (regridding/remapping).
                                 ! If False, use the layered isopycnal algorithm.

--- a/ocean_only/torus_advection_test/MOM_parameter_doc.all
+++ b/ocean_only/torus_advection_test/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False

--- a/ocean_only/torus_advection_test/MOM_parameter_doc.debugging
+++ b/ocean_only/torus_advection_test/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/torus_advection_test/MOM_parameter_doc.short
+++ b/ocean_only/torus_advection_test/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 BULKMIXEDLAYER = False          !   [Boolean] default = True
                                 ! If true, use a Kraus-Turner-like bulk mixed layer
                                 ! with transitional buffer layers.  Layers 1 through

--- a/ocean_only/tracer_mixing/rho/MOM_parameter_doc.all
+++ b/ocean_only/tracer_mixing/rho/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False

--- a/ocean_only/tracer_mixing/rho/MOM_parameter_doc.debugging
+++ b/ocean_only/tracer_mixing/rho/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/tracer_mixing/rho/MOM_parameter_doc.short
+++ b/ocean_only/tracer_mixing/rho/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 USE_REGRIDDING = True           !   [Boolean] default = False
                                 ! If True, use the ALE algorithm (regridding/remapping).
                                 ! If False, use the layered isopycnal algorithm.

--- a/ocean_only/tracer_mixing/z/MOM_parameter_doc.all
+++ b/ocean_only/tracer_mixing/z/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = True                    !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 CALC_RHO_FOR_SEA_LEVEL = False  !   [Boolean] default = False

--- a/ocean_only/tracer_mixing/z/MOM_parameter_doc.debugging
+++ b/ocean_only/tracer_mixing/z/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = False           !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = "U_velocity_truncations" ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/tracer_mixing/z/MOM_parameter_doc.short
+++ b/ocean_only/tracer_mixing/z/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 USE_REGRIDDING = True           !   [Boolean] default = False
                                 ! If True, use the ALE algorithm (regridding/remapping).
                                 ! If False, use the layered isopycnal algorithm.

--- a/ocean_only/unit_tests/MOM_parameter_doc.all
+++ b/ocean_only/unit_tests/MOM_parameter_doc.all
@@ -1,6 +1,9 @@
 ! This file was written by the model and records all non-layout or debugging parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 USE_RK2 = False                 !   [Boolean] default = False

--- a/ocean_only/unit_tests/MOM_parameter_doc.debugging
+++ b/ocean_only/unit_tests/MOM_parameter_doc.debugging
@@ -6,6 +6,15 @@ VERBOSITY = 2                   ! default = 2
                                 !   9 = All)
 DO_UNIT_TESTS = True            !   [Boolean] default = False
                                 ! If True, exercises unit tests at model start up.
+Z_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
+L_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of lateral distances.  Valid values range from -300 to 300.
+T_RESCALE_POWER = 0             !   [nondim] default = 0
+                                ! An integer power of 2 that is used to rescale the model's
+                                ! intenal units of time.  Valid values range from -300 to 300.
 DEBUG = False                   !   [Boolean] default = False
                                 ! If true, write out verbose debugging data.
 DEBUG_TRUNCATIONS = False       !   [Boolean] default = False
@@ -20,9 +29,6 @@ DEBUG_REDUNDANT = False         !   [Boolean] default = False
 H_RESCALE_POWER = 0             !   [nondim] default = 0
                                 ! An integer power of 2 that is used to rescale the model's
                                 ! intenal units of thickness.  Valid values range from -300 to 300.
-Z_RESCALE_POWER = 0             !   [nondim] default = 0
-                                ! An integer power of 2 that is used to rescale the model's
-                                ! intenal units of depths and heights.  Valid values range from -300 to 300.
 U_TRUNC_FILE = ""               ! default = ""
                                 ! The absolute path to a file into which the accelerations
                                 ! leading to zonal velocity truncations are written.

--- a/ocean_only/unit_tests/MOM_parameter_doc.short
+++ b/ocean_only/unit_tests/MOM_parameter_doc.short
@@ -1,6 +1,9 @@
 ! This file was written by the model and records the non-default parameters used at run-time.
 
 ! === module MOM ===
+
+! === module MOM_unit_scaling ===
+! Parameters for doing unit scaling of variables.
 SPLIT = False                   !   [Boolean] default = True
                                 ! Use the split time stepping if true.
 ENABLE_THERMODYNAMICS = False   !   [Boolean] default = True


### PR DESCRIPTION
This MOM6-examples PR updates the MOM_parameter_doc files in conjunction with MOM6 PR https://github.com/NOAA-GFDL/MOM6/pull/875

  Added a new unit_scale_type and related module to handle dimensional unit
rescaling, and use it throughout the MOM6 code for rescaling Z_to_m and m_to_Z.
This involves numerous additional arguments and widespread changes.  There are
two new runtime debugging parameters and a third moved from the MOM_verticalGrid
module.  All answers are bitwise identical, but there are updates to all of the
MOM_parameter_doc files.  The list of MOM6 commits in this PR include:
- NOAA-GFDL/MOM6@e1136e0 Rescale HMIX_SFC_PROP via get_param
- NOAA-GFDL/MOM6@fa04b52 Corrected openMP directives
- NOAA-GFDL/MOM6@04069b7 +Pass unit_scale_type argument to step_MOM_thermo
- NOAA-GFDL/MOM6@f8384ef +Replace GV%Z_to_m with US%Z_to_m
- NOAA-GFDL/MOM6@533d495 +Replace GV%m_to_Z with US%m_to_Z
- NOAA-GFDL/MOM6@9b542c3 +Add MOM_unit_scaling module