### PR TITLE
Document user code parameters

### DIFF
--- a/ocean_only/benchmark/MOM_parameter_doc.all
+++ b/ocean_only/benchmark/MOM_parameter_doc.all
@@ -465,6 +465,12 @@ THICKNESS_CONFIG = "benchmark"  !
                                 !     soliton - Equatorial Rossby soliton.
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
+
+! === module benchmark_initialize_thickness ===
+BENCHMARK_ML_DEPTH_IC = 50.0    !   [m] default = 50.0
+                                ! Initial mixed layer depth in the benchmark test case.
+BENCHMARK_THERMOCLINE_SCALE = 500.0 !   [m] default = 500.0
+                                ! Initial thermocline depth scale in the benchmark test case.
 TS_CONFIG = "benchmark"         !
                                 ! A string that determines how the initial tempertures
                                 ! and salinities are specified for a new run:

--- a/ocean_only/benchmark/MOM_parameter_doc.short
+++ b/ocean_only/benchmark/MOM_parameter_doc.short
@@ -199,6 +199,8 @@ THICKNESS_CONFIG = "benchmark"  !
                                 !     soliton - Equatorial Rossby soliton.
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
+
+! === module benchmark_initialize_thickness ===
 TS_CONFIG = "benchmark"         !
                                 ! A string that determines how the initial tempertures
                                 ! and salinities are specified for a new run:

--- a/ocean_only/circle_obcs/MOM_parameter_doc.all
+++ b/ocean_only/circle_obcs/MOM_parameter_doc.all
@@ -470,6 +470,9 @@ DISK_RADIUS = 24.0              !   [kilometers]
 DISK_X_OFFSET = 0.0             !   [kilometers] default = 0.0
                                 ! The x-offset of the initially elevated disk in the
                                 ! circle_obcs test case.
+DISK_IC_AMPLITUDE = 5.0         !   [m] default = 5.0
+                                ! Initial amplitude of interface height displacements
+                                ! in the circle_obcs test case.
 VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 ! A string that determines how the initial velocities
                                 ! are specified for a new run:

--- a/ocean_only/seamount/layer/MOM_parameter_doc.all
+++ b/ocean_only/seamount/layer/MOM_parameter_doc.all
@@ -459,6 +459,9 @@ THICKNESS_CONFIG = "seamount"   !
                                 !     USER - call a user modified routine.
 MIN_THICKNESS = 0.1             !   [m] default = 0.001
                                 ! Minimum thickness for layer
+INTERFACE_IC_QUANTA = 2048.0    !   [m-1] default = 2048.0
+                                ! The granularity of initial interface height values
+                                ! per meter, to avoid sensivity to order-of-arithmetic changes.
 TS_CONFIG = "seamount"          !
                                 ! A string that determines how the initial tempertures
                                 ! and salinities are specified for a new run:

--- a/ocean_only/seamount/rho/MOM_parameter_doc.all
+++ b/ocean_only/seamount/rho/MOM_parameter_doc.all
@@ -586,6 +586,9 @@ THICKNESS_CONFIG = "seamount"   !
                                 !     soliton - Equatorial Rossby soliton.
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
+INTERFACE_IC_QUANTA = 2048.0    !   [m-1] default = 2048.0
+                                ! The granularity of initial interface height values
+                                ! per meter, to avoid sensivity to order-of-arithmetic changes.
 TS_CONFIG = "seamount"          !
                                 ! A string that determines how the initial tempertures
                                 ! and salinities are specified for a new run:

--- a/ocean_only/sloshing/layer/MOM_parameter_doc.all
+++ b/ocean_only/sloshing/layer/MOM_parameter_doc.all
@@ -434,6 +434,13 @@ THICKNESS_CONFIG = "sloshing"   !
                                 !     soliton - Equatorial Rossby soliton.
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
+
+! === module sloshing_initialization ===
+SLOSHING_IC_AMPLITUDE = 75.0    !   [m] default = 75.0
+                                ! Initial amplitude of sloshing internal interface height
+                                ! displacements it the sloshing test case.
+SLOSHING_IC_BUG = True          !   [Boolean] default = True
+                                ! If true, use code with a bug to set the sloshing initial conditions.
 TS_CONFIG = "sloshing"          !
                                 ! A string that determines how the initial tempertures
                                 ! and salinities are specified for a new run:

--- a/ocean_only/sloshing/layer/MOM_parameter_doc.short
+++ b/ocean_only/sloshing/layer/MOM_parameter_doc.short
@@ -190,6 +190,8 @@ THICKNESS_CONFIG = "sloshing"   !
                                 !     soliton - Equatorial Rossby soliton.
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
+
+! === module sloshing_initialization ===
 TS_CONFIG = "sloshing"          !
                                 ! A string that determines how the initial tempertures
                                 ! and salinities are specified for a new run:

--- a/ocean_only/sloshing/rho/MOM_parameter_doc.all
+++ b/ocean_only/sloshing/rho/MOM_parameter_doc.all
@@ -563,6 +563,13 @@ THICKNESS_CONFIG = "sloshing"   !
                                 !     soliton - Equatorial Rossby soliton.
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
+
+! === module sloshing_initialization ===
+SLOSHING_IC_AMPLITUDE = 75.0    !   [m] default = 75.0
+                                ! Initial amplitude of sloshing internal interface height
+                                ! displacements it the sloshing test case.
+SLOSHING_IC_BUG = True          !   [Boolean] default = True
+                                ! If true, use code with a bug to set the sloshing initial conditions.
 TS_CONFIG = "sloshing"          !
                                 ! A string that determines how the initial tempertures
                                 ! and salinities are specified for a new run:

--- a/ocean_only/sloshing/rho/MOM_parameter_doc.short
+++ b/ocean_only/sloshing/rho/MOM_parameter_doc.short
@@ -237,6 +237,8 @@ THICKNESS_CONFIG = "sloshing"   !
                                 !     soliton - Equatorial Rossby soliton.
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
+
+! === module sloshing_initialization ===
 TS_CONFIG = "sloshing"          !
                                 ! A string that determines how the initial tempertures
                                 ! and salinities are specified for a new run:

--- a/ocean_only/sloshing/z/MOM_parameter_doc.all
+++ b/ocean_only/sloshing/z/MOM_parameter_doc.all
@@ -517,6 +517,13 @@ THICKNESS_CONFIG = "sloshing"   !
                                 !     soliton - Equatorial Rossby soliton.
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
+
+! === module sloshing_initialization ===
+SLOSHING_IC_AMPLITUDE = 75.0    !   [m] default = 75.0
+                                ! Initial amplitude of sloshing internal interface height
+                                ! displacements it the sloshing test case.
+SLOSHING_IC_BUG = True          !   [Boolean] default = True
+                                ! If true, use code with a bug to set the sloshing initial conditions.
 TS_CONFIG = "sloshing"          !
                                 ! A string that determines how the initial tempertures
                                 ! and salinities are specified for a new run:

--- a/ocean_only/sloshing/z/MOM_parameter_doc.short
+++ b/ocean_only/sloshing/z/MOM_parameter_doc.short
@@ -213,6 +213,8 @@ THICKNESS_CONFIG = "sloshing"   !
                                 !     soliton - Equatorial Rossby soliton.
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
+
+! === module sloshing_initialization ===
 TS_CONFIG = "sloshing"          !
                                 ! A string that determines how the initial tempertures
                                 ! and salinities are specified for a new run:


### PR DESCRIPTION
  This PR to MOM6-examples updates the MOM_parameter_doc files that are changed by MOM6 commit https://github.com/NOAA-GFDL/MOM6/pull/877.  This commit added new runtime parameters and get_param calls that specify some of the details of the user test cases.  All answers are bitwise identical, but there are updates to several of the MOM_parameter_doc files for these test cases.  The
list of commits in this PR include:
- NOAA-GFDL/MOM6@0ace776 Added a comment in USER_initialize_thickness
- NOAA-GFDL/MOM6@9259ba1 +Added run-time parameters for sloshing test case
- NOAA-GFDL/MOM6@0874ac4 +Added the INTERFACE_IC_QUANTA runtime parameter
- NOAA-GFDL/MOM6@6ccb6b6 +Added a run-time parameter for circle_obcs
- NOAA-GFDL/MOM6@fa1a762 +Added run-time parameters for benchmark test case