### PR TITLE
+(*)Updated coupler, SIS2 & MOM6 for interspersed ice

### DIFF
--- a/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/SIS_parameter_doc.all
+++ b/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/SIS_parameter_doc.all
@@ -90,6 +90,8 @@ RESTARTFILE = "ice_model.res.nc" ! default = "ice_model.res.nc"
 FAST_ICE_RESTARTFILE = "ice_model.res.nc" ! default = "ice_model.res.nc"
                                 ! The name of the restart file for those elements of the
                                 ! the sea ice that are handled by the fast ice PEs.
+APPLY_MASKS_AFTER_RESTART = True !   [Boolean] default = True
+                                ! If true, applies masks to mH_ice,mH_snow and part_size after a restart.
 WRITE_GEOM = 1                  ! default = 1
                                 ! If =0, never write the geometry and vertical grid files.
                                 ! If =1, write the geometry and vertical grid files only for
@@ -324,11 +326,24 @@ DT_ICE_DYNAMICS = 3600.0        !   [seconds] default = -1.0
                                 ! stepping the continuity equation and interactions
                                 ! between the ice mass field and velocities.  If 0 or
                                 ! negative the coupling time step will be used.
+MERGED_CONTINUITY = False       !   [Boolean] default = False
+                                ! If true, update the continuity equations for the ice, snow,
+                                ! and melt pond water together summed across categories, with
+                                ! proportionate fluxes for each part. Otherwise the media are
+                                ! updated separately.
+NSTEPS_ADV = 1                  ! default = 1
+                                ! The number of advective iterations for each slow dynamics
+                                ! time step.
 ICEBERG_WINDSTRESS_BUG = False  !   [Boolean] default = False
                                 ! If true, use older code that applied an old ice-ocean
                                 ! stress to the icebergs in place of the current air-ocean
                                 ! stress.  This option is here for backward compatibility,
                                 ! but should be avoided.
+WARSAW_SUM_ORDER = True         !   [Boolean] default = True
+                                ! If true, use the order of sums in the Warsaw version of SIS2.
+                                ! The default is the opposite of MERGED_CONTINUITY.
+                                ! This option exists for backward compatibilty but may
+                                ! eventually be obsoleted.
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit for ICE_STATS_INTERVAL.
 ICE_STATS_INTERVAL = 0.25       !   [days] default = 1.0
@@ -380,9 +395,6 @@ CFL_TRUNC_DYN_ITS = False       !   [Boolean] default = False
                                 ! If true, check the CFL number for every iteration of the
                                 ! rheology solver; otherwise only the final velocities that
                                 ! are used for transport are checked.
-NSTEPS_ADV = 1                  ! default = 1
-                                ! The number of advective iterations for each slow time
-                                ! step.
 RECATEGORIZE_ICE = True         !   [Boolean] default = True
                                 ! If true, readjust the distribution into ice thickness
                                 ! categories after advection.
@@ -399,6 +411,9 @@ SIS_THICKNESS_ADVECTION_SCHEME = "PCM" ! default = "UPWIND_2D"
                                 !   PCM    - Directionally split piecewise constant
                                 !   PLM    - Piecewise Linear Method
                                 !   PPM:H3 - Piecewise Parabolic Method (Huyhn 3rd order)
+INCONSISTENT_COVER_BUG = True   !   [Boolean] default = True
+                                ! If true, omit a recalculation of the fractional ice-free
+                                ! areal coverage after the adjustment of the ice categories.
 SIS_CONTINUITY_SCHEME = "PCM"   ! default = "UPWIND_2D"
                                 ! The horizontal transport scheme used in continuity:
                                 !   UPWIND_2D - Non-directionally split upwind
@@ -433,6 +448,9 @@ MAXTRUNC = 0                    !   [truncations save_interval-1] default = 0
 STATISTICS_FILE = "seaice.stats" ! default = "seaice.stats"
                                 ! The file to use to write the globally integrated
                                 ! statistics.
+
+! === module SIS_ice_diagnostics ===
+! This module handles sea-ice state diagnostics.
 
 ! === module SIS_fast_thermo ===
 ! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.

--- a/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/SIS_parameter_doc.short
+++ b/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/SIS_parameter_doc.short
@@ -117,6 +117,9 @@ SIS_TRACER_ADVECTION_SCHEME = "PPM:H3" ! default = "UPWIND_2D"
 
 ! === module SIS_sum_output ===
 
+! === module SIS_ice_diagnostics ===
+! This module handles sea-ice state diagnostics.
+
 ! === module SIS_fast_thermo ===
 ! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.
 

--- a/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/SIS_parameter_doc.all
+++ b/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/SIS_parameter_doc.all
@@ -90,6 +90,8 @@ RESTARTFILE = "ice_model.res.nc" ! default = "ice_model.res.nc"
 FAST_ICE_RESTARTFILE = "ice_model_fast.res.nc" ! default = "ice_model_fast.res.nc"
                                 ! The name of the restart file for those elements of the
                                 ! the sea ice that are handled by the fast ice PEs.
+APPLY_MASKS_AFTER_RESTART = True !   [Boolean] default = True
+                                ! If true, applies masks to mH_ice,mH_snow and part_size after a restart.
 WRITE_GEOM = 1                  ! default = 1
                                 ! If =0, never write the geometry and vertical grid files.
                                 ! If =1, write the geometry and vertical grid files only for
@@ -321,11 +323,24 @@ DT_ICE_DYNAMICS = 3600.0        !   [seconds] default = -1.0
                                 ! stepping the continuity equation and interactions
                                 ! between the ice mass field and velocities.  If 0 or
                                 ! negative the coupling time step will be used.
+MERGED_CONTINUITY = False       !   [Boolean] default = False
+                                ! If true, update the continuity equations for the ice, snow,
+                                ! and melt pond water together summed across categories, with
+                                ! proportionate fluxes for each part. Otherwise the media are
+                                ! updated separately.
+NSTEPS_ADV = 1                  ! default = 1
+                                ! The number of advective iterations for each slow dynamics
+                                ! time step.
 ICEBERG_WINDSTRESS_BUG = False  !   [Boolean] default = False
                                 ! If true, use older code that applied an old ice-ocean
                                 ! stress to the icebergs in place of the current air-ocean
                                 ! stress.  This option is here for backward compatibility,
                                 ! but should be avoided.
+WARSAW_SUM_ORDER = True         !   [Boolean] default = True
+                                ! If true, use the order of sums in the Warsaw version of SIS2.
+                                ! The default is the opposite of MERGED_CONTINUITY.
+                                ! This option exists for backward compatibilty but may
+                                ! eventually be obsoleted.
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit for ICE_STATS_INTERVAL.
 ICE_STATS_INTERVAL = 0.25       !   [days] default = 1.0
@@ -377,9 +392,6 @@ CFL_TRUNC_DYN_ITS = False       !   [Boolean] default = False
                                 ! If true, check the CFL number for every iteration of the
                                 ! rheology solver; otherwise only the final velocities that
                                 ! are used for transport are checked.
-NSTEPS_ADV = 1                  ! default = 1
-                                ! The number of advective iterations for each slow time
-                                ! step.
 RECATEGORIZE_ICE = True         !   [Boolean] default = True
                                 ! If true, readjust the distribution into ice thickness
                                 ! categories after advection.
@@ -396,6 +408,9 @@ SIS_THICKNESS_ADVECTION_SCHEME = "PCM" ! default = "UPWIND_2D"
                                 !   PCM    - Directionally split piecewise constant
                                 !   PLM    - Piecewise Linear Method
                                 !   PPM:H3 - Piecewise Parabolic Method (Huyhn 3rd order)
+INCONSISTENT_COVER_BUG = True   !   [Boolean] default = True
+                                ! If true, omit a recalculation of the fractional ice-free
+                                ! areal coverage after the adjustment of the ice categories.
 SIS_CONTINUITY_SCHEME = "PCM"   ! default = "UPWIND_2D"
                                 ! The horizontal transport scheme used in continuity:
                                 !   UPWIND_2D - Non-directionally split upwind
@@ -430,6 +445,9 @@ MAXTRUNC = 0                    !   [truncations save_interval-1] default = 0
 STATISTICS_FILE = "seaice.stats" ! default = "seaice.stats"
                                 ! The file to use to write the globally integrated
                                 ! statistics.
+
+! === module SIS_ice_diagnostics ===
+! This module handles sea-ice state diagnostics.
 
 ! === module SIS_fast_thermo ===
 ! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.

--- a/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/SIS_parameter_doc.short
+++ b/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/SIS_parameter_doc.short
@@ -117,6 +117,9 @@ SIS_TRACER_ADVECTION_SCHEME = "PPM:H3" ! default = "UPWIND_2D"
 
 ! === module SIS_sum_output ===
 
+! === module SIS_ice_diagnostics ===
+! This module handles sea-ice state diagnostics.
+
 ! === module SIS_fast_thermo ===
 ! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.
 

--- a/ice_ocean_SIS2/Baltic/SIS_parameter_doc.all
+++ b/ice_ocean_SIS2/Baltic/SIS_parameter_doc.all
@@ -90,6 +90,8 @@ RESTARTFILE = "ice_model.res.nc" ! default = "ice_model.res.nc"
 FAST_ICE_RESTARTFILE = "ice_model.res.nc" ! default = "ice_model.res.nc"
                                 ! The name of the restart file for those elements of the
                                 ! the sea ice that are handled by the fast ice PEs.
+APPLY_MASKS_AFTER_RESTART = True !   [Boolean] default = True
+                                ! If true, applies masks to mH_ice,mH_snow and part_size after a restart.
 WRITE_GEOM = 1                  ! default = 1
                                 ! If =0, never write the geometry and vertical grid files.
                                 ! If =1, write the geometry and vertical grid files only for
@@ -342,11 +344,24 @@ DT_ICE_DYNAMICS = 3600.0        !   [seconds] default = -1.0
                                 ! stepping the continuity equation and interactions
                                 ! between the ice mass field and velocities.  If 0 or
                                 ! negative the coupling time step will be used.
+MERGED_CONTINUITY = False       !   [Boolean] default = False
+                                ! If true, update the continuity equations for the ice, snow,
+                                ! and melt pond water together summed across categories, with
+                                ! proportionate fluxes for each part. Otherwise the media are
+                                ! updated separately.
+NSTEPS_ADV = 1                  ! default = 1
+                                ! The number of advective iterations for each slow dynamics
+                                ! time step.
 ICEBERG_WINDSTRESS_BUG = False  !   [Boolean] default = False
                                 ! If true, use older code that applied an old ice-ocean
                                 ! stress to the icebergs in place of the current air-ocean
                                 ! stress.  This option is here for backward compatibility,
                                 ! but should be avoided.
+WARSAW_SUM_ORDER = True         !   [Boolean] default = True
+                                ! If true, use the order of sums in the Warsaw version of SIS2.
+                                ! The default is the opposite of MERGED_CONTINUITY.
+                                ! This option exists for backward compatibilty but may
+                                ! eventually be obsoleted.
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit for ICE_STATS_INTERVAL.
 ICE_STATS_INTERVAL = 0.25       !   [days] default = 1.0
@@ -398,9 +413,6 @@ CFL_TRUNC_DYN_ITS = False       !   [Boolean] default = False
                                 ! If true, check the CFL number for every iteration of the
                                 ! rheology solver; otherwise only the final velocities that
                                 ! are used for transport are checked.
-NSTEPS_ADV = 1                  ! default = 1
-                                ! The number of advective iterations for each slow time
-                                ! step.
 RECATEGORIZE_ICE = True         !   [Boolean] default = True
                                 ! If true, readjust the distribution into ice thickness
                                 ! categories after advection.
@@ -417,6 +429,9 @@ SIS_THICKNESS_ADVECTION_SCHEME = "UPWIND_2D" ! default = "UPWIND_2D"
                                 !   PCM    - Directionally split piecewise constant
                                 !   PLM    - Piecewise Linear Method
                                 !   PPM:H3 - Piecewise Parabolic Method (Huyhn 3rd order)
+INCONSISTENT_COVER_BUG = True   !   [Boolean] default = True
+                                ! If true, omit a recalculation of the fractional ice-free
+                                ! areal coverage after the adjustment of the ice categories.
 SIS_CONTINUITY_SCHEME = "UPWIND_2D" ! default = "UPWIND_2D"
                                 ! The horizontal transport scheme used in continuity:
                                 !   UPWIND_2D - Non-directionally split upwind
@@ -451,6 +466,9 @@ MAXTRUNC = 0                    !   [truncations save_interval-1] default = 0
 STATISTICS_FILE = "seaice.stats" ! default = "seaice.stats"
                                 ! The file to use to write the globally integrated
                                 ! statistics.
+
+! === module SIS_ice_diagnostics ===
+! This module handles sea-ice state diagnostics.
 
 ! === module SIS_fast_thermo ===
 ! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.

--- a/ice_ocean_SIS2/Baltic/SIS_parameter_doc.short
+++ b/ice_ocean_SIS2/Baltic/SIS_parameter_doc.short
@@ -127,6 +127,9 @@ SIS_TRACER_ADVECTION_SCHEME = "PPM:H3" ! default = "UPWIND_2D"
 
 ! === module SIS_sum_output ===
 
+! === module SIS_ice_diagnostics ===
+! This module handles sea-ice state diagnostics.
+
 ! === module SIS_fast_thermo ===
 ! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.
 

--- a/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/SIS_parameter_doc.all
+++ b/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/SIS_parameter_doc.all
@@ -90,6 +90,8 @@ RESTARTFILE = "ice_model.res.nc" ! default = "ice_model.res.nc"
 FAST_ICE_RESTARTFILE = "ice_model.res.nc" ! default = "ice_model.res.nc"
                                 ! The name of the restart file for those elements of the
                                 ! the sea ice that are handled by the fast ice PEs.
+APPLY_MASKS_AFTER_RESTART = True !   [Boolean] default = True
+                                ! If true, applies masks to mH_ice,mH_snow and part_size after a restart.
 WRITE_GEOM = 1                  ! default = 1
                                 ! If =0, never write the geometry and vertical grid files.
                                 ! If =1, write the geometry and vertical grid files only for
@@ -324,11 +326,24 @@ DT_ICE_DYNAMICS = 3600.0        !   [seconds] default = -1.0
                                 ! stepping the continuity equation and interactions
                                 ! between the ice mass field and velocities.  If 0 or
                                 ! negative the coupling time step will be used.
+MERGED_CONTINUITY = False       !   [Boolean] default = False
+                                ! If true, update the continuity equations for the ice, snow,
+                                ! and melt pond water together summed across categories, with
+                                ! proportionate fluxes for each part. Otherwise the media are
+                                ! updated separately.
+NSTEPS_ADV = 1                  ! default = 1
+                                ! The number of advective iterations for each slow dynamics
+                                ! time step.
 ICEBERG_WINDSTRESS_BUG = False  !   [Boolean] default = False
                                 ! If true, use older code that applied an old ice-ocean
                                 ! stress to the icebergs in place of the current air-ocean
                                 ! stress.  This option is here for backward compatibility,
                                 ! but should be avoided.
+WARSAW_SUM_ORDER = True         !   [Boolean] default = True
+                                ! If true, use the order of sums in the Warsaw version of SIS2.
+                                ! The default is the opposite of MERGED_CONTINUITY.
+                                ! This option exists for backward compatibilty but may
+                                ! eventually be obsoleted.
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit for ICE_STATS_INTERVAL.
 ICE_STATS_INTERVAL = 1.0        !   [days] default = 1.0
@@ -380,9 +395,6 @@ CFL_TRUNC_DYN_ITS = False       !   [Boolean] default = False
                                 ! If true, check the CFL number for every iteration of the
                                 ! rheology solver; otherwise only the final velocities that
                                 ! are used for transport are checked.
-NSTEPS_ADV = 1                  ! default = 1
-                                ! The number of advective iterations for each slow time
-                                ! step.
 RECATEGORIZE_ICE = True         !   [Boolean] default = True
                                 ! If true, readjust the distribution into ice thickness
                                 ! categories after advection.
@@ -399,6 +411,9 @@ SIS_THICKNESS_ADVECTION_SCHEME = "UPWIND_2D" ! default = "UPWIND_2D"
                                 !   PCM    - Directionally split piecewise constant
                                 !   PLM    - Piecewise Linear Method
                                 !   PPM:H3 - Piecewise Parabolic Method (Huyhn 3rd order)
+INCONSISTENT_COVER_BUG = True   !   [Boolean] default = True
+                                ! If true, omit a recalculation of the fractional ice-free
+                                ! areal coverage after the adjustment of the ice categories.
 SIS_CONTINUITY_SCHEME = "UPWIND_2D" ! default = "UPWIND_2D"
                                 ! The horizontal transport scheme used in continuity:
                                 !   UPWIND_2D - Non-directionally split upwind
@@ -433,6 +448,9 @@ MAXTRUNC = 0                    !   [truncations save_interval-1] default = 0
 STATISTICS_FILE = "seaice.stats" ! default = "seaice.stats"
                                 ! The file to use to write the globally integrated
                                 ! statistics.
+
+! === module SIS_ice_diagnostics ===
+! This module handles sea-ice state diagnostics.
 
 ! === module SIS_fast_thermo ===
 ! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.

--- a/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/SIS_parameter_doc.short
+++ b/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/SIS_parameter_doc.short
@@ -97,6 +97,9 @@ SIS_TRACER_ADVECTION_SCHEME = "PPM:H3" ! default = "UPWIND_2D"
 
 ! === module SIS_sum_output ===
 
+! === module SIS_ice_diagnostics ===
+! This module handles sea-ice state diagnostics.
+
 ! === module SIS_fast_thermo ===
 ! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.
 

--- a/ice_ocean_SIS2/Baltic_OM4_025/SIS_parameter_doc.all
+++ b/ice_ocean_SIS2/Baltic_OM4_025/SIS_parameter_doc.all
@@ -90,6 +90,8 @@ RESTARTFILE = "ice_model.res.nc" ! default = "ice_model.res.nc"
 FAST_ICE_RESTARTFILE = "ice_model.res.nc" ! default = "ice_model.res.nc"
                                 ! The name of the restart file for those elements of the
                                 ! the sea ice that are handled by the fast ice PEs.
+APPLY_MASKS_AFTER_RESTART = True !   [Boolean] default = True
+                                ! If true, applies masks to mH_ice,mH_snow and part_size after a restart.
 WRITE_GEOM = 1                  ! default = 1
                                 ! If =0, never write the geometry and vertical grid files.
                                 ! If =1, write the geometry and vertical grid files only for
@@ -324,11 +326,24 @@ DT_ICE_DYNAMICS = 1200.0        !   [seconds] default = -1.0
                                 ! stepping the continuity equation and interactions
                                 ! between the ice mass field and velocities.  If 0 or
                                 ! negative the coupling time step will be used.
+MERGED_CONTINUITY = False       !   [Boolean] default = False
+                                ! If true, update the continuity equations for the ice, snow,
+                                ! and melt pond water together summed across categories, with
+                                ! proportionate fluxes for each part. Otherwise the media are
+                                ! updated separately.
+NSTEPS_ADV = 1                  ! default = 1
+                                ! The number of advective iterations for each slow dynamics
+                                ! time step.
 ICEBERG_WINDSTRESS_BUG = False  !   [Boolean] default = False
                                 ! If true, use older code that applied an old ice-ocean
                                 ! stress to the icebergs in place of the current air-ocean
                                 ! stress.  This option is here for backward compatibility,
                                 ! but should be avoided.
+WARSAW_SUM_ORDER = True         !   [Boolean] default = True
+                                ! If true, use the order of sums in the Warsaw version of SIS2.
+                                ! The default is the opposite of MERGED_CONTINUITY.
+                                ! This option exists for backward compatibilty but may
+                                ! eventually be obsoleted.
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit for ICE_STATS_INTERVAL.
 ICE_STATS_INTERVAL = 0.25       !   [days] default = 1.0
@@ -380,9 +395,6 @@ CFL_TRUNC_DYN_ITS = False       !   [Boolean] default = False
                                 ! If true, check the CFL number for every iteration of the
                                 ! rheology solver; otherwise only the final velocities that
                                 ! are used for transport are checked.
-NSTEPS_ADV = 1                  ! default = 1
-                                ! The number of advective iterations for each slow time
-                                ! step.
 RECATEGORIZE_ICE = True         !   [Boolean] default = True
                                 ! If true, readjust the distribution into ice thickness
                                 ! categories after advection.
@@ -399,6 +411,9 @@ SIS_THICKNESS_ADVECTION_SCHEME = "PCM" ! default = "UPWIND_2D"
                                 !   PCM    - Directionally split piecewise constant
                                 !   PLM    - Piecewise Linear Method
                                 !   PPM:H3 - Piecewise Parabolic Method (Huyhn 3rd order)
+INCONSISTENT_COVER_BUG = True   !   [Boolean] default = True
+                                ! If true, omit a recalculation of the fractional ice-free
+                                ! areal coverage after the adjustment of the ice categories.
 SIS_CONTINUITY_SCHEME = "PCM"   ! default = "UPWIND_2D"
                                 ! The horizontal transport scheme used in continuity:
                                 !   UPWIND_2D - Non-directionally split upwind
@@ -433,6 +448,9 @@ MAXTRUNC = 200                  !   [truncations save_interval-1] default = 0
 STATISTICS_FILE = "seaice.stats" ! default = "seaice.stats"
                                 ! The file to use to write the globally integrated
                                 ! statistics.
+
+! === module SIS_ice_diagnostics ===
+! This module handles sea-ice state diagnostics.
 
 ! === module SIS_fast_thermo ===
 ! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.

--- a/ice_ocean_SIS2/Baltic_OM4_025/SIS_parameter_doc.short
+++ b/ice_ocean_SIS2/Baltic_OM4_025/SIS_parameter_doc.short
@@ -117,6 +117,9 @@ MAXTRUNC = 200                  !   [truncations save_interval-1] default = 0
                                 ! Set MAXTRUNC to 0 to stop if there is any truncation
                                 ! of sea ice velocities.
 
+! === module SIS_ice_diagnostics ===
+! This module handles sea-ice state diagnostics.
+
 ! === module SIS_fast_thermo ===
 ! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.
 

--- a/ice_ocean_SIS2/Baltic_OM4_05/SIS_parameter_doc.all
+++ b/ice_ocean_SIS2/Baltic_OM4_05/SIS_parameter_doc.all
@@ -90,6 +90,8 @@ RESTARTFILE = "ice_model.res.nc" ! default = "ice_model.res.nc"
 FAST_ICE_RESTARTFILE = "ice_model.res.nc" ! default = "ice_model.res.nc"
                                 ! The name of the restart file for those elements of the
                                 ! the sea ice that are handled by the fast ice PEs.
+APPLY_MASKS_AFTER_RESTART = True !   [Boolean] default = True
+                                ! If true, applies masks to mH_ice,mH_snow and part_size after a restart.
 WRITE_GEOM = 1                  ! default = 1
                                 ! If =0, never write the geometry and vertical grid files.
                                 ! If =1, write the geometry and vertical grid files only for
@@ -320,11 +322,24 @@ DT_ICE_DYNAMICS = 1200.0        !   [seconds] default = -1.0
                                 ! stepping the continuity equation and interactions
                                 ! between the ice mass field and velocities.  If 0 or
                                 ! negative the coupling time step will be used.
+MERGED_CONTINUITY = False       !   [Boolean] default = False
+                                ! If true, update the continuity equations for the ice, snow,
+                                ! and melt pond water together summed across categories, with
+                                ! proportionate fluxes for each part. Otherwise the media are
+                                ! updated separately.
+NSTEPS_ADV = 1                  ! default = 1
+                                ! The number of advective iterations for each slow dynamics
+                                ! time step.
 ICEBERG_WINDSTRESS_BUG = True   !   [Boolean] default = False
                                 ! If true, use older code that applied an old ice-ocean
                                 ! stress to the icebergs in place of the current air-ocean
                                 ! stress.  This option is here for backward compatibility,
                                 ! but should be avoided.
+WARSAW_SUM_ORDER = True         !   [Boolean] default = True
+                                ! If true, use the order of sums in the Warsaw version of SIS2.
+                                ! The default is the opposite of MERGED_CONTINUITY.
+                                ! This option exists for backward compatibilty but may
+                                ! eventually be obsoleted.
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit for ICE_STATS_INTERVAL.
 ICE_STATS_INTERVAL = 0.25       !   [days] default = 1.0
@@ -376,9 +391,6 @@ CFL_TRUNC_DYN_ITS = False       !   [Boolean] default = False
                                 ! If true, check the CFL number for every iteration of the
                                 ! rheology solver; otherwise only the final velocities that
                                 ! are used for transport are checked.
-NSTEPS_ADV = 1                  ! default = 1
-                                ! The number of advective iterations for each slow time
-                                ! step.
 RECATEGORIZE_ICE = True         !   [Boolean] default = True
                                 ! If true, readjust the distribution into ice thickness
                                 ! categories after advection.
@@ -395,6 +407,9 @@ SIS_THICKNESS_ADVECTION_SCHEME = "PCM" ! default = "UPWIND_2D"
                                 !   PCM    - Directionally split piecewise constant
                                 !   PLM    - Piecewise Linear Method
                                 !   PPM:H3 - Piecewise Parabolic Method (Huyhn 3rd order)
+INCONSISTENT_COVER_BUG = True   !   [Boolean] default = True
+                                ! If true, omit a recalculation of the fractional ice-free
+                                ! areal coverage after the adjustment of the ice categories.
 SIS_CONTINUITY_SCHEME = "PCM"   ! default = "UPWIND_2D"
                                 ! The horizontal transport scheme used in continuity:
                                 !   UPWIND_2D - Non-directionally split upwind
@@ -429,6 +444,9 @@ MAXTRUNC = 0                    !   [truncations save_interval-1] default = 0
 STATISTICS_FILE = "seaice.stats" ! default = "seaice.stats"
                                 ! The file to use to write the globally integrated
                                 ! statistics.
+
+! === module SIS_ice_diagnostics ===
+! This module handles sea-ice state diagnostics.
 
 ! === module SIS_fast_thermo ===
 ! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.

--- a/ice_ocean_SIS2/Baltic_OM4_05/SIS_parameter_doc.short
+++ b/ice_ocean_SIS2/Baltic_OM4_05/SIS_parameter_doc.short
@@ -126,6 +126,9 @@ SIS_TRACER_ADVECTION_SCHEME = "PPM:H3" ! default = "UPWIND_2D"
 
 ! === module SIS_sum_output ===
 
+! === module SIS_ice_diagnostics ===
+! This module handles sea-ice state diagnostics.
+
 ! === module SIS_fast_thermo ===
 ! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.
 

--- a/ice_ocean_SIS2/OM4_025/SIS_parameter_doc.all
+++ b/ice_ocean_SIS2/OM4_025/SIS_parameter_doc.all
@@ -92,6 +92,8 @@ RESTARTFILE = "ice_model.res.nc" ! default = "ice_model.res.nc"
 FAST_ICE_RESTARTFILE = "ice_model.res.nc" ! default = "ice_model.res.nc"
                                 ! The name of the restart file for those elements of the
                                 ! the sea ice that are handled by the fast ice PEs.
+APPLY_MASKS_AFTER_RESTART = True !   [Boolean] default = True
+                                ! If true, applies masks to mH_ice,mH_snow and part_size after a restart.
 WRITE_GEOM = 1                  ! default = 1
                                 ! If =0, never write the geometry and vertical grid files.
                                 ! If =1, write the geometry and vertical grid files only for
@@ -326,11 +328,24 @@ DT_ICE_DYNAMICS = 1200.0        !   [seconds] default = -1.0
                                 ! stepping the continuity equation and interactions
                                 ! between the ice mass field and velocities.  If 0 or
                                 ! negative the coupling time step will be used.
+MERGED_CONTINUITY = False       !   [Boolean] default = False
+                                ! If true, update the continuity equations for the ice, snow,
+                                ! and melt pond water together summed across categories, with
+                                ! proportionate fluxes for each part. Otherwise the media are
+                                ! updated separately.
+NSTEPS_ADV = 1                  ! default = 1
+                                ! The number of advective iterations for each slow dynamics
+                                ! time step.
 ICEBERG_WINDSTRESS_BUG = False  !   [Boolean] default = False
                                 ! If true, use older code that applied an old ice-ocean
                                 ! stress to the icebergs in place of the current air-ocean
                                 ! stress.  This option is here for backward compatibility,
                                 ! but should be avoided.
+WARSAW_SUM_ORDER = True         !   [Boolean] default = True
+                                ! If true, use the order of sums in the Warsaw version of SIS2.
+                                ! The default is the opposite of MERGED_CONTINUITY.
+                                ! This option exists for backward compatibilty but may
+                                ! eventually be obsoleted.
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit for ICE_STATS_INTERVAL.
 ICE_STATS_INTERVAL = 0.25       !   [days] default = 1.0
@@ -382,9 +397,6 @@ CFL_TRUNC_DYN_ITS = False       !   [Boolean] default = False
                                 ! If true, check the CFL number for every iteration of the
                                 ! rheology solver; otherwise only the final velocities that
                                 ! are used for transport are checked.
-NSTEPS_ADV = 1                  ! default = 1
-                                ! The number of advective iterations for each slow time
-                                ! step.
 RECATEGORIZE_ICE = True         !   [Boolean] default = True
                                 ! If true, readjust the distribution into ice thickness
                                 ! categories after advection.
@@ -401,6 +413,9 @@ SIS_THICKNESS_ADVECTION_SCHEME = "PCM" ! default = "UPWIND_2D"
                                 !   PCM    - Directionally split piecewise constant
                                 !   PLM    - Piecewise Linear Method
                                 !   PPM:H3 - Piecewise Parabolic Method (Huyhn 3rd order)
+INCONSISTENT_COVER_BUG = True   !   [Boolean] default = True
+                                ! If true, omit a recalculation of the fractional ice-free
+                                ! areal coverage after the adjustment of the ice categories.
 SIS_CONTINUITY_SCHEME = "PCM"   ! default = "UPWIND_2D"
                                 ! The horizontal transport scheme used in continuity:
                                 !   UPWIND_2D - Non-directionally split upwind
@@ -435,6 +450,9 @@ MAXTRUNC = 200                  !   [truncations save_interval-1] default = 0
 STATISTICS_FILE = "seaice.stats" ! default = "seaice.stats"
                                 ! The file to use to write the globally integrated
                                 ! statistics.
+
+! === module SIS_ice_diagnostics ===
+! This module handles sea-ice state diagnostics.
 
 ! === module SIS_fast_thermo ===
 ! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.

--- a/ice_ocean_SIS2/OM4_025/SIS_parameter_doc.short
+++ b/ice_ocean_SIS2/OM4_025/SIS_parameter_doc.short
@@ -120,6 +120,9 @@ MAXTRUNC = 200                  !   [truncations save_interval-1] default = 0
                                 ! Set MAXTRUNC to 0 to stop if there is any truncation
                                 ! of sea ice velocities.
 
+! === module SIS_ice_diagnostics ===
+! This module handles sea-ice state diagnostics.
+
 ! === module SIS_fast_thermo ===
 ! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.
 

--- a/ice_ocean_SIS2/OM4_05/SIS_parameter_doc.all
+++ b/ice_ocean_SIS2/OM4_05/SIS_parameter_doc.all
@@ -92,6 +92,8 @@ RESTARTFILE = "ice_model.res.nc" ! default = "ice_model.res.nc"
 FAST_ICE_RESTARTFILE = "ice_model.res.nc" ! default = "ice_model.res.nc"
                                 ! The name of the restart file for those elements of the
                                 ! the sea ice that are handled by the fast ice PEs.
+APPLY_MASKS_AFTER_RESTART = True !   [Boolean] default = True
+                                ! If true, applies masks to mH_ice,mH_snow and part_size after a restart.
 WRITE_GEOM = 1                  ! default = 1
                                 ! If =0, never write the geometry and vertical grid files.
                                 ! If =1, write the geometry and vertical grid files only for
@@ -322,11 +324,24 @@ DT_ICE_DYNAMICS = 1200.0        !   [seconds] default = -1.0
                                 ! stepping the continuity equation and interactions
                                 ! between the ice mass field and velocities.  If 0 or
                                 ! negative the coupling time step will be used.
+MERGED_CONTINUITY = False       !   [Boolean] default = False
+                                ! If true, update the continuity equations for the ice, snow,
+                                ! and melt pond water together summed across categories, with
+                                ! proportionate fluxes for each part. Otherwise the media are
+                                ! updated separately.
+NSTEPS_ADV = 1                  ! default = 1
+                                ! The number of advective iterations for each slow dynamics
+                                ! time step.
 ICEBERG_WINDSTRESS_BUG = True   !   [Boolean] default = False
                                 ! If true, use older code that applied an old ice-ocean
                                 ! stress to the icebergs in place of the current air-ocean
                                 ! stress.  This option is here for backward compatibility,
                                 ! but should be avoided.
+WARSAW_SUM_ORDER = True         !   [Boolean] default = True
+                                ! If true, use the order of sums in the Warsaw version of SIS2.
+                                ! The default is the opposite of MERGED_CONTINUITY.
+                                ! This option exists for backward compatibilty but may
+                                ! eventually be obsoleted.
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit for ICE_STATS_INTERVAL.
 ICE_STATS_INTERVAL = 0.25       !   [days] default = 1.0
@@ -378,9 +393,6 @@ CFL_TRUNC_DYN_ITS = False       !   [Boolean] default = False
                                 ! If true, check the CFL number for every iteration of the
                                 ! rheology solver; otherwise only the final velocities that
                                 ! are used for transport are checked.
-NSTEPS_ADV = 1                  ! default = 1
-                                ! The number of advective iterations for each slow time
-                                ! step.
 RECATEGORIZE_ICE = True         !   [Boolean] default = True
                                 ! If true, readjust the distribution into ice thickness
                                 ! categories after advection.
@@ -397,6 +409,9 @@ SIS_THICKNESS_ADVECTION_SCHEME = "PCM" ! default = "UPWIND_2D"
                                 !   PCM    - Directionally split piecewise constant
                                 !   PLM    - Piecewise Linear Method
                                 !   PPM:H3 - Piecewise Parabolic Method (Huyhn 3rd order)
+INCONSISTENT_COVER_BUG = True   !   [Boolean] default = True
+                                ! If true, omit a recalculation of the fractional ice-free
+                                ! areal coverage after the adjustment of the ice categories.
 SIS_CONTINUITY_SCHEME = "PCM"   ! default = "UPWIND_2D"
                                 ! The horizontal transport scheme used in continuity:
                                 !   UPWIND_2D - Non-directionally split upwind
@@ -431,6 +446,9 @@ MAXTRUNC = 0                    !   [truncations save_interval-1] default = 0
 STATISTICS_FILE = "seaice.stats" ! default = "seaice.stats"
                                 ! The file to use to write the globally integrated
                                 ! statistics.
+
+! === module SIS_ice_diagnostics ===
+! This module handles sea-ice state diagnostics.
 
 ! === module SIS_fast_thermo ===
 ! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.

--- a/ice_ocean_SIS2/OM4_05/SIS_parameter_doc.short
+++ b/ice_ocean_SIS2/OM4_05/SIS_parameter_doc.short
@@ -129,6 +129,9 @@ SIS_TRACER_ADVECTION_SCHEME = "PPM:H3" ! default = "UPWIND_2D"
 
 ! === module SIS_sum_output ===
 
+! === module SIS_ice_diagnostics ===
+! This module handles sea-ice state diagnostics.
+
 ! === module SIS_fast_thermo ===
 ! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.
 

--- a/ice_ocean_SIS2/SIS2/SIS.available_diags
+++ b/ice_ocean_SIS2/SIS2/SIS.available_diags
@@ -184,6 +184,18 @@
 "ice_model", "IY_TRANS"  [Used]
     ! long_name: y-direction ice transport
     ! units: kg/s
+"ice_model", "XPRT"  [Used]
+    ! long_name: frozen water transport convergence
+    ! units: kg/(m^2*yr)
+"ice_model", "RDG_RATE"  [Unused]
+    ! long_name: ice ridging rate
+    ! units: 1/sec
+"ice_model", "FA_X"  [Used]
+    ! long_name: air stress on ice - x component
+    ! units: Pa
+"ice_model", "FA_Y"  [Used]
+    ! long_name: air stress on ice - y component
+    ! units: Pa
 "ice_model", "EXT"  [Used]
     ! long_name: ice modeled
     ! units: 0 or 1
@@ -250,15 +262,6 @@
 "ice_model", "Sal4"  [Unused]
     ! long_name: ice layer 4 salinity
     ! units: g/kg
-"ice_model", "FA_X"  [Used]
-    ! long_name: air stress on ice - x component
-    ! units: Pa
-"ice_model", "FA_Y"  [Used]
-    ! long_name: air stress on ice - y component
-    ! units: Pa
-"ice_model", "XPRT"  [Used]
-    ! long_name: frozen water transport convergence
-    ! units: kg/(m^2*yr)
 "ice_model", "MI"  [Used]
     ! long_name: ice + snow mass
     ! units: kg/m^2
@@ -274,6 +277,3 @@
 "ice_model", "E2MELT"  [Unused]
     ! long_name: heat needed to melt ice
     ! units: J/m^2
-"ice_model", "RDG_RATE"  [Unused]
-    ! long_name: ice ridging rate
-    ! units: 1/sec

--- a/ice_ocean_SIS2/SIS2/SIS_parameter_doc.all
+++ b/ice_ocean_SIS2/SIS2/SIS_parameter_doc.all
@@ -90,6 +90,8 @@ RESTARTFILE = "ice_model.res.nc" ! default = "ice_model.res.nc"
 FAST_ICE_RESTARTFILE = "ice_model.res.nc" ! default = "ice_model.res.nc"
                                 ! The name of the restart file for those elements of the
                                 ! the sea ice that are handled by the fast ice PEs.
+APPLY_MASKS_AFTER_RESTART = True !   [Boolean] default = True
+                                ! If true, applies masks to mH_ice,mH_snow and part_size after a restart.
 WRITE_GEOM = 1                  ! default = 1
                                 ! If =0, never write the geometry and vertical grid files.
                                 ! If =1, write the geometry and vertical grid files only for
@@ -320,11 +322,24 @@ DT_ICE_DYNAMICS = 3600.0        !   [seconds] default = -1.0
                                 ! stepping the continuity equation and interactions
                                 ! between the ice mass field and velocities.  If 0 or
                                 ! negative the coupling time step will be used.
+MERGED_CONTINUITY = False       !   [Boolean] default = False
+                                ! If true, update the continuity equations for the ice, snow,
+                                ! and melt pond water together summed across categories, with
+                                ! proportionate fluxes for each part. Otherwise the media are
+                                ! updated separately.
+NSTEPS_ADV = 1                  ! default = 1
+                                ! The number of advective iterations for each slow dynamics
+                                ! time step.
 ICEBERG_WINDSTRESS_BUG = False  !   [Boolean] default = False
                                 ! If true, use older code that applied an old ice-ocean
                                 ! stress to the icebergs in place of the current air-ocean
                                 ! stress.  This option is here for backward compatibility,
                                 ! but should be avoided.
+WARSAW_SUM_ORDER = True         !   [Boolean] default = True
+                                ! If true, use the order of sums in the Warsaw version of SIS2.
+                                ! The default is the opposite of MERGED_CONTINUITY.
+                                ! This option exists for backward compatibilty but may
+                                ! eventually be obsoleted.
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit for ICE_STATS_INTERVAL.
 ICE_STATS_INTERVAL = 0.25       !   [days] default = 1.0
@@ -345,9 +360,6 @@ ICE_CDRAG_WATER = 0.00324       !   [nondim] default = 0.00324
 AIR_WATER_STRESS_TURN_ANGLE = 0.0 !   [degrees] default = 0.0
                                 ! An angle by which to rotate the velocities at the air-
                                 ! water boundary in calculating stresses.
-NSTEPS_ADV = 1                  ! default = 1
-                                ! The number of advective iterations for each slow time
-                                ! step.
 RECATEGORIZE_ICE = False        !   [Boolean] default = True
                                 ! If true, readjust the distribution into ice thickness
                                 ! categories after advection.
@@ -364,6 +376,9 @@ SIS_THICKNESS_ADVECTION_SCHEME = "UPWIND_2D" ! default = "UPWIND_2D"
                                 !   PCM    - Directionally split piecewise constant
                                 !   PLM    - Piecewise Linear Method
                                 !   PPM:H3 - Piecewise Parabolic Method (Huyhn 3rd order)
+INCONSISTENT_COVER_BUG = True   !   [Boolean] default = True
+                                ! If true, omit a recalculation of the fractional ice-free
+                                ! areal coverage after the adjustment of the ice categories.
 SIS_CONTINUITY_SCHEME = "UPWIND_2D" ! default = "UPWIND_2D"
                                 ! The horizontal transport scheme used in continuity:
                                 !   UPWIND_2D - Non-directionally split upwind
@@ -398,6 +413,9 @@ MAXTRUNC = 0                    !   [truncations save_interval-1] default = 0
 STATISTICS_FILE = "seaice.stats" ! default = "seaice.stats"
                                 ! The file to use to write the globally integrated
                                 ! statistics.
+
+! === module SIS_ice_diagnostics ===
+! This module handles sea-ice state diagnostics.
 
 ! === module SIS_fast_thermo ===
 ! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.

--- a/ice_ocean_SIS2/SIS2/SIS_parameter_doc.short
+++ b/ice_ocean_SIS2/SIS2/SIS_parameter_doc.short
@@ -101,6 +101,9 @@ RECATEGORIZE_ICE = False        !   [Boolean] default = True
 
 ! === module SIS_sum_output ===
 
+! === module SIS_ice_diagnostics ===
+! This module handles sea-ice state diagnostics.
+
 ! === module SIS_fast_thermo ===
 ! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.
 

--- a/ice_ocean_SIS2/SIS2_bergs_cgrid/SIS.available_diags
+++ b/ice_ocean_SIS2/SIS2_bergs_cgrid/SIS.available_diags
@@ -316,6 +316,18 @@
 "ice_model", "IY_TRANS"  [Used]
     ! long_name: y-direction ice transport
     ! units: kg/s
+"ice_model", "XPRT"  [Used]
+    ! long_name: frozen water transport convergence
+    ! units: kg/(m^2*yr)
+"ice_model", "RDG_RATE"  [Unused]
+    ! long_name: ice ridging rate
+    ! units: 1/sec
+"ice_model", "FA_X"  [Used]
+    ! long_name: Air stress on ice on C-grid - x component
+    ! units: Pa
+"ice_model", "FA_Y"  [Used]
+    ! long_name: Air stress on ice on C-grid - y component
+    ! units: Pa
 "ice_model", "EXT"  [Used]
     ! long_name: ice modeled
     ! units: 0 or 1
@@ -382,15 +394,6 @@
 "ice_model", "Sal4"  [Unused]
     ! long_name: ice layer 4 salinity
     ! units: g/kg
-"ice_model", "FA_X"  [Used]
-    ! long_name: Air stress on ice on C-grid - x component
-    ! units: Pa
-"ice_model", "FA_Y"  [Used]
-    ! long_name: Air stress on ice on C-grid - y component
-    ! units: Pa
-"ice_model", "XPRT"  [Used]
-    ! long_name: frozen water transport convergence
-    ! units: kg/(m^2*yr)
 "ice_model", "MI"  [Used]
     ! long_name: ice + snow mass
     ! units: kg/m^2
@@ -406,6 +409,3 @@
 "ice_model", "E2MELT"  [Unused]
     ! long_name: heat needed to melt ice
     ! units: J/m^2
-"ice_model", "RDG_RATE"  [Unused]
-    ! long_name: ice ridging rate
-    ! units: 1/sec

--- a/ice_ocean_SIS2/SIS2_bergs_cgrid/SIS_parameter_doc.all
+++ b/ice_ocean_SIS2/SIS2_bergs_cgrid/SIS_parameter_doc.all
@@ -92,6 +92,8 @@ RESTARTFILE = "ice_model.res.nc" ! default = "ice_model.res.nc"
 FAST_ICE_RESTARTFILE = "ice_model.res.nc" ! default = "ice_model.res.nc"
                                 ! The name of the restart file for those elements of the
                                 ! the sea ice that are handled by the fast ice PEs.
+APPLY_MASKS_AFTER_RESTART = True !   [Boolean] default = True
+                                ! If true, applies masks to mH_ice,mH_snow and part_size after a restart.
 WRITE_GEOM = 1                  ! default = 1
                                 ! If =0, never write the geometry and vertical grid files.
                                 ! If =1, write the geometry and vertical grid files only for
@@ -326,11 +328,24 @@ DT_ICE_DYNAMICS = 3600.0        !   [seconds] default = -1.0
                                 ! stepping the continuity equation and interactions
                                 ! between the ice mass field and velocities.  If 0 or
                                 ! negative the coupling time step will be used.
+MERGED_CONTINUITY = False       !   [Boolean] default = False
+                                ! If true, update the continuity equations for the ice, snow,
+                                ! and melt pond water together summed across categories, with
+                                ! proportionate fluxes for each part. Otherwise the media are
+                                ! updated separately.
+NSTEPS_ADV = 1                  ! default = 1
+                                ! The number of advective iterations for each slow dynamics
+                                ! time step.
 ICEBERG_WINDSTRESS_BUG = False  !   [Boolean] default = False
                                 ! If true, use older code that applied an old ice-ocean
                                 ! stress to the icebergs in place of the current air-ocean
                                 ! stress.  This option is here for backward compatibility,
                                 ! but should be avoided.
+WARSAW_SUM_ORDER = True         !   [Boolean] default = True
+                                ! If true, use the order of sums in the Warsaw version of SIS2.
+                                ! The default is the opposite of MERGED_CONTINUITY.
+                                ! This option exists for backward compatibilty but may
+                                ! eventually be obsoleted.
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit for ICE_STATS_INTERVAL.
 ICE_STATS_INTERVAL = 0.25       !   [days] default = 1.0
@@ -382,9 +397,6 @@ CFL_TRUNC_DYN_ITS = False       !   [Boolean] default = False
                                 ! If true, check the CFL number for every iteration of the
                                 ! rheology solver; otherwise only the final velocities that
                                 ! are used for transport are checked.
-NSTEPS_ADV = 1                  ! default = 1
-                                ! The number of advective iterations for each slow time
-                                ! step.
 RECATEGORIZE_ICE = True         !   [Boolean] default = True
                                 ! If true, readjust the distribution into ice thickness
                                 ! categories after advection.
@@ -401,6 +413,9 @@ SIS_THICKNESS_ADVECTION_SCHEME = "UPWIND_2D" ! default = "UPWIND_2D"
                                 !   PCM    - Directionally split piecewise constant
                                 !   PLM    - Piecewise Linear Method
                                 !   PPM:H3 - Piecewise Parabolic Method (Huyhn 3rd order)
+INCONSISTENT_COVER_BUG = True   !   [Boolean] default = True
+                                ! If true, omit a recalculation of the fractional ice-free
+                                ! areal coverage after the adjustment of the ice categories.
 SIS_CONTINUITY_SCHEME = "UPWIND_2D" ! default = "UPWIND_2D"
                                 ! The horizontal transport scheme used in continuity:
                                 !   UPWIND_2D - Non-directionally split upwind
@@ -435,6 +450,9 @@ MAXTRUNC = 0                    !   [truncations save_interval-1] default = 0
 STATISTICS_FILE = "seaice.stats" ! default = "seaice.stats"
                                 ! The file to use to write the globally integrated
                                 ! statistics.
+
+! === module SIS_ice_diagnostics ===
+! This module handles sea-ice state diagnostics.
 
 ! === module SIS_fast_thermo ===
 ! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.

--- a/ice_ocean_SIS2/SIS2_bergs_cgrid/SIS_parameter_doc.short
+++ b/ice_ocean_SIS2/SIS2_bergs_cgrid/SIS_parameter_doc.short
@@ -99,6 +99,9 @@ ICE_TDAMP_ELASTIC = 1000.0      !   [s or nondim] default = -0.2
 
 ! === module SIS_sum_output ===
 
+! === module SIS_ice_diagnostics ===
+! This module handles sea-ice state diagnostics.
+
 ! === module SIS_fast_thermo ===
 ! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.
 

--- a/ice_ocean_SIS2/SIS2_cgrid/SIS.available_diags
+++ b/ice_ocean_SIS2/SIS2_cgrid/SIS.available_diags
@@ -307,6 +307,18 @@
 "ice_model", "IY_TRANS"  [Used]
     ! long_name: y-direction ice transport
     ! units: kg/s
+"ice_model", "XPRT"  [Used]
+    ! long_name: frozen water transport convergence
+    ! units: kg/(m^2*yr)
+"ice_model", "RDG_RATE"  [Unused]
+    ! long_name: ice ridging rate
+    ! units: 1/sec
+"ice_model", "FA_X"  [Used]
+    ! long_name: Air stress on ice on C-grid - x component
+    ! units: Pa
+"ice_model", "FA_Y"  [Used]
+    ! long_name: Air stress on ice on C-grid - y component
+    ! units: Pa
 "ice_model", "EXT"  [Used]
     ! long_name: ice modeled
     ! units: 0 or 1
@@ -373,15 +385,6 @@
 "ice_model", "Sal4"  [Unused]
     ! long_name: ice layer 4 salinity
     ! units: g/kg
-"ice_model", "FA_X"  [Used]
-    ! long_name: Air stress on ice on C-grid - x component
-    ! units: Pa
-"ice_model", "FA_Y"  [Used]
-    ! long_name: Air stress on ice on C-grid - y component
-    ! units: Pa
-"ice_model", "XPRT"  [Used]
-    ! long_name: frozen water transport convergence
-    ! units: kg/(m^2*yr)
 "ice_model", "MI"  [Used]
     ! long_name: ice + snow mass
     ! units: kg/m^2
@@ -397,6 +400,3 @@
 "ice_model", "E2MELT"  [Unused]
     ! long_name: heat needed to melt ice
     ! units: J/m^2
-"ice_model", "RDG_RATE"  [Unused]
-    ! long_name: ice ridging rate
-    ! units: 1/sec

--- a/ice_ocean_SIS2/SIS2_cgrid/SIS_parameter_doc.all
+++ b/ice_ocean_SIS2/SIS2_cgrid/SIS_parameter_doc.all
@@ -90,6 +90,8 @@ RESTARTFILE = "ice_model.res.nc" ! default = "ice_model.res.nc"
 FAST_ICE_RESTARTFILE = "ice_model.res.nc" ! default = "ice_model.res.nc"
                                 ! The name of the restart file for those elements of the
                                 ! the sea ice that are handled by the fast ice PEs.
+APPLY_MASKS_AFTER_RESTART = True !   [Boolean] default = True
+                                ! If true, applies masks to mH_ice,mH_snow and part_size after a restart.
 WRITE_GEOM = 1                  ! default = 1
                                 ! If =0, never write the geometry and vertical grid files.
                                 ! If =1, write the geometry and vertical grid files only for
@@ -324,11 +326,24 @@ DT_ICE_DYNAMICS = 3600.0        !   [seconds] default = -1.0
                                 ! stepping the continuity equation and interactions
                                 ! between the ice mass field and velocities.  If 0 or
                                 ! negative the coupling time step will be used.
+MERGED_CONTINUITY = False       !   [Boolean] default = False
+                                ! If true, update the continuity equations for the ice, snow,
+                                ! and melt pond water together summed across categories, with
+                                ! proportionate fluxes for each part. Otherwise the media are
+                                ! updated separately.
+NSTEPS_ADV = 1                  ! default = 1
+                                ! The number of advective iterations for each slow dynamics
+                                ! time step.
 ICEBERG_WINDSTRESS_BUG = False  !   [Boolean] default = False
                                 ! If true, use older code that applied an old ice-ocean
                                 ! stress to the icebergs in place of the current air-ocean
                                 ! stress.  This option is here for backward compatibility,
                                 ! but should be avoided.
+WARSAW_SUM_ORDER = True         !   [Boolean] default = True
+                                ! If true, use the order of sums in the Warsaw version of SIS2.
+                                ! The default is the opposite of MERGED_CONTINUITY.
+                                ! This option exists for backward compatibilty but may
+                                ! eventually be obsoleted.
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit for ICE_STATS_INTERVAL.
 ICE_STATS_INTERVAL = 0.25       !   [days] default = 1.0
@@ -380,9 +395,6 @@ CFL_TRUNC_DYN_ITS = False       !   [Boolean] default = False
                                 ! If true, check the CFL number for every iteration of the
                                 ! rheology solver; otherwise only the final velocities that
                                 ! are used for transport are checked.
-NSTEPS_ADV = 1                  ! default = 1
-                                ! The number of advective iterations for each slow time
-                                ! step.
 RECATEGORIZE_ICE = True         !   [Boolean] default = True
                                 ! If true, readjust the distribution into ice thickness
                                 ! categories after advection.
@@ -399,6 +411,9 @@ SIS_THICKNESS_ADVECTION_SCHEME = "UPWIND_2D" ! default = "UPWIND_2D"
                                 !   PCM    - Directionally split piecewise constant
                                 !   PLM    - Piecewise Linear Method
                                 !   PPM:H3 - Piecewise Parabolic Method (Huyhn 3rd order)
+INCONSISTENT_COVER_BUG = True   !   [Boolean] default = True
+                                ! If true, omit a recalculation of the fractional ice-free
+                                ! areal coverage after the adjustment of the ice categories.
 SIS_CONTINUITY_SCHEME = "UPWIND_2D" ! default = "UPWIND_2D"
                                 ! The horizontal transport scheme used in continuity:
                                 !   UPWIND_2D - Non-directionally split upwind
@@ -433,6 +448,9 @@ MAXTRUNC = 0                    !   [truncations save_interval-1] default = 0
 STATISTICS_FILE = "seaice.stats" ! default = "seaice.stats"
                                 ! The file to use to write the globally integrated
                                 ! statistics.
+
+! === module SIS_ice_diagnostics ===
+! This module handles sea-ice state diagnostics.
 
 ! === module SIS_fast_thermo ===
 ! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.

--- a/ice_ocean_SIS2/SIS2_cgrid/SIS_parameter_doc.short
+++ b/ice_ocean_SIS2/SIS2_cgrid/SIS_parameter_doc.short
@@ -102,6 +102,9 @@ ICE_TDAMP_ELASTIC = 1000.0      !   [s or nondim] default = -0.2
 
 ! === module SIS_sum_output ===
 
+! === module SIS_ice_diagnostics ===
+! This module handles sea-ice state diagnostics.
+
 ! === module SIS_fast_thermo ===
 ! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.
 

--- a/land_ice_ocean_LM3_SIS2/OM_360x320_C180/SIS_parameter_doc.all
+++ b/land_ice_ocean_LM3_SIS2/OM_360x320_C180/SIS_parameter_doc.all
@@ -90,6 +90,8 @@ RESTARTFILE = "ice_model.res.nc" ! default = "ice_model.res.nc"
 FAST_ICE_RESTARTFILE = "ice_model.res.nc" ! default = "ice_model.res.nc"
                                 ! The name of the restart file for those elements of the
                                 ! the sea ice that are handled by the fast ice PEs.
+APPLY_MASKS_AFTER_RESTART = True !   [Boolean] default = True
+                                ! If true, applies masks to mH_ice,mH_snow and part_size after a restart.
 WRITE_GEOM = 1                  ! default = 1
                                 ! If =0, never write the geometry and vertical grid files.
                                 ! If =1, write the geometry and vertical grid files only for
@@ -320,11 +322,24 @@ DT_ICE_DYNAMICS = 1200.0        !   [seconds] default = -1.0
                                 ! stepping the continuity equation and interactions
                                 ! between the ice mass field and velocities.  If 0 or
                                 ! negative the coupling time step will be used.
+MERGED_CONTINUITY = False       !   [Boolean] default = False
+                                ! If true, update the continuity equations for the ice, snow,
+                                ! and melt pond water together summed across categories, with
+                                ! proportionate fluxes for each part. Otherwise the media are
+                                ! updated separately.
+NSTEPS_ADV = 1                  ! default = 1
+                                ! The number of advective iterations for each slow dynamics
+                                ! time step.
 ICEBERG_WINDSTRESS_BUG = False  !   [Boolean] default = False
                                 ! If true, use older code that applied an old ice-ocean
                                 ! stress to the icebergs in place of the current air-ocean
                                 ! stress.  This option is here for backward compatibility,
                                 ! but should be avoided.
+WARSAW_SUM_ORDER = True         !   [Boolean] default = True
+                                ! If true, use the order of sums in the Warsaw version of SIS2.
+                                ! The default is the opposite of MERGED_CONTINUITY.
+                                ! This option exists for backward compatibilty but may
+                                ! eventually be obsoleted.
 TIMEUNIT = 8.64E+04             !   [s] default = 8.64E+04
                                 ! The time unit for ICE_STATS_INTERVAL.
 ICE_STATS_INTERVAL = 0.25       !   [days] default = 1.0
@@ -376,9 +391,6 @@ CFL_TRUNC_DYN_ITS = False       !   [Boolean] default = False
                                 ! If true, check the CFL number for every iteration of the
                                 ! rheology solver; otherwise only the final velocities that
                                 ! are used for transport are checked.
-NSTEPS_ADV = 1                  ! default = 1
-                                ! The number of advective iterations for each slow time
-                                ! step.
 RECATEGORIZE_ICE = True         !   [Boolean] default = True
                                 ! If true, readjust the distribution into ice thickness
                                 ! categories after advection.
@@ -395,6 +407,9 @@ SIS_THICKNESS_ADVECTION_SCHEME = "UPWIND_2D" ! default = "UPWIND_2D"
                                 !   PCM    - Directionally split piecewise constant
                                 !   PLM    - Piecewise Linear Method
                                 !   PPM:H3 - Piecewise Parabolic Method (Huyhn 3rd order)
+INCONSISTENT_COVER_BUG = True   !   [Boolean] default = True
+                                ! If true, omit a recalculation of the fractional ice-free
+                                ! areal coverage after the adjustment of the ice categories.
 SIS_CONTINUITY_SCHEME = "UPWIND_2D" ! default = "UPWIND_2D"
                                 ! The horizontal transport scheme used in continuity:
                                 !   UPWIND_2D - Non-directionally split upwind
@@ -429,6 +444,9 @@ MAXTRUNC = 0                    !   [truncations save_interval-1] default = 0
 STATISTICS_FILE = "seaice.stats" ! default = "seaice.stats"
                                 ! The file to use to write the globally integrated
                                 ! statistics.
+
+! === module SIS_ice_diagnostics ===
+! This module handles sea-ice state diagnostics.
 
 ! === module SIS_fast_thermo ===
 ! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.

--- a/land_ice_ocean_LM3_SIS2/OM_360x320_C180/SIS_parameter_doc.short
+++ b/land_ice_ocean_LM3_SIS2/OM_360x320_C180/SIS_parameter_doc.short
@@ -99,6 +99,9 @@ ICE_TDAMP_ELASTIC = 1000.0      !   [s or nondim] default = -0.2
 
 ! === module SIS_sum_output ===
 
+! === module SIS_ice_diagnostics ===
+! This module handles sea-ice state diagnostics.
+
 ! === module SIS_fast_thermo ===
 ! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.
 

--- a/ocean_only/global_ALE/layer/available_diags.000000
+++ b/ocean_only/global_ALE/layer/available_diags.000000
@@ -144,7 +144,31 @@
     ! units: m3
     ! standard_name: ocean_volume
     ! cell_methods: z_l:sum
+"ocean_model_d2", "volcello"  [Unused]
+    ! long_name: Ocean grid-cell volume
+    ! units: m3
+    ! standard_name: ocean_volume
+    ! cell_methods: xh:sum yh:sum zl:sum area:sum
+"ocean_model_d2", "volcello_xyave"  [Unused]
+    ! long_name: Ocean grid-cell volume
+    ! units: m3
+    ! standard_name: ocean_volume
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "volcello"  [Unused]
+    ! long_name: Ocean grid-cell volume
+    ! units: m3
+    ! standard_name: ocean_volume
+    ! cell_methods: xh:sum yh:sum z_l:sum area:sum
+"ocean_model_z_d2", "volcello_xyave"  [Unused]
+    ! long_name: Ocean grid-cell volume
+    ! units: m3
+    ! standard_name: ocean_volume
+    ! cell_methods: z_l:sum
 "ocean_model", "MEKE"  [Used]
+    ! long_name: Mesoscale Eddy Kinetic Energy
+    ! units: m2 s-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "MEKE"  [Unused]
     ! long_name: Mesoscale Eddy Kinetic Energy
     ! units: m2 s-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -152,7 +176,15 @@
     ! long_name: MEKE derived diffusivity
     ! units: m2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "MEKE_KH"  [Unused]
+    ! long_name: MEKE derived diffusivity
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "MEKE_KU"  [Unused]
+    ! long_name: MEKE derived lateral viscosity
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "MEKE_KU"  [Unused]
     ! long_name: MEKE derived lateral viscosity
     ! units: m2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
@@ -160,7 +192,15 @@
     ! long_name: MEKE derived eddy-velocity scale
     ! units: m s-1
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "MEKE_Ue"  [Unused]
+    ! long_name: MEKE derived eddy-velocity scale
+    ! units: m s-1
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "MEKE_Ub"  [Unused]
+    ! long_name: MEKE derived bottom eddy-velocity scale
+    ! units: m s-1
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "MEKE_Ub"  [Unused]
     ! long_name: MEKE derived bottom eddy-velocity scale
     ! units: m s-1
     ! cell_methods: xh:mean yh:mean area:mean
@@ -168,7 +208,15 @@
     ! long_name: MEKE derived barotropic eddy-velocity scale
     ! units: m s-1
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "MEKE_Ut"  [Unused]
+    ! long_name: MEKE derived barotropic eddy-velocity scale
+    ! units: m s-1
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "MEKE_src"  [Unused]
+    ! long_name: MEKE energy source
+    ! units: m2 s-3
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "MEKE_src"  [Unused]
     ! long_name: MEKE energy source
     ! units: m2 s-3
     ! cell_methods: xh:mean yh:mean area:mean
@@ -176,7 +224,15 @@
     ! long_name: MEKE decay rate
     ! units: s-1
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "MEKE_decay"  [Unused]
+    ! long_name: MEKE decay rate
+    ! units: s-1
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "KHMEKE_u"  [Unused]
+    ! long_name: Zonal diffusivity of MEKE
+    ! units: m2 s-1
+    ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "KHMEKE_u"  [Unused]
     ! long_name: Zonal diffusivity of MEKE
     ! units: m2 s-1
     ! cell_methods: xq:point yh:mean
@@ -184,7 +240,15 @@
     ! long_name: Meridional diffusivity of MEKE
     ! units: m2 s-1
     ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "KHMEKE_v"  [Unused]
+    ! long_name: Meridional diffusivity of MEKE
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yq:point
 "ocean_model", "MEKE_GM_src"  [Unused]
+    ! long_name: MEKE energy available from thickness mixing
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "MEKE_GM_src"  [Unused]
     ! long_name: MEKE energy available from thickness mixing
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -192,7 +256,15 @@
     ! long_name: MEKE energy available from momentum
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "MEKE_mom_src"  [Unused]
+    ! long_name: MEKE energy available from momentum
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "MEKE_Le"  [Unused]
+    ! long_name: Eddy mixing length used in the MEKE derived eddy diffusivity
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "MEKE_Le"  [Unused]
     ! long_name: Eddy mixing length used in the MEKE derived eddy diffusivity
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
@@ -200,7 +272,15 @@
     ! long_name: Rhines length scale used in the MEKE derived eddy diffusivity
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "MEKE_Lrhines"  [Unused]
+    ! long_name: Rhines length scale used in the MEKE derived eddy diffusivity
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "MEKE_Leady"  [Unused]
+    ! long_name: Eady length scale used in the MEKE derived eddy diffusivity
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "MEKE_Leady"  [Unused]
     ! long_name: Eady length scale used in the MEKE derived eddy diffusivity
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
@@ -208,7 +288,15 @@
     ! long_name: Ratio of bottom-projected eddy velocity to column-mean eddy velocity
     ! units: nondim
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "MEKE_gamma_b"  [Unused]
+    ! long_name: Ratio of bottom-projected eddy velocity to column-mean eddy velocity
+    ! units: nondim
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "MEKE_gamma_t"  [Unused]
+    ! long_name: Ratio of barotropic eddy velocity to column-mean eddy velocity
+    ! units: nondim
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "MEKE_gamma_t"  [Unused]
     ! long_name: Ratio of barotropic eddy velocity to column-mean eddy velocity
     ! units: nondim
     ! cell_methods: xh:mean yh:mean area:mean
@@ -216,7 +304,15 @@
     ! long_name: Inverse eddy time-scale, S*N, at u-points
     ! units: s-1
     ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "SN_u"  [Unused]
+    ! long_name: Inverse eddy time-scale, S*N, at u-points
+    ! units: s-1
+    ! cell_methods: xq:point yh:mean
 "ocean_model", "SN_v"  [Unused]
+    ! long_name: Inverse eddy time-scale, S*N, at v-points
+    ! units: s-1
+    ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "SN_v"  [Unused]
     ! long_name: Inverse eddy time-scale, S*N, at v-points
     ! units: s-1
     ! cell_methods: xh:mean yq:point
@@ -224,7 +320,15 @@
     ! long_name: Resolution function for scaling diffusivities
     ! units: nondim
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "Res_fn"  [Unused]
+    ! long_name: Resolution function for scaling diffusivities
+    ! units: nondim
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "Rd_dx"  [Unused]
+    ! long_name: Ratio between deformation radius and grid spacing
+    ! units: m m-1
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "Rd_dx"  [Unused]
     ! long_name: Ratio between deformation radius and grid spacing
     ! units: m m-1
     ! cell_methods: xh:mean yh:mean area:mean
@@ -232,7 +336,15 @@
     ! long_name: BBL thickness at u points
     ! units: m
     ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "bbl_thick_u"  [Unused]
+    ! long_name: BBL thickness at u points
+    ! units: m
+    ! cell_methods: xq:point yh:mean
 "ocean_model", "kv_bbl_u"  [Unused]
+    ! long_name: BBL viscosity at u points
+    ! units: m2 s-1
+    ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "kv_bbl_u"  [Unused]
     ! long_name: BBL viscosity at u points
     ! units: m2 s-1
     ! cell_methods: xq:point yh:mean
@@ -240,7 +352,15 @@
     ! long_name: BBL thickness at v points
     ! units: m
     ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "bbl_thick_v"  [Unused]
+    ! long_name: BBL thickness at v points
+    ! units: m
+    ! cell_methods: xh:mean yq:point
 "ocean_model", "kv_bbl_v"  [Unused]
+    ! long_name: BBL viscosity at v points
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "kv_bbl_v"  [Unused]
     ! long_name: BBL viscosity at v points
     ! units: m2 s-1
     ! cell_methods: xh:mean yq:point
@@ -260,6 +380,22 @@
     ! long_name: Rayleigh drag velocity at u points
     ! units: m s-1
     ! cell_methods: z_l:mean
+"ocean_model_d2", "Rayleigh_u"  [Unused]
+    ! long_name: Rayleigh drag velocity at u points
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean zl:mean
+"ocean_model_d2", "Rayleigh_u_xyave"  [Unused]
+    ! long_name: Rayleigh drag velocity at u points
+    ! units: m s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "Rayleigh_u"  [Unused]
+    ! long_name: Rayleigh drag velocity at u points
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean z_l:mean
+"ocean_model_z_d2", "Rayleigh_u_xyave"  [Unused]
+    ! long_name: Rayleigh drag velocity at u points
+    ! units: m s-1
+    ! cell_methods: z_l:mean
 "ocean_model", "Rayleigh_v"  [Unused]
     ! long_name: Rayleigh drag velocity at v points
     ! units: m s-1
@@ -276,11 +412,35 @@
     ! long_name: Rayleigh drag velocity at v points
     ! units: m s-1
     ! cell_methods: z_l:mean
+"ocean_model_d2", "Rayleigh_v"  [Unused]
+    ! long_name: Rayleigh drag velocity at v points
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point zl:mean
+"ocean_model_d2", "Rayleigh_v_xyave"  [Unused]
+    ! long_name: Rayleigh drag velocity at v points
+    ! units: m s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "Rayleigh_v"  [Unused]
+    ! long_name: Rayleigh drag velocity at v points
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point z_l:mean
+"ocean_model_z_d2", "Rayleigh_v_xyave"  [Unused]
+    ! long_name: Rayleigh drag velocity at v points
+    ! units: m s-1
+    ! cell_methods: z_l:mean
 "ocean_model", "RV"  [Unused]
     ! long_name: Relative Vorticity
     ! units: s-1
     ! cell_methods: xq:point yq:point zl:mean
+"ocean_model_d2", "RV"  [Unused]
+    ! long_name: Relative Vorticity
+    ! units: s-1
+    ! cell_methods: xq:point yq:point zl:mean
 "ocean_model", "PV"  [Unused]
+    ! long_name: Potential Vorticity
+    ! units: m-1 s-1
+    ! cell_methods: xq:point yq:point zl:mean
+"ocean_model_d2", "PV"  [Unused]
     ! long_name: Potential Vorticity
     ! units: m-1 s-1
     ! cell_methods: xq:point yq:point zl:mean
@@ -300,6 +460,22 @@
     ! long_name: Zonal Acceleration from Grad. Kinetic Energy
     ! units: m-1 s-2
     ! cell_methods: z_l:mean
+"ocean_model_d2", "gKEu"  [Unused]
+    ! long_name: Zonal Acceleration from Grad. Kinetic Energy
+    ! units: m-1 s-2
+    ! cell_methods: xq:point yh:mean zl:mean
+"ocean_model_d2", "gKEu_xyave"  [Unused]
+    ! long_name: Zonal Acceleration from Grad. Kinetic Energy
+    ! units: m-1 s-2
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "gKEu"  [Unused]
+    ! long_name: Zonal Acceleration from Grad. Kinetic Energy
+    ! units: m-1 s-2
+    ! cell_methods: xq:point yh:mean z_l:mean
+"ocean_model_z_d2", "gKEu_xyave"  [Unused]
+    ! long_name: Zonal Acceleration from Grad. Kinetic Energy
+    ! units: m-1 s-2
+    ! cell_methods: z_l:mean
 "ocean_model", "gKEv"  [Unused]
     ! long_name: Meridional Acceleration from Grad. Kinetic Energy
     ! units: m-1 s-2
@@ -313,6 +489,22 @@
     ! units: m-1 s-2
     ! cell_methods: xh:mean yq:point z_l:mean
 "ocean_model_z", "gKEv_xyave"  [Unused]
+    ! long_name: Meridional Acceleration from Grad. Kinetic Energy
+    ! units: m-1 s-2
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "gKEv"  [Unused]
+    ! long_name: Meridional Acceleration from Grad. Kinetic Energy
+    ! units: m-1 s-2
+    ! cell_methods: xh:mean yq:point zl:mean
+"ocean_model_d2", "gKEv_xyave"  [Unused]
+    ! long_name: Meridional Acceleration from Grad. Kinetic Energy
+    ! units: m-1 s-2
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "gKEv"  [Unused]
+    ! long_name: Meridional Acceleration from Grad. Kinetic Energy
+    ! units: m-1 s-2
+    ! cell_methods: xh:mean yq:point z_l:mean
+"ocean_model_z_d2", "gKEv_xyave"  [Unused]
     ! long_name: Meridional Acceleration from Grad. Kinetic Energy
     ! units: m-1 s-2
     ! cell_methods: z_l:mean
@@ -332,6 +524,22 @@
     ! long_name: Meridional Acceleration from Relative Vorticity
     ! units: m-1 s-2
     ! cell_methods: z_l:mean
+"ocean_model_d2", "rvxu"  [Unused]
+    ! long_name: Meridional Acceleration from Relative Vorticity
+    ! units: m-1 s-2
+    ! cell_methods: xh:mean yq:point zl:mean
+"ocean_model_d2", "rvxu_xyave"  [Unused]
+    ! long_name: Meridional Acceleration from Relative Vorticity
+    ! units: m-1 s-2
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "rvxu"  [Unused]
+    ! long_name: Meridional Acceleration from Relative Vorticity
+    ! units: m-1 s-2
+    ! cell_methods: xh:mean yq:point z_l:mean
+"ocean_model_z_d2", "rvxu_xyave"  [Unused]
+    ! long_name: Meridional Acceleration from Relative Vorticity
+    ! units: m-1 s-2
+    ! cell_methods: z_l:mean
 "ocean_model", "rvxv"  [Unused]
     ! long_name: Zonal Acceleration from Relative Vorticity
     ! units: m-1 s-2
@@ -348,7 +556,27 @@
     ! long_name: Zonal Acceleration from Relative Vorticity
     ! units: m-1 s-2
     ! cell_methods: z_l:mean
+"ocean_model_d2", "rvxv"  [Unused]
+    ! long_name: Zonal Acceleration from Relative Vorticity
+    ! units: m-1 s-2
+    ! cell_methods: xq:point yh:mean zl:mean
+"ocean_model_d2", "rvxv_xyave"  [Unused]
+    ! long_name: Zonal Acceleration from Relative Vorticity
+    ! units: m-1 s-2
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "rvxv"  [Unused]
+    ! long_name: Zonal Acceleration from Relative Vorticity
+    ! units: m-1 s-2
+    ! cell_methods: xq:point yh:mean z_l:mean
+"ocean_model_z_d2", "rvxv_xyave"  [Unused]
+    ! long_name: Zonal Acceleration from Relative Vorticity
+    ! units: m-1 s-2
+    ! cell_methods: z_l:mean
 "ocean_model", "e_tidal"  [Unused]
+    ! long_name: Tidal Forcing Astronomical and SAL Height Anomaly
+    ! units: meter
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "e_tidal"  [Unused]
     ! long_name: Tidal Forcing Astronomical and SAL Height Anomaly
     ! units: meter
     ! cell_methods: xh:mean yh:mean area:mean
@@ -368,6 +596,22 @@
     ! long_name: Zonal Acceleration from Horizontal Viscosity
     ! units: m s-2
     ! cell_methods: z_l:mean
+"ocean_model_d2", "diffu"  [Unused]
+    ! long_name: Zonal Acceleration from Horizontal Viscosity
+    ! units: m s-2
+    ! cell_methods: xq:point yh:mean zl:mean
+"ocean_model_d2", "diffu_xyave"  [Unused]
+    ! long_name: Zonal Acceleration from Horizontal Viscosity
+    ! units: m s-2
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "diffu"  [Unused]
+    ! long_name: Zonal Acceleration from Horizontal Viscosity
+    ! units: m s-2
+    ! cell_methods: xq:point yh:mean z_l:mean
+"ocean_model_z_d2", "diffu_xyave"  [Unused]
+    ! long_name: Zonal Acceleration from Horizontal Viscosity
+    ! units: m s-2
+    ! cell_methods: z_l:mean
 "ocean_model", "diffv"  [Unused]
     ! long_name: Meridional Acceleration from Horizontal Viscosity
     ! units: m s-2
@@ -381,6 +625,22 @@
     ! units: m s-2
     ! cell_methods: xh:mean yq:point z_l:mean
 "ocean_model_z", "diffv_xyave"  [Unused]
+    ! long_name: Meridional Acceleration from Horizontal Viscosity
+    ! units: m s-2
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "diffv"  [Unused]
+    ! long_name: Meridional Acceleration from Horizontal Viscosity
+    ! units: m s-2
+    ! cell_methods: xh:mean yq:point zl:mean
+"ocean_model_d2", "diffv_xyave"  [Unused]
+    ! long_name: Meridional Acceleration from Horizontal Viscosity
+    ! units: m s-2
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "diffv"  [Unused]
+    ! long_name: Meridional Acceleration from Horizontal Viscosity
+    ! units: m s-2
+    ! cell_methods: xh:mean yq:point z_l:mean
+"ocean_model_z_d2", "diffv_xyave"  [Unused]
     ! long_name: Meridional Acceleration from Horizontal Viscosity
     ! units: m s-2
     ! cell_methods: z_l:mean
@@ -420,7 +680,47 @@
     ! units: m4 s-1
     ! standard_name: ocean_momentum_xy_biharmonic_diffusivity
     ! cell_methods: z_l:mean
+"ocean_model_d2", "Ahh"  [Unused] (CMOR equivalent is "difmxybo")
+    ! long_name: Biharmonic Horizontal Viscosity at h Points
+    ! units: m4 s-1
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "Ahh_xyave"  [Unused] (CMOR equivalent is "difmxybo_xyave")
+    ! long_name: Biharmonic Horizontal Viscosity at h Points
+    ! units: m4 s-1
+    ! cell_methods: zl:mean
+"ocean_model_d2", "difmxybo"  [Unused] (native name is "Ahh")
+    ! long_name: Ocean lateral biharmonic viscosity
+    ! units: m4 s-1
+    ! standard_name: ocean_momentum_xy_biharmonic_diffusivity
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "difmxybo_xyave"  [Unused] (native name is "Ahh_xyave")
+    ! long_name: Ocean lateral biharmonic viscosity
+    ! units: m4 s-1
+    ! standard_name: ocean_momentum_xy_biharmonic_diffusivity
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "Ahh"  [Unused] (CMOR equivalent is "difmxybo")
+    ! long_name: Biharmonic Horizontal Viscosity at h Points
+    ! units: m4 s-1
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "Ahh_xyave"  [Unused] (CMOR equivalent is "difmxybo_xyave")
+    ! long_name: Biharmonic Horizontal Viscosity at h Points
+    ! units: m4 s-1
+    ! cell_methods: z_l:mean
+"ocean_model_z_d2", "difmxybo"  [Unused] (native name is "Ahh")
+    ! long_name: Ocean lateral biharmonic viscosity
+    ! units: m4 s-1
+    ! standard_name: ocean_momentum_xy_biharmonic_diffusivity
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "difmxybo_xyave"  [Unused] (native name is "Ahh_xyave")
+    ! long_name: Ocean lateral biharmonic viscosity
+    ! units: m4 s-1
+    ! standard_name: ocean_momentum_xy_biharmonic_diffusivity
+    ! cell_methods: z_l:mean
 "ocean_model", "Ahq"  [Unused]
+    ! long_name: Biharmonic Horizontal Viscosity at q Points
+    ! units: m4 s-1
+    ! cell_methods: xq:point yq:point zl:mean
+"ocean_model_d2", "Ahq"  [Unused]
     ! long_name: Biharmonic Horizontal Viscosity at q Points
     ! units: m4 s-1
     ! cell_methods: xq:point yq:point zl:mean
@@ -460,7 +760,47 @@
     ! units: m2 s-1
     ! standard_name: ocean_momentum_xy_laplacian_diffusivity
     ! cell_methods: z_l:mean
+"ocean_model_d2", "Khh"  [Unused] (CMOR equivalent is "difmxylo")
+    ! long_name: Laplacian Horizontal Viscosity at h Points
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "Khh_xyave"  [Unused] (CMOR equivalent is "difmxylo_xyave")
+    ! long_name: Laplacian Horizontal Viscosity at h Points
+    ! units: m2 s-1
+    ! cell_methods: zl:mean
+"ocean_model_d2", "difmxylo"  [Unused] (native name is "Khh")
+    ! long_name: Ocean lateral Laplacian viscosity
+    ! units: m2 s-1
+    ! standard_name: ocean_momentum_xy_laplacian_diffusivity
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "difmxylo_xyave"  [Unused] (native name is "Khh_xyave")
+    ! long_name: Ocean lateral Laplacian viscosity
+    ! units: m2 s-1
+    ! standard_name: ocean_momentum_xy_laplacian_diffusivity
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "Khh"  [Unused] (CMOR equivalent is "difmxylo")
+    ! long_name: Laplacian Horizontal Viscosity at h Points
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "Khh_xyave"  [Unused] (CMOR equivalent is "difmxylo_xyave")
+    ! long_name: Laplacian Horizontal Viscosity at h Points
+    ! units: m2 s-1
+    ! cell_methods: z_l:mean
+"ocean_model_z_d2", "difmxylo"  [Unused] (native name is "Khh")
+    ! long_name: Ocean lateral Laplacian viscosity
+    ! units: m2 s-1
+    ! standard_name: ocean_momentum_xy_laplacian_diffusivity
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "difmxylo_xyave"  [Unused] (native name is "Khh_xyave")
+    ! long_name: Ocean lateral Laplacian viscosity
+    ! units: m2 s-1
+    ! standard_name: ocean_momentum_xy_laplacian_diffusivity
+    ! cell_methods: z_l:mean
 "ocean_model", "Khq"  [Unused]
+    ! long_name: Laplacian Horizontal Viscosity at q Points
+    ! units: m2 s-1
+    ! cell_methods: xq:point yq:point zl:mean
+"ocean_model_d2", "Khq"  [Unused]
     ! long_name: Laplacian Horizontal Viscosity at q Points
     ! units: m2 s-1
     ! cell_methods: xq:point yq:point zl:mean
@@ -480,11 +820,36 @@
     ! long_name: Integral work done by lateral friction terms
     ! units: W m-2
     ! cell_methods: z_l:mean
+"ocean_model_d2", "FrictWork"  [Unused]
+    ! long_name: Integral work done by lateral friction terms
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "FrictWork_xyave"  [Unused]
+    ! long_name: Integral work done by lateral friction terms
+    ! units: W m-2
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "FrictWork"  [Unused]
+    ! long_name: Integral work done by lateral friction terms
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "FrictWork_xyave"  [Unused]
+    ! long_name: Integral work done by lateral friction terms
+    ! units: W m-2
+    ! cell_methods: z_l:mean
 "ocean_model", "FrictWorkIntz"  [Unused] (CMOR equivalent is "dispkexyfo")
     ! long_name: Depth integrated work done by lateral friction
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "dispkexyfo"  [Used] (native name is "FrictWorkIntz")
+    ! long_name: Depth integrated ocean kinetic energy dissipation due to lateral friction
+    ! units: W m-2
+    ! standard_name: ocean_kinetic_energy_dissipation_per_unit_area_due_to_xy_friction
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "FrictWorkIntz"  [Unused] (CMOR equivalent is "dispkexyfo")
+    ! long_name: Depth integrated work done by lateral friction
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "dispkexyfo"  [Unused] (native name is "FrictWorkIntz")
     ! long_name: Depth integrated ocean kinetic energy dissipation due to lateral friction
     ! units: W m-2
     ! standard_name: ocean_kinetic_energy_dissipation_per_unit_area_due_to_xy_friction
@@ -505,6 +870,22 @@
     ! long_name: Slow varying vertical viscosity
     ! units: m2 s-1
     ! cell_methods: z_i:point
+"ocean_model_d2", "Kv_slow"  [Unused]
+    ! long_name: Slow varying vertical viscosity
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "Kv_slow_xyave"  [Unused]
+    ! long_name: Slow varying vertical viscosity
+    ! units: m2 s-1
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "Kv_slow"  [Unused]
+    ! long_name: Slow varying vertical viscosity
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "Kv_slow_xyave"  [Unused]
+    ! long_name: Slow varying vertical viscosity
+    ! units: m2 s-1
+    ! cell_methods: z_i:point
 "ocean_model", "Kv_u"  [Unused]
     ! long_name: Total vertical viscosity at u-points
     ! units: m2 s-1
@@ -518,6 +899,22 @@
     ! units: m2 s-1
     ! cell_methods: xq:point yh:mean z_l:mean
 "ocean_model_z", "Kv_u_xyave"  [Unused]
+    ! long_name: Total vertical viscosity at u-points
+    ! units: m2 s-1
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "Kv_u"  [Unused]
+    ! long_name: Total vertical viscosity at u-points
+    ! units: m2 s-1
+    ! cell_methods: xq:point yh:mean zl:mean
+"ocean_model_d2", "Kv_u_xyave"  [Unused]
+    ! long_name: Total vertical viscosity at u-points
+    ! units: m2 s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "Kv_u"  [Unused]
+    ! long_name: Total vertical viscosity at u-points
+    ! units: m2 s-1
+    ! cell_methods: xq:point yh:mean z_l:mean
+"ocean_model_z_d2", "Kv_u_xyave"  [Unused]
     ! long_name: Total vertical viscosity at u-points
     ! units: m2 s-1
     ! cell_methods: z_l:mean
@@ -537,6 +934,22 @@
     ! long_name: Total vertical viscosity at v-points
     ! units: m2 s-1
     ! cell_methods: z_l:mean
+"ocean_model_d2", "Kv_v"  [Unused]
+    ! long_name: Total vertical viscosity at v-points
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yq:point zl:mean
+"ocean_model_d2", "Kv_v_xyave"  [Unused]
+    ! long_name: Total vertical viscosity at v-points
+    ! units: m2 s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "Kv_v"  [Unused]
+    ! long_name: Total vertical viscosity at v-points
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yq:point z_l:mean
+"ocean_model_z_d2", "Kv_v_xyave"  [Unused]
+    ! long_name: Total vertical viscosity at v-points
+    ! units: m2 s-1
+    ! cell_methods: z_l:mean
 "ocean_model", "au_visc"  [Unused]
     ! long_name: Zonal Viscous Vertical Coupling Coefficient
     ! units: m s-1
@@ -550,6 +963,22 @@
     ! units: m s-1
     ! cell_methods: xq:point yh:mean z_i:point
 "ocean_model_z", "au_visc_xyave"  [Unused]
+    ! long_name: Zonal Viscous Vertical Coupling Coefficient
+    ! units: m s-1
+    ! cell_methods: z_i:point
+"ocean_model_d2", "au_visc"  [Unused]
+    ! long_name: Zonal Viscous Vertical Coupling Coefficient
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean zi:point
+"ocean_model_d2", "au_visc_xyave"  [Unused]
+    ! long_name: Zonal Viscous Vertical Coupling Coefficient
+    ! units: m s-1
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "au_visc"  [Unused]
+    ! long_name: Zonal Viscous Vertical Coupling Coefficient
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean z_i:point
+"ocean_model_z_d2", "au_visc_xyave"  [Unused]
     ! long_name: Zonal Viscous Vertical Coupling Coefficient
     ! units: m s-1
     ! cell_methods: z_i:point
@@ -569,6 +998,22 @@
     ! long_name: Meridional Viscous Vertical Coupling Coefficient
     ! units: m s-1
     ! cell_methods: z_i:point
+"ocean_model_d2", "av_visc"  [Unused]
+    ! long_name: Meridional Viscous Vertical Coupling Coefficient
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point zi:point
+"ocean_model_d2", "av_visc_xyave"  [Unused]
+    ! long_name: Meridional Viscous Vertical Coupling Coefficient
+    ! units: m s-1
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "av_visc"  [Unused]
+    ! long_name: Meridional Viscous Vertical Coupling Coefficient
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point z_i:point
+"ocean_model_z_d2", "av_visc_xyave"  [Unused]
+    ! long_name: Meridional Viscous Vertical Coupling Coefficient
+    ! units: m s-1
+    ! cell_methods: z_i:point
 "ocean_model", "Hu_visc"  [Unused]
     ! long_name: Thickness at Zonal Velocity Points for Viscosity
     ! units: m
@@ -582,6 +1027,22 @@
     ! units: m
     ! cell_methods: xq:point yh:mean z_l:mean
 "ocean_model_z", "Hu_visc_xyave"  [Unused]
+    ! long_name: Thickness at Zonal Velocity Points for Viscosity
+    ! units: m
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "Hu_visc"  [Unused]
+    ! long_name: Thickness at Zonal Velocity Points for Viscosity
+    ! units: m
+    ! cell_methods: xq:point yh:mean zl:mean
+"ocean_model_d2", "Hu_visc_xyave"  [Unused]
+    ! long_name: Thickness at Zonal Velocity Points for Viscosity
+    ! units: m
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "Hu_visc"  [Unused]
+    ! long_name: Thickness at Zonal Velocity Points for Viscosity
+    ! units: m
+    ! cell_methods: xq:point yh:mean z_l:mean
+"ocean_model_z_d2", "Hu_visc_xyave"  [Unused]
     ! long_name: Thickness at Zonal Velocity Points for Viscosity
     ! units: m
     ! cell_methods: z_l:mean
@@ -601,11 +1062,35 @@
     ! long_name: Thickness at Meridional Velocity Points for Viscosity
     ! units: m
     ! cell_methods: z_l:mean
+"ocean_model_d2", "Hv_visc"  [Unused]
+    ! long_name: Thickness at Meridional Velocity Points for Viscosity
+    ! units: m
+    ! cell_methods: xh:mean yq:point zl:mean
+"ocean_model_d2", "Hv_visc_xyave"  [Unused]
+    ! long_name: Thickness at Meridional Velocity Points for Viscosity
+    ! units: m
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "Hv_visc"  [Unused]
+    ! long_name: Thickness at Meridional Velocity Points for Viscosity
+    ! units: m
+    ! cell_methods: xh:mean yq:point z_l:mean
+"ocean_model_z_d2", "Hv_visc_xyave"  [Unused]
+    ! long_name: Thickness at Meridional Velocity Points for Viscosity
+    ! units: m
+    ! cell_methods: z_l:mean
 "ocean_model", "HMLu_visc"  [Unused]
     ! long_name: Mixed Layer Thickness at Zonal Velocity Points for Viscosity
     ! units: m
     ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "HMLu_visc"  [Unused]
+    ! long_name: Mixed Layer Thickness at Zonal Velocity Points for Viscosity
+    ! units: m
+    ! cell_methods: xq:point yh:mean
 "ocean_model", "HMLv_visc"  [Unused]
+    ! long_name: Mixed Layer Thickness at Meridional Velocity Points for Viscosity
+    ! units: m
+    ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "HMLv_visc"  [Unused]
     ! long_name: Mixed Layer Thickness at Meridional Velocity Points for Viscosity
     ! units: m
     ! cell_methods: xh:mean yq:point
@@ -625,6 +1110,22 @@
     ! long_name: Zonal Acceleration from Vertical Viscosity
     ! units: m s-2
     ! cell_methods: z_l:mean
+"ocean_model_d2", "du_dt_visc"  [Unused]
+    ! long_name: Zonal Acceleration from Vertical Viscosity
+    ! units: m s-2
+    ! cell_methods: xq:point yh:mean zl:mean
+"ocean_model_d2", "du_dt_visc_xyave"  [Unused]
+    ! long_name: Zonal Acceleration from Vertical Viscosity
+    ! units: m s-2
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "du_dt_visc"  [Unused]
+    ! long_name: Zonal Acceleration from Vertical Viscosity
+    ! units: m s-2
+    ! cell_methods: xq:point yh:mean z_l:mean
+"ocean_model_z_d2", "du_dt_visc_xyave"  [Unused]
+    ! long_name: Zonal Acceleration from Vertical Viscosity
+    ! units: m s-2
+    ! cell_methods: z_l:mean
 "ocean_model", "dv_dt_visc"  [Unused]
     ! long_name: Meridional Acceleration from Vertical Viscosity
     ! units: m s-2
@@ -641,7 +1142,27 @@
     ! long_name: Meridional Acceleration from Vertical Viscosity
     ! units: m s-2
     ! cell_methods: z_l:mean
+"ocean_model_d2", "dv_dt_visc"  [Unused]
+    ! long_name: Meridional Acceleration from Vertical Viscosity
+    ! units: m s-2
+    ! cell_methods: xh:mean yq:point zl:mean
+"ocean_model_d2", "dv_dt_visc_xyave"  [Unused]
+    ! long_name: Meridional Acceleration from Vertical Viscosity
+    ! units: m s-2
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "dv_dt_visc"  [Unused]
+    ! long_name: Meridional Acceleration from Vertical Viscosity
+    ! units: m s-2
+    ! cell_methods: xh:mean yq:point z_l:mean
+"ocean_model_z_d2", "dv_dt_visc_xyave"  [Unused]
+    ! long_name: Meridional Acceleration from Vertical Viscosity
+    ! units: m s-2
+    ! cell_methods: z_l:mean
 "ocean_model", "taux_bot"  [Unused]
+    ! long_name: Zonal Bottom Stress from Ocean to Earth
+    ! units: Pa
+    ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "taux_bot"  [Unused]
     ! long_name: Zonal Bottom Stress from Ocean to Earth
     ! units: Pa
     ! cell_methods: xq:point yh:mean
@@ -649,7 +1170,15 @@
     ! long_name: Meridional Bottom Stress from Ocean to Earth
     ! units: Pa
     ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "tauy_bot"  [Unused]
+    ! long_name: Meridional Bottom Stress from Ocean to Earth
+    ! units: Pa
+    ! cell_methods: xh:mean yq:point
 "ocean_model", "PFuBT"  [Unused]
+    ! long_name: Zonal Anomalous Barotropic Pressure Force Force Acceleration
+    ! units: m s-2
+    ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "PFuBT"  [Unused]
     ! long_name: Zonal Anomalous Barotropic Pressure Force Force Acceleration
     ! units: m s-2
     ! cell_methods: xq:point yh:mean
@@ -657,7 +1186,15 @@
     ! long_name: Meridional Anomalous Barotropic Pressure Force Acceleration
     ! units: m s-2
     ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "PFvBT"  [Unused]
+    ! long_name: Meridional Anomalous Barotropic Pressure Force Acceleration
+    ! units: m s-2
+    ! cell_methods: xh:mean yq:point
 "ocean_model", "CoruBT"  [Unused]
+    ! long_name: Zonal Barotropic Coriolis Acceleration
+    ! units: m s-2
+    ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "CoruBT"  [Unused]
     ! long_name: Zonal Barotropic Coriolis Acceleration
     ! units: m s-2
     ! cell_methods: xq:point yh:mean
@@ -665,7 +1202,15 @@
     ! long_name: Meridional Barotropic Coriolis Acceleration
     ! units: m s-2
     ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "CorvBT"  [Unused]
+    ! long_name: Meridional Barotropic Coriolis Acceleration
+    ! units: m s-2
+    ! cell_methods: xh:mean yq:point
 "ocean_model", "u_accel_bt"  [Unused]
+    ! long_name: Barotropic zonal acceleration
+    ! units: m s-2
+    ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "u_accel_bt"  [Unused]
     ! long_name: Barotropic zonal acceleration
     ! units: m s-2
     ! cell_methods: xq:point yh:mean
@@ -673,7 +1218,15 @@
     ! long_name: Barotropic meridional acceleration
     ! units: m s-2
     ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "v_accel_bt"  [Unused]
+    ! long_name: Barotropic meridional acceleration
+    ! units: m s-2
+    ! cell_methods: xh:mean yq:point
 "ocean_model", "ubtforce"  [Unused]
+    ! long_name: Barotropic zonal acceleration from baroclinic terms
+    ! units: m s-2
+    ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "ubtforce"  [Unused]
     ! long_name: Barotropic zonal acceleration from baroclinic terms
     ! units: m s-2
     ! cell_methods: xq:point yh:mean
@@ -681,7 +1234,15 @@
     ! long_name: Barotropic meridional acceleration from baroclinic terms
     ! units: m s-2
     ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "vbtforce"  [Unused]
+    ! long_name: Barotropic meridional acceleration from baroclinic terms
+    ! units: m s-2
+    ! cell_methods: xh:mean yq:point
 "ocean_model", "eta_bt"  [Unused]
+    ! long_name: Barotropic end SSH
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "eta_bt"  [Unused]
     ! long_name: Barotropic end SSH
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
@@ -689,7 +1250,15 @@
     ! long_name: Barotropic end zonal velocity
     ! units: m s-1
     ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "ubt"  [Unused]
+    ! long_name: Barotropic end zonal velocity
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean
 "ocean_model", "vbt"  [Unused]
+    ! long_name: Barotropic end meridional velocity
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "vbt"  [Unused]
     ! long_name: Barotropic end meridional velocity
     ! units: m s-1
     ! cell_methods: xh:mean yq:point
@@ -697,7 +1266,15 @@
     ! long_name: Barotropic start SSH
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "eta_st"  [Unused]
+    ! long_name: Barotropic start SSH
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "ubt_st"  [Unused]
+    ! long_name: Barotropic start zonal velocity
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "ubt_st"  [Unused]
     ! long_name: Barotropic start zonal velocity
     ! units: m s-1
     ! cell_methods: xq:point yh:mean
@@ -705,7 +1282,15 @@
     ! long_name: Barotropic start meridional velocity
     ! units: m s-1
     ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "vbt_st"  [Unused]
+    ! long_name: Barotropic start meridional velocity
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point
 "ocean_model", "ubtav"  [Unused]
+    ! long_name: Barotropic time-average zonal velocity
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "ubtav"  [Unused]
     ! long_name: Barotropic time-average zonal velocity
     ! units: m s-1
     ! cell_methods: xq:point yh:mean
@@ -713,7 +1298,15 @@
     ! long_name: Barotropic time-average meridional velocity
     ! units: m s-1
     ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "vbtav"  [Unused]
+    ! long_name: Barotropic time-average meridional velocity
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point
 "ocean_model", "eta_cor"  [Unused]
+    ! long_name: Corrective mass flux
+    ! units: m s-1
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "eta_cor"  [Unused]
     ! long_name: Corrective mass flux
     ! units: m s-1
     ! cell_methods: xh:mean yh:mean area:mean
@@ -733,6 +1326,22 @@
     ! long_name: Viscous remnant at u
     ! units: nondim
     ! cell_methods: z_l:mean
+"ocean_model_d2", "visc_rem_u"  [Unused]
+    ! long_name: Viscous remnant at u
+    ! units: nondim
+    ! cell_methods: xq:point yh:mean zl:mean
+"ocean_model_d2", "visc_rem_u_xyave"  [Unused]
+    ! long_name: Viscous remnant at u
+    ! units: nondim
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "visc_rem_u"  [Unused]
+    ! long_name: Viscous remnant at u
+    ! units: nondim
+    ! cell_methods: xq:point yh:mean z_l:mean
+"ocean_model_z_d2", "visc_rem_u_xyave"  [Unused]
+    ! long_name: Viscous remnant at u
+    ! units: nondim
+    ! cell_methods: z_l:mean
 "ocean_model", "visc_rem_v"  [Unused]
     ! long_name: Viscous remnant at v
     ! units: nondim
@@ -749,7 +1358,27 @@
     ! long_name: Viscous remnant at v
     ! units: nondim
     ! cell_methods: z_l:mean
+"ocean_model_d2", "visc_rem_v"  [Unused]
+    ! long_name: Viscous remnant at v
+    ! units: nondim
+    ! cell_methods: xh:mean yq:point zl:mean
+"ocean_model_d2", "visc_rem_v_xyave"  [Unused]
+    ! long_name: Viscous remnant at v
+    ! units: nondim
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "visc_rem_v"  [Unused]
+    ! long_name: Viscous remnant at v
+    ! units: nondim
+    ! cell_methods: xh:mean yq:point z_l:mean
+"ocean_model_z_d2", "visc_rem_v_xyave"  [Unused]
+    ! long_name: Viscous remnant at v
+    ! units: nondim
+    ! cell_methods: z_l:mean
 "ocean_model", "gtot_n"  [Unused]
+    ! long_name: gtot to North
+    ! units: m s-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "gtot_n"  [Unused]
     ! long_name: gtot to North
     ! units: m s-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -757,7 +1386,15 @@
     ! long_name: gtot to South
     ! units: m s-2
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "gtot_s"  [Unused]
+    ! long_name: gtot to South
+    ! units: m s-2
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "gtot_e"  [Unused]
+    ! long_name: gtot to East
+    ! units: m s-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "gtot_e"  [Unused]
     ! long_name: gtot to East
     ! units: m s-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -765,7 +1402,15 @@
     ! long_name: gtot to West
     ! units: m s-2
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "gtot_w"  [Unused]
+    ! long_name: gtot to West
+    ! units: m s-2
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "eta_hifreq"  [Unused]
+    ! long_name: High Frequency Barotropic SSH
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "eta_hifreq"  [Unused]
     ! long_name: High Frequency Barotropic SSH
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
@@ -773,7 +1418,15 @@
     ! long_name: High Frequency Barotropic zonal velocity
     ! units: m s-1
     ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "ubt_hifreq"  [Unused]
+    ! long_name: High Frequency Barotropic zonal velocity
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean
 "ocean_model", "vbt_hifreq"  [Unused]
+    ! long_name: High Frequency Barotropic meridional velocity
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "vbt_hifreq"  [Unused]
     ! long_name: High Frequency Barotropic meridional velocity
     ! units: m s-1
     ! cell_methods: xh:mean yq:point
@@ -781,11 +1434,23 @@
     ! long_name: High Frequency Predictor Barotropic SSH
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "eta_pred_hifreq"  [Unused]
+    ! long_name: High Frequency Predictor Barotropic SSH
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "uhbt_hifreq"  [Unused]
     ! long_name: High Frequency Barotropic zonal transport
     ! units: m3 s-1
     ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "uhbt_hifreq"  [Unused]
+    ! long_name: High Frequency Barotropic zonal transport
+    ! units: m3 s-1
+    ! cell_methods: xq:point yh:mean
 "ocean_model", "vhbt_hifreq"  [Unused]
+    ! long_name: High Frequency Barotropic meridional transport
+    ! units: m3 s-1
+    ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "vhbt_hifreq"  [Unused]
     ! long_name: High Frequency Barotropic meridional transport
     ! units: m3 s-1
     ! cell_methods: xh:mean yq:point
@@ -805,6 +1470,22 @@
     ! long_name: Fractional thickness of layers in u-columns
     ! units: nondim
     ! cell_methods: z_l:mean
+"ocean_model_d2", "frhatu"  [Unused]
+    ! long_name: Fractional thickness of layers in u-columns
+    ! units: nondim
+    ! cell_methods: xq:point yh:mean zl:mean
+"ocean_model_d2", "frhatu_xyave"  [Unused]
+    ! long_name: Fractional thickness of layers in u-columns
+    ! units: nondim
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "frhatu"  [Unused]
+    ! long_name: Fractional thickness of layers in u-columns
+    ! units: nondim
+    ! cell_methods: xq:point yh:mean z_l:mean
+"ocean_model_z_d2", "frhatu_xyave"  [Unused]
+    ! long_name: Fractional thickness of layers in u-columns
+    ! units: nondim
+    ! cell_methods: z_l:mean
 "ocean_model", "frhatv"  [Unused]
     ! long_name: Fractional thickness of layers in v-columns
     ! units: nondim
@@ -818,6 +1499,22 @@
     ! units: nondim
     ! cell_methods: xh:mean yq:point z_l:mean
 "ocean_model_z", "frhatv_xyave"  [Unused]
+    ! long_name: Fractional thickness of layers in v-columns
+    ! units: nondim
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "frhatv"  [Unused]
+    ! long_name: Fractional thickness of layers in v-columns
+    ! units: nondim
+    ! cell_methods: xh:mean yq:point zl:mean
+"ocean_model_d2", "frhatv_xyave"  [Unused]
+    ! long_name: Fractional thickness of layers in v-columns
+    ! units: nondim
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "frhatv"  [Unused]
+    ! long_name: Fractional thickness of layers in v-columns
+    ! units: nondim
+    ! cell_methods: xh:mean yq:point z_l:mean
+"ocean_model_z_d2", "frhatv_xyave"  [Unused]
     ! long_name: Fractional thickness of layers in v-columns
     ! units: nondim
     ! cell_methods: z_l:mean
@@ -837,6 +1534,22 @@
     ! long_name: Predictor Fractional thickness of layers in u-columns
     ! units: nondim
     ! cell_methods: z_l:mean
+"ocean_model_d2", "frhatu1"  [Unused]
+    ! long_name: Predictor Fractional thickness of layers in u-columns
+    ! units: nondim
+    ! cell_methods: xq:point yh:mean zl:mean
+"ocean_model_d2", "frhatu1_xyave"  [Unused]
+    ! long_name: Predictor Fractional thickness of layers in u-columns
+    ! units: nondim
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "frhatu1"  [Unused]
+    ! long_name: Predictor Fractional thickness of layers in u-columns
+    ! units: nondim
+    ! cell_methods: xq:point yh:mean z_l:mean
+"ocean_model_z_d2", "frhatu1_xyave"  [Unused]
+    ! long_name: Predictor Fractional thickness of layers in u-columns
+    ! units: nondim
+    ! cell_methods: z_l:mean
 "ocean_model", "frhatv1"  [Unused]
     ! long_name: Predictor Fractional thickness of layers in v-columns
     ! units: nondim
@@ -853,7 +1566,27 @@
     ! long_name: Predictor Fractional thickness of layers in v-columns
     ! units: nondim
     ! cell_methods: z_l:mean
+"ocean_model_d2", "frhatv1"  [Unused]
+    ! long_name: Predictor Fractional thickness of layers in v-columns
+    ! units: nondim
+    ! cell_methods: xh:mean yq:point zl:mean
+"ocean_model_d2", "frhatv1_xyave"  [Unused]
+    ! long_name: Predictor Fractional thickness of layers in v-columns
+    ! units: nondim
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "frhatv1"  [Unused]
+    ! long_name: Predictor Fractional thickness of layers in v-columns
+    ! units: nondim
+    ! cell_methods: xh:mean yq:point z_l:mean
+"ocean_model_z_d2", "frhatv1_xyave"  [Unused]
+    ! long_name: Predictor Fractional thickness of layers in v-columns
+    ! units: nondim
+    ! cell_methods: z_l:mean
 "ocean_model", "uhbt"  [Unused]
+    ! long_name: Barotropic zonal transport averaged over a baroclinic step
+    ! units: m3 s-1
+    ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "uhbt"  [Unused]
     ! long_name: Barotropic zonal transport averaged over a baroclinic step
     ! units: m3 s-1
     ! cell_methods: xq:point yh:mean
@@ -861,7 +1594,15 @@
     ! long_name: Barotropic meridional transport averaged over a baroclinic step
     ! units: m3 s-1
     ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "vhbt"  [Unused]
+    ! long_name: Barotropic meridional transport averaged over a baroclinic step
+    ! units: m3 s-1
+    ! cell_methods: xh:mean yq:point
 "ocean_model", "BTC_FA_u_EE"  [Unused]
+    ! long_name: BTCont type far east face area
+    ! units: m2
+    ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "BTC_FA_u_EE"  [Unused]
     ! long_name: BTCont type far east face area
     ! units: m2
     ! cell_methods: xq:point yh:mean
@@ -869,7 +1610,15 @@
     ! long_name: BTCont type near east face area
     ! units: m2
     ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "BTC_FA_u_E0"  [Unused]
+    ! long_name: BTCont type near east face area
+    ! units: m2
+    ! cell_methods: xq:point yh:mean
 "ocean_model", "BTC_FA_u_WW"  [Unused]
+    ! long_name: BTCont type far west face area
+    ! units: m2
+    ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "BTC_FA_u_WW"  [Unused]
     ! long_name: BTCont type far west face area
     ! units: m2
     ! cell_methods: xq:point yh:mean
@@ -877,7 +1626,15 @@
     ! long_name: BTCont type near west face area
     ! units: m2
     ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "BTC_FA_u_W0"  [Unused]
+    ! long_name: BTCont type near west face area
+    ! units: m2
+    ! cell_methods: xq:point yh:mean
 "ocean_model", "BTC_ubt_EE"  [Unused]
+    ! long_name: BTCont type far east velocity
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "BTC_ubt_EE"  [Unused]
     ! long_name: BTCont type far east velocity
     ! units: m s-1
     ! cell_methods: xq:point yh:mean
@@ -885,7 +1642,15 @@
     ! long_name: BTCont type far west velocity
     ! units: m s-1
     ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "BTC_ubt_WW"  [Unused]
+    ! long_name: BTCont type far west velocity
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean
 "ocean_model", "BTC_FA_v_NN"  [Unused]
+    ! long_name: BTCont type far north face area
+    ! units: m2
+    ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "BTC_FA_v_NN"  [Unused]
     ! long_name: BTCont type far north face area
     ! units: m2
     ! cell_methods: xh:mean yq:point
@@ -893,7 +1658,15 @@
     ! long_name: BTCont type near north face area
     ! units: m2
     ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "BTC_FA_v_N0"  [Unused]
+    ! long_name: BTCont type near north face area
+    ! units: m2
+    ! cell_methods: xh:mean yq:point
 "ocean_model", "BTC_FA_v_SS"  [Unused]
+    ! long_name: BTCont type far south face area
+    ! units: m2
+    ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "BTC_FA_v_SS"  [Unused]
     ! long_name: BTCont type far south face area
     ! units: m2
     ! cell_methods: xh:mean yq:point
@@ -901,7 +1674,15 @@
     ! long_name: BTCont type near south face area
     ! units: m2
     ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "BTC_FA_v_S0"  [Unused]
+    ! long_name: BTCont type near south face area
+    ! units: m2
+    ! cell_methods: xh:mean yq:point
 "ocean_model", "BTC_vbt_NN"  [Unused]
+    ! long_name: BTCont type far north velocity
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "BTC_vbt_NN"  [Unused]
     ! long_name: BTCont type far north velocity
     ! units: m s-1
     ! cell_methods: xh:mean yq:point
@@ -909,11 +1690,23 @@
     ! long_name: BTCont type far south velocity
     ! units: m s-1
     ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "BTC_vbt_SS"  [Unused]
+    ! long_name: BTCont type far south velocity
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point
 "ocean_model", "uhbt0"  [Unused]
     ! long_name: Barotropic zonal transport difference
     ! units: m3 s-1
     ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "uhbt0"  [Unused]
+    ! long_name: Barotropic zonal transport difference
+    ! units: m3 s-1
+    ! cell_methods: xq:point yh:mean
 "ocean_model", "vhbt0"  [Unused]
+    ! long_name: Barotropic meridional transport difference
+    ! units: m3 s-1
+    ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "vhbt0"  [Unused]
     ! long_name: Barotropic meridional transport difference
     ! units: m3 s-1
     ! cell_methods: xh:mean yq:point
@@ -933,6 +1726,22 @@
     ! long_name: Zonal Thickness Flux
     ! units: m3 s-1
     ! cell_methods: z_l:sum
+"ocean_model_d2", "uh"  [Unused]
+    ! long_name: Zonal Thickness Flux
+    ! units: m3 s-1
+    ! cell_methods: xq:point yh:sum zl:sum
+"ocean_model_d2", "uh_xyave"  [Unused]
+    ! long_name: Zonal Thickness Flux
+    ! units: m3 s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "uh"  [Unused]
+    ! long_name: Zonal Thickness Flux
+    ! units: m3 s-1
+    ! cell_methods: xq:point yh:sum z_l:sum
+"ocean_model_z_d2", "uh_xyave"  [Unused]
+    ! long_name: Zonal Thickness Flux
+    ! units: m3 s-1
+    ! cell_methods: z_l:sum
 "ocean_model", "vh"  [Used]
     ! long_name: Meridional Thickness Flux
     ! units: m3 s-1
@@ -946,6 +1755,22 @@
     ! units: m3 s-1
     ! cell_methods: xh:sum yq:point z_l:sum
 "ocean_model_z", "vh_xyave"  [Unused]
+    ! long_name: Meridional Thickness Flux
+    ! units: m3 s-1
+    ! cell_methods: z_l:sum
+"ocean_model_d2", "vh"  [Unused]
+    ! long_name: Meridional Thickness Flux
+    ! units: m3 s-1
+    ! cell_methods: xh:sum yq:point zl:sum
+"ocean_model_d2", "vh_xyave"  [Unused]
+    ! long_name: Meridional Thickness Flux
+    ! units: m3 s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "vh"  [Unused]
+    ! long_name: Meridional Thickness Flux
+    ! units: m3 s-1
+    ! cell_methods: xh:sum yq:point z_l:sum
+"ocean_model_z_d2", "vh_xyave"  [Unused]
     ! long_name: Meridional Thickness Flux
     ! units: m3 s-1
     ! cell_methods: z_l:sum
@@ -965,6 +1790,22 @@
     ! long_name: Zonal Coriolis and Advective Acceleration
     ! units: m s-2
     ! cell_methods: z_l:mean
+"ocean_model_d2", "CAu"  [Unused]
+    ! long_name: Zonal Coriolis and Advective Acceleration
+    ! units: m s-2
+    ! cell_methods: xq:point yh:mean zl:mean
+"ocean_model_d2", "CAu_xyave"  [Unused]
+    ! long_name: Zonal Coriolis and Advective Acceleration
+    ! units: m s-2
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "CAu"  [Unused]
+    ! long_name: Zonal Coriolis and Advective Acceleration
+    ! units: m s-2
+    ! cell_methods: xq:point yh:mean z_l:mean
+"ocean_model_z_d2", "CAu_xyave"  [Unused]
+    ! long_name: Zonal Coriolis and Advective Acceleration
+    ! units: m s-2
+    ! cell_methods: z_l:mean
 "ocean_model", "CAv"  [Unused]
     ! long_name: Meridional Coriolis and Advective Acceleration
     ! units: m s-2
@@ -978,6 +1819,22 @@
     ! units: m s-2
     ! cell_methods: xh:mean yq:point z_l:mean
 "ocean_model_z", "CAv_xyave"  [Unused]
+    ! long_name: Meridional Coriolis and Advective Acceleration
+    ! units: m s-2
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "CAv"  [Unused]
+    ! long_name: Meridional Coriolis and Advective Acceleration
+    ! units: m s-2
+    ! cell_methods: xh:mean yq:point zl:mean
+"ocean_model_d2", "CAv_xyave"  [Unused]
+    ! long_name: Meridional Coriolis and Advective Acceleration
+    ! units: m s-2
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "CAv"  [Unused]
+    ! long_name: Meridional Coriolis and Advective Acceleration
+    ! units: m s-2
+    ! cell_methods: xh:mean yq:point z_l:mean
+"ocean_model_z_d2", "CAv_xyave"  [Unused]
     ! long_name: Meridional Coriolis and Advective Acceleration
     ! units: m s-2
     ! cell_methods: z_l:mean
@@ -997,6 +1854,22 @@
     ! long_name: Zonal Pressure Force Acceleration
     ! units: m s-2
     ! cell_methods: z_l:mean
+"ocean_model_d2", "PFu"  [Unused]
+    ! long_name: Zonal Pressure Force Acceleration
+    ! units: m s-2
+    ! cell_methods: xq:point yh:mean zl:mean
+"ocean_model_d2", "PFu_xyave"  [Unused]
+    ! long_name: Zonal Pressure Force Acceleration
+    ! units: m s-2
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "PFu"  [Unused]
+    ! long_name: Zonal Pressure Force Acceleration
+    ! units: m s-2
+    ! cell_methods: xq:point yh:mean z_l:mean
+"ocean_model_z_d2", "PFu_xyave"  [Unused]
+    ! long_name: Zonal Pressure Force Acceleration
+    ! units: m s-2
+    ! cell_methods: z_l:mean
 "ocean_model", "PFv"  [Unused]
     ! long_name: Meridional Pressure Force Acceleration
     ! units: m s-2
@@ -1010,6 +1883,22 @@
     ! units: m s-2
     ! cell_methods: xh:mean yq:point z_l:mean
 "ocean_model_z", "PFv_xyave"  [Unused]
+    ! long_name: Meridional Pressure Force Acceleration
+    ! units: m s-2
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "PFv"  [Unused]
+    ! long_name: Meridional Pressure Force Acceleration
+    ! units: m s-2
+    ! cell_methods: xh:mean yq:point zl:mean
+"ocean_model_d2", "PFv_xyave"  [Unused]
+    ! long_name: Meridional Pressure Force Acceleration
+    ! units: m s-2
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "PFv"  [Unused]
+    ! long_name: Meridional Pressure Force Acceleration
+    ! units: m s-2
+    ! cell_methods: xh:mean yq:point z_l:mean
+"ocean_model_z_d2", "PFv_xyave"  [Unused]
     ! long_name: Meridional Pressure Force Acceleration
     ! units: m s-2
     ! cell_methods: z_l:mean
@@ -1029,6 +1918,22 @@
     ! long_name: Barotropic-step Averaged Zonal Velocity
     ! units: m s-1
     ! cell_methods: z_l:mean
+"ocean_model_d2", "uav"  [Unused]
+    ! long_name: Barotropic-step Averaged Zonal Velocity
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean zl:mean
+"ocean_model_d2", "uav_xyave"  [Unused]
+    ! long_name: Barotropic-step Averaged Zonal Velocity
+    ! units: m s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "uav"  [Unused]
+    ! long_name: Barotropic-step Averaged Zonal Velocity
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean z_l:mean
+"ocean_model_z_d2", "uav_xyave"  [Unused]
+    ! long_name: Barotropic-step Averaged Zonal Velocity
+    ! units: m s-1
+    ! cell_methods: z_l:mean
 "ocean_model", "vav"  [Unused]
     ! long_name: Barotropic-step Averaged Meridional Velocity
     ! units: m s-1
@@ -1042,6 +1947,22 @@
     ! units: m s-1
     ! cell_methods: xh:mean yq:point z_l:mean
 "ocean_model_z", "vav_xyave"  [Unused]
+    ! long_name: Barotropic-step Averaged Meridional Velocity
+    ! units: m s-1
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "vav"  [Unused]
+    ! long_name: Barotropic-step Averaged Meridional Velocity
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point zl:mean
+"ocean_model_d2", "vav_xyave"  [Unused]
+    ! long_name: Barotropic-step Averaged Meridional Velocity
+    ! units: m s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "vav"  [Unused]
+    ! long_name: Barotropic-step Averaged Meridional Velocity
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point z_l:mean
+"ocean_model_z_d2", "vav_xyave"  [Unused]
     ! long_name: Barotropic-step Averaged Meridional Velocity
     ! units: m s-1
     ! cell_methods: z_l:mean
@@ -1061,6 +1982,22 @@
     ! long_name: Barotropic Anomaly Zonal Acceleration
     ! units: m s-1
     ! cell_methods: z_l:mean
+"ocean_model_d2", "u_BT_accel"  [Unused]
+    ! long_name: Barotropic Anomaly Zonal Acceleration
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean zl:mean
+"ocean_model_d2", "u_BT_accel_xyave"  [Unused]
+    ! long_name: Barotropic Anomaly Zonal Acceleration
+    ! units: m s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "u_BT_accel"  [Unused]
+    ! long_name: Barotropic Anomaly Zonal Acceleration
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean z_l:mean
+"ocean_model_z_d2", "u_BT_accel_xyave"  [Unused]
+    ! long_name: Barotropic Anomaly Zonal Acceleration
+    ! units: m s-1
+    ! cell_methods: z_l:mean
 "ocean_model", "v_BT_accel"  [Unused]
     ! long_name: Barotropic Anomaly Meridional Acceleration
     ! units: m s-1
@@ -1074,6 +2011,22 @@
     ! units: m s-1
     ! cell_methods: xh:mean yq:point z_l:mean
 "ocean_model_z", "v_BT_accel_xyave"  [Unused]
+    ! long_name: Barotropic Anomaly Meridional Acceleration
+    ! units: m s-1
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "v_BT_accel"  [Unused]
+    ! long_name: Barotropic Anomaly Meridional Acceleration
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point zl:mean
+"ocean_model_d2", "v_BT_accel_xyave"  [Unused]
+    ! long_name: Barotropic Anomaly Meridional Acceleration
+    ! units: m s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "v_BT_accel"  [Unused]
+    ! long_name: Barotropic Anomaly Meridional Acceleration
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point z_l:mean
+"ocean_model_z_d2", "v_BT_accel_xyave"  [Unused]
     ! long_name: Barotropic Anomaly Meridional Acceleration
     ! units: m s-1
     ! cell_methods: z_l:mean
@@ -1093,6 +2046,22 @@
     ! long_name: Time Mean Diffusive Zonal Thickness Flux
     ! units: kg s-1
     ! cell_methods: z_l:sum
+"ocean_model_d2", "uhGM"  [Unused]
+    ! long_name: Time Mean Diffusive Zonal Thickness Flux
+    ! units: kg s-1
+    ! cell_methods: xq:point yh:sum zl:sum
+"ocean_model_d2", "uhGM_xyave"  [Unused]
+    ! long_name: Time Mean Diffusive Zonal Thickness Flux
+    ! units: kg s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "uhGM"  [Unused]
+    ! long_name: Time Mean Diffusive Zonal Thickness Flux
+    ! units: kg s-1
+    ! cell_methods: xq:point yh:sum z_l:sum
+"ocean_model_z_d2", "uhGM_xyave"  [Unused]
+    ! long_name: Time Mean Diffusive Zonal Thickness Flux
+    ! units: kg s-1
+    ! cell_methods: z_l:sum
 "ocean_model", "vhGM"  [Unused]
     ! long_name: Time Mean Diffusive Meridional Thickness Flux
     ! units: kg s-1
@@ -1109,11 +2078,36 @@
     ! long_name: Time Mean Diffusive Meridional Thickness Flux
     ! units: kg s-1
     ! cell_methods: z_l:sum
+"ocean_model_d2", "vhGM"  [Unused]
+    ! long_name: Time Mean Diffusive Meridional Thickness Flux
+    ! units: kg s-1
+    ! cell_methods: xh:sum yq:point zl:sum
+"ocean_model_d2", "vhGM_xyave"  [Unused]
+    ! long_name: Time Mean Diffusive Meridional Thickness Flux
+    ! units: kg s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "vhGM"  [Unused]
+    ! long_name: Time Mean Diffusive Meridional Thickness Flux
+    ! units: kg s-1
+    ! cell_methods: xh:sum yq:point z_l:sum
+"ocean_model_z_d2", "vhGM_xyave"  [Unused]
+    ! long_name: Time Mean Diffusive Meridional Thickness Flux
+    ! units: kg s-1
+    ! cell_methods: z_l:sum
 "ocean_model", "GMwork"  [Used] (CMOR equivalent is "tnkebto")
     ! long_name: Integrated Tendency of Ocean Mesoscale Eddy KE from Parameterized Eddy Advection
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "tnkebto"  [Unused] (native name is "GMwork")
+    ! long_name: Integrated Tendency of Ocean Mesoscale Eddy KE from Parameterized Eddy Advection
+    ! units: W m-2
+    ! standard_name: tendency_of_ocean_eddy_kinetic_energy_content_due_to_parameterized_eddy_advection
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "GMwork"  [Unused] (CMOR equivalent is "tnkebto")
+    ! long_name: Integrated Tendency of Ocean Mesoscale Eddy KE from Parameterized Eddy Advection
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "tnkebto"  [Unused] (native name is "GMwork")
     ! long_name: Integrated Tendency of Ocean Mesoscale Eddy KE from Parameterized Eddy Advection
     ! units: W m-2
     ! standard_name: tendency_of_ocean_eddy_kinetic_energy_content_due_to_parameterized_eddy_advection
@@ -1134,6 +2128,22 @@
     ! long_name: Parameterized mesoscale eddy advection diffusivity at U-point
     ! units: m2 s-1
     ! cell_methods: z_i:point
+"ocean_model_d2", "KHTH_u"  [Unused]
+    ! long_name: Parameterized mesoscale eddy advection diffusivity at U-point
+    ! units: m2 s-1
+    ! cell_methods: xq:point yh:mean zi:point
+"ocean_model_d2", "KHTH_u_xyave"  [Unused]
+    ! long_name: Parameterized mesoscale eddy advection diffusivity at U-point
+    ! units: m2 s-1
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "KHTH_u"  [Unused]
+    ! long_name: Parameterized mesoscale eddy advection diffusivity at U-point
+    ! units: m2 s-1
+    ! cell_methods: xq:point yh:mean z_i:point
+"ocean_model_z_d2", "KHTH_u_xyave"  [Unused]
+    ! long_name: Parameterized mesoscale eddy advection diffusivity at U-point
+    ! units: m2 s-1
+    ! cell_methods: z_i:point
 "ocean_model", "KHTH_v"  [Used]
     ! long_name: Parameterized mesoscale eddy advection diffusivity at V-point
     ! units: m2 s-1
@@ -1147,6 +2157,22 @@
     ! units: m2 s-1
     ! cell_methods: xh:mean yq:point z_i:point
 "ocean_model_z", "KHTH_v_xyave"  [Unused]
+    ! long_name: Parameterized mesoscale eddy advection diffusivity at V-point
+    ! units: m2 s-1
+    ! cell_methods: z_i:point
+"ocean_model_d2", "KHTH_v"  [Unused]
+    ! long_name: Parameterized mesoscale eddy advection diffusivity at V-point
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yq:point zi:point
+"ocean_model_d2", "KHTH_v_xyave"  [Unused]
+    ! long_name: Parameterized mesoscale eddy advection diffusivity at V-point
+    ! units: m2 s-1
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "KHTH_v"  [Unused]
+    ! long_name: Parameterized mesoscale eddy advection diffusivity at V-point
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yq:point z_i:point
+"ocean_model_z_d2", "KHTH_v_xyave"  [Unused]
     ! long_name: Parameterized mesoscale eddy advection diffusivity at V-point
     ! units: m2 s-1
     ! cell_methods: z_i:point
@@ -1186,7 +2212,47 @@
     ! units: m2 s-1
     ! standard_name: ocean_tracer_diffusivity_due_to_parameterized_mesoscale_advection
     ! cell_methods: z_l:mean
+"ocean_model_d2", "KHTH_t"  [Unused] (CMOR equivalent is "diftrblo")
+    ! long_name: Ocean Tracer Diffusivity due to Parameterized Mesoscale Advection
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "KHTH_t_xyave"  [Unused] (CMOR equivalent is "diftrblo_xyave")
+    ! long_name: Ocean Tracer Diffusivity due to Parameterized Mesoscale Advection
+    ! units: m2 s-1
+    ! cell_methods: zl:mean
+"ocean_model_d2", "diftrblo"  [Unused] (native name is "KHTH_t")
+    ! long_name: Ocean Tracer Diffusivity due to Parameterized Mesoscale Advection
+    ! units: m2 s-1
+    ! standard_name: ocean_tracer_diffusivity_due_to_parameterized_mesoscale_advection
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "diftrblo_xyave"  [Unused] (native name is "KHTH_t_xyave")
+    ! long_name: Ocean Tracer Diffusivity due to Parameterized Mesoscale Advection
+    ! units: m2 s-1
+    ! standard_name: ocean_tracer_diffusivity_due_to_parameterized_mesoscale_advection
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "KHTH_t"  [Unused] (CMOR equivalent is "diftrblo")
+    ! long_name: Ocean Tracer Diffusivity due to Parameterized Mesoscale Advection
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "KHTH_t_xyave"  [Unused] (CMOR equivalent is "diftrblo_xyave")
+    ! long_name: Ocean Tracer Diffusivity due to Parameterized Mesoscale Advection
+    ! units: m2 s-1
+    ! cell_methods: z_l:mean
+"ocean_model_z_d2", "diftrblo"  [Unused] (native name is "KHTH_t")
+    ! long_name: Ocean Tracer Diffusivity due to Parameterized Mesoscale Advection
+    ! units: m2 s-1
+    ! standard_name: ocean_tracer_diffusivity_due_to_parameterized_mesoscale_advection
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "diftrblo_xyave"  [Unused] (native name is "KHTH_t_xyave")
+    ! long_name: Ocean Tracer Diffusivity due to Parameterized Mesoscale Advection
+    ! units: m2 s-1
+    ! standard_name: ocean_tracer_diffusivity_due_to_parameterized_mesoscale_advection
+    ! cell_methods: z_l:mean
 "ocean_model", "KHTH_u1"  [Unused]
+    ! long_name: Parameterized mesoscale eddy advection diffusivity at U-points (2-D)
+    ! units: m2 s-1
+    ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "KHTH_u1"  [Unused]
     ! long_name: Parameterized mesoscale eddy advection diffusivity at U-points (2-D)
     ! units: m2 s-1
     ! cell_methods: xq:point yh:mean
@@ -1194,7 +2260,15 @@
     ! long_name: Parameterized mesoscale eddy advection diffusivity at V-points (2-D)
     ! units: m2 s-1
     ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "KHTH_v1"  [Unused]
+    ! long_name: Parameterized mesoscale eddy advection diffusivity at V-points (2-D)
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yq:point
 "ocean_model", "KHTH_t1"  [Unused]
+    ! long_name: Parameterized mesoscale eddy advection diffusivity at T-points (2-D)
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "KHTH_t1"  [Unused]
     ! long_name: Parameterized mesoscale eddy advection diffusivity at T-points (2-D)
     ! units: m2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
@@ -1214,6 +2288,22 @@
     ! long_name: Zonal slope of neutral surface
     ! units: nondim
     ! cell_methods: z_i:point
+"ocean_model_d2", "neutral_slope_x"  [Unused]
+    ! long_name: Zonal slope of neutral surface
+    ! units: nondim
+    ! cell_methods: xq:point yh:mean zi:point
+"ocean_model_d2", "neutral_slope_x_xyave"  [Unused]
+    ! long_name: Zonal slope of neutral surface
+    ! units: nondim
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "neutral_slope_x"  [Unused]
+    ! long_name: Zonal slope of neutral surface
+    ! units: nondim
+    ! cell_methods: xq:point yh:mean z_i:point
+"ocean_model_z_d2", "neutral_slope_x_xyave"  [Unused]
+    ! long_name: Zonal slope of neutral surface
+    ! units: nondim
+    ! cell_methods: z_i:point
 "ocean_model", "neutral_slope_y"  [Unused]
     ! long_name: Meridional slope of neutral surface
     ! units: nondim
@@ -1227,6 +2317,22 @@
     ! units: nondim
     ! cell_methods: xh:mean yq:point z_i:point
 "ocean_model_z", "neutral_slope_y_xyave"  [Unused]
+    ! long_name: Meridional slope of neutral surface
+    ! units: nondim
+    ! cell_methods: z_i:point
+"ocean_model_d2", "neutral_slope_y"  [Unused]
+    ! long_name: Meridional slope of neutral surface
+    ! units: nondim
+    ! cell_methods: xh:mean yq:point zi:point
+"ocean_model_d2", "neutral_slope_y_xyave"  [Unused]
+    ! long_name: Meridional slope of neutral surface
+    ! units: nondim
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "neutral_slope_y"  [Unused]
+    ! long_name: Meridional slope of neutral surface
+    ! units: nondim
+    ! cell_methods: xh:mean yq:point z_i:point
+"ocean_model_z_d2", "neutral_slope_y_xyave"  [Unused]
     ! long_name: Meridional slope of neutral surface
     ! units: nondim
     ! cell_methods: z_i:point
@@ -1246,6 +2352,22 @@
     ! long_name: Parameterized Zonal Overturning Streamfunction
     ! units: m3 s-1
     ! cell_methods: z_i:point
+"ocean_model_d2", "GM_sfn_x"  [Unused]
+    ! long_name: Parameterized Zonal Overturning Streamfunction
+    ! units: m3 s-1
+    ! cell_methods: xq:point yh:mean zi:point
+"ocean_model_d2", "GM_sfn_x_xyave"  [Unused]
+    ! long_name: Parameterized Zonal Overturning Streamfunction
+    ! units: m3 s-1
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "GM_sfn_x"  [Unused]
+    ! long_name: Parameterized Zonal Overturning Streamfunction
+    ! units: m3 s-1
+    ! cell_methods: xq:point yh:mean z_i:point
+"ocean_model_z_d2", "GM_sfn_x_xyave"  [Unused]
+    ! long_name: Parameterized Zonal Overturning Streamfunction
+    ! units: m3 s-1
+    ! cell_methods: z_i:point
 "ocean_model", "GM_sfn_y"  [Unused]
     ! long_name: Parameterized Meridional Overturning Streamfunction
     ! units: m3 s-1
@@ -1259,6 +2381,22 @@
     ! units: m3 s-1
     ! cell_methods: xh:mean yq:point z_i:point
 "ocean_model_z", "GM_sfn_y_xyave"  [Unused]
+    ! long_name: Parameterized Meridional Overturning Streamfunction
+    ! units: m3 s-1
+    ! cell_methods: z_i:point
+"ocean_model_d2", "GM_sfn_y"  [Unused]
+    ! long_name: Parameterized Meridional Overturning Streamfunction
+    ! units: m3 s-1
+    ! cell_methods: xh:mean yq:point zi:point
+"ocean_model_d2", "GM_sfn_y_xyave"  [Unused]
+    ! long_name: Parameterized Meridional Overturning Streamfunction
+    ! units: m3 s-1
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "GM_sfn_y"  [Unused]
+    ! long_name: Parameterized Meridional Overturning Streamfunction
+    ! units: m3 s-1
+    ! cell_methods: xh:mean yq:point z_i:point
+"ocean_model_z_d2", "GM_sfn_y_xyave"  [Unused]
     ! long_name: Parameterized Meridional Overturning Streamfunction
     ! units: m3 s-1
     ! cell_methods: z_i:point
@@ -1278,6 +2416,22 @@
     ! long_name: Parameterized Zonal Overturning Streamfunction before limiting/smoothing
     ! units: m3 s-1
     ! cell_methods: z_i:point
+"ocean_model_d2", "GM_sfn_unlim_x"  [Unused]
+    ! long_name: Parameterized Zonal Overturning Streamfunction before limiting/smoothing
+    ! units: m3 s-1
+    ! cell_methods: xq:point yh:mean zi:point
+"ocean_model_d2", "GM_sfn_unlim_x_xyave"  [Unused]
+    ! long_name: Parameterized Zonal Overturning Streamfunction before limiting/smoothing
+    ! units: m3 s-1
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "GM_sfn_unlim_x"  [Unused]
+    ! long_name: Parameterized Zonal Overturning Streamfunction before limiting/smoothing
+    ! units: m3 s-1
+    ! cell_methods: xq:point yh:mean z_i:point
+"ocean_model_z_d2", "GM_sfn_unlim_x_xyave"  [Unused]
+    ! long_name: Parameterized Zonal Overturning Streamfunction before limiting/smoothing
+    ! units: m3 s-1
+    ! cell_methods: z_i:point
 "ocean_model", "GM_sfn_unlim_y"  [Unused]
     ! long_name: Parameterized Meridional Overturning Streamfunction before limiting/smoothing
     ! units: m3 s-1
@@ -1291,6 +2445,22 @@
     ! units: m3 s-1
     ! cell_methods: xh:mean yq:point z_i:point
 "ocean_model_z", "GM_sfn_unlim_y_xyave"  [Unused]
+    ! long_name: Parameterized Meridional Overturning Streamfunction before limiting/smoothing
+    ! units: m3 s-1
+    ! cell_methods: z_i:point
+"ocean_model_d2", "GM_sfn_unlim_y"  [Unused]
+    ! long_name: Parameterized Meridional Overturning Streamfunction before limiting/smoothing
+    ! units: m3 s-1
+    ! cell_methods: xh:mean yq:point zi:point
+"ocean_model_d2", "GM_sfn_unlim_y_xyave"  [Unused]
+    ! long_name: Parameterized Meridional Overturning Streamfunction before limiting/smoothing
+    ! units: m3 s-1
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "GM_sfn_unlim_y"  [Unused]
+    ! long_name: Parameterized Meridional Overturning Streamfunction before limiting/smoothing
+    ! units: m3 s-1
+    ! cell_methods: xh:mean yq:point z_i:point
+"ocean_model_z_d2", "GM_sfn_unlim_y_xyave"  [Unused]
     ! long_name: Parameterized Meridional Overturning Streamfunction before limiting/smoothing
     ! units: m3 s-1
     ! cell_methods: z_i:point
@@ -1310,6 +2480,22 @@
     ! long_name: Zonal Thickness Flux to Restratify Mixed Layer
     ! units: kg s-1
     ! cell_methods: z_l:sum
+"ocean_model_d2", "uhml"  [Unused]
+    ! long_name: Zonal Thickness Flux to Restratify Mixed Layer
+    ! units: kg s-1
+    ! cell_methods: xq:point yh:sum zl:sum
+"ocean_model_d2", "uhml_xyave"  [Unused]
+    ! long_name: Zonal Thickness Flux to Restratify Mixed Layer
+    ! units: kg s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "uhml"  [Unused]
+    ! long_name: Zonal Thickness Flux to Restratify Mixed Layer
+    ! units: kg s-1
+    ! cell_methods: xq:point yh:sum z_l:sum
+"ocean_model_z_d2", "uhml_xyave"  [Unused]
+    ! long_name: Zonal Thickness Flux to Restratify Mixed Layer
+    ! units: kg s-1
+    ! cell_methods: z_l:sum
 "ocean_model", "vhml"  [Unused]
     ! long_name: Meridional Thickness Flux to Restratify Mixed Layer
     ! units: kg s-1
@@ -1326,7 +2512,27 @@
     ! long_name: Meridional Thickness Flux to Restratify Mixed Layer
     ! units: kg s-1
     ! cell_methods: z_l:sum
+"ocean_model_d2", "vhml"  [Unused]
+    ! long_name: Meridional Thickness Flux to Restratify Mixed Layer
+    ! units: kg s-1
+    ! cell_methods: xh:sum yq:point zl:sum
+"ocean_model_d2", "vhml_xyave"  [Unused]
+    ! long_name: Meridional Thickness Flux to Restratify Mixed Layer
+    ! units: kg s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "vhml"  [Unused]
+    ! long_name: Meridional Thickness Flux to Restratify Mixed Layer
+    ! units: kg s-1
+    ! cell_methods: xh:sum yq:point z_l:sum
+"ocean_model_z_d2", "vhml_xyave"  [Unused]
+    ! long_name: Meridional Thickness Flux to Restratify Mixed Layer
+    ! units: kg s-1
+    ! cell_methods: z_l:sum
 "ocean_model", "MLu_restrat_time"  [Unused]
+    ! long_name: Mixed Layer Zonal Restratification Timescale
+    ! units: s
+    ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "MLu_restrat_time"  [Unused]
     ! long_name: Mixed Layer Zonal Restratification Timescale
     ! units: s
     ! cell_methods: xq:point yh:mean
@@ -1334,7 +2540,15 @@
     ! long_name: Mixed Layer Meridional Restratification Timescale
     ! units: s
     ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "MLv_restrat_time"  [Unused]
+    ! long_name: Mixed Layer Meridional Restratification Timescale
+    ! units: s
+    ! cell_methods: xh:mean yq:point
 "ocean_model", "MLD_restrat"  [Unused]
+    ! long_name: Mixed Layer Depth as used in the mixed-layer restratification parameterization
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "MLD_restrat"  [Unused]
     ! long_name: Mixed Layer Depth as used in the mixed-layer restratification parameterization
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
@@ -1342,7 +2556,15 @@
     ! long_name: Mixed Layer Buoyancy as used in the mixed-layer restratification parameterization
     ! units: m s2
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "ML_buoy_restrat"  [Unused]
+    ! long_name: Mixed Layer Buoyancy as used in the mixed-layer restratification parameterization
+    ! units: m s2
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "udml_restrat"  [Unused]
+    ! long_name: Transport stream function amplitude for zonal restratification of mixed layer
+    ! units: m3 s-1
+    ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "udml_restrat"  [Unused]
     ! long_name: Transport stream function amplitude for zonal restratification of mixed layer
     ! units: m3 s-1
     ! cell_methods: xq:point yh:mean
@@ -1350,11 +2572,23 @@
     ! long_name: Transport stream function amplitude for meridional restratification of mixed layer
     ! units: m3 s-1
     ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "vdml_restrat"  [Unused]
+    ! long_name: Transport stream function amplitude for meridional restratification of mixed layer
+    ! units: m3 s-1
+    ! cell_methods: xh:mean yq:point
 "ocean_model", "uml_restrat"  [Unused]
     ! long_name: Surface zonal velocity component of mixed layer restratification
     ! units: m s-1
     ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "uml_restrat"  [Unused]
+    ! long_name: Surface zonal velocity component of mixed layer restratification
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean
 "ocean_model", "vml_restrat"  [Unused]
+    ! long_name: Surface meridional velocity component of mixed layer restratification
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "vml_restrat"  [Unused]
     ! long_name: Surface meridional velocity component of mixed layer restratification
     ! units: m s-1
     ! cell_methods: xh:mean yq:point
@@ -1374,6 +2608,26 @@
     ! standard_name: sea_water_mass_per_unit_area
     ! cell_methods: xh:mean yh:mean z_l:sum area:mean
 "ocean_model_z", "masscello_xyave"  [Unused]
+    ! long_name: Mass per unit area of liquid ocean grid cell
+    ! units: kg m-2
+    ! standard_name: sea_water_mass_per_unit_area
+    ! cell_methods: z_l:sum
+"ocean_model_d2", "masscello"  [Unused]
+    ! long_name: Mass per unit area of liquid ocean grid cell
+    ! units: kg m-2
+    ! standard_name: sea_water_mass_per_unit_area
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "masscello_xyave"  [Unused]
+    ! long_name: Mass per unit area of liquid ocean grid cell
+    ! units: kg m-2
+    ! standard_name: sea_water_mass_per_unit_area
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "masscello"  [Unused]
+    ! long_name: Mass per unit area of liquid ocean grid cell
+    ! units: kg m-2
+    ! standard_name: sea_water_mass_per_unit_area
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "masscello_xyave"  [Unused]
     ! long_name: Mass per unit area of liquid ocean grid cell
     ! units: kg m-2
     ! standard_name: sea_water_mass_per_unit_area
@@ -1402,6 +2656,26 @@
     ! units: m
     ! standard_name: cell_thickness
     ! cell_methods: z_l:sum
+"ocean_model_d2", "thkcello"  [Unused]
+    ! long_name: Cell Thickness
+    ! units: m
+    ! standard_name: cell_thickness
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "thkcello_xyave"  [Unused]
+    ! long_name: Cell Thickness
+    ! units: m
+    ! standard_name: cell_thickness
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "thkcello"  [Unused]
+    ! long_name: Cell Thickness
+    ! units: m
+    ! standard_name: cell_thickness
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "thkcello_xyave"  [Unused]
+    ! long_name: Cell Thickness
+    ! units: m
+    ! standard_name: cell_thickness
+    ! cell_methods: z_l:sum
 "ocean_model", "h_pre_sync"  [Unused]
     ! long_name: Cell thickness from the previous timestep
     ! units: m
@@ -1418,7 +2692,28 @@
     ! long_name: Cell thickness from the previous timestep
     ! units: m
     ! cell_methods: z_l:sum
+"ocean_model_d2", "h_pre_sync"  [Unused]
+    ! long_name: Cell thickness from the previous timestep
+    ! units: m
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "h_pre_sync_xyave"  [Unused]
+    ! long_name: Cell thickness from the previous timestep
+    ! units: m
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "h_pre_sync"  [Unused]
+    ! long_name: Cell thickness from the previous timestep
+    ! units: m
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "h_pre_sync_xyave"  [Unused]
+    ! long_name: Cell thickness from the previous timestep
+    ! units: m
+    ! cell_methods: z_l:sum
 "ocean_model", "tob"  [Unused]
+    ! long_name: Sea Water Potential Temperature at Sea Floor
+    ! units: degC
+    ! standard_name: sea_water_potential_temperature_at_sea_floor
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "tob"  [Unused]
     ! long_name: Sea Water Potential Temperature at Sea Floor
     ! units: degC
     ! standard_name: sea_water_potential_temperature_at_sea_floor
@@ -1428,11 +2723,24 @@
     ! units: psu
     ! standard_name: sea_water_salinity_at_sea_floor
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "sob"  [Unused]
+    ! long_name: Sea Water Salinity at Sea Floor
+    ! units: psu
+    ! standard_name: sea_water_salinity_at_sea_floor
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "temp_layer_ave"  [Used]
     ! long_name: Layer Average Ocean Temperature
     ! units: degC
     ! cell_methods: zl:mean
+"ocean_model_d2", "temp_layer_ave"  [Unused]
+    ! long_name: Layer Average Ocean Temperature
+    ! units: degC
+    ! cell_methods: zl:mean
 "ocean_model", "salt_layer_ave"  [Used]
+    ! long_name: Layer Average Ocean Salinity
+    ! units: psu
+    ! cell_methods: zl:mean
+"ocean_model_d2", "salt_layer_ave"  [Unused]
     ! long_name: Layer Average Ocean Salinity
     ! units: psu
     ! cell_methods: zl:mean
@@ -1496,6 +2804,42 @@
     ! units: m s-1
     ! standard_name: sea_water_x_velocity
     ! cell_methods: z_l:mean
+"ocean_model_d2", "u"  [Unused] (CMOR equivalent is "uo")
+    ! long_name: Zonal velocity
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean zl:mean
+"ocean_model_d2", "u_xyave"  [Unused] (CMOR equivalent is "uo_xyave")
+    ! long_name: Zonal velocity
+    ! units: m s-1
+    ! cell_methods: zl:mean
+"ocean_model_d2", "uo"  [Unused] (native name is "u")
+    ! long_name: Sea Water X Velocity
+    ! units: m s-1
+    ! standard_name: sea_water_x_velocity
+    ! cell_methods: xq:point yh:mean zl:mean
+"ocean_model_d2", "uo_xyave"  [Unused] (native name is "u_xyave")
+    ! long_name: Sea Water X Velocity
+    ! units: m s-1
+    ! standard_name: sea_water_x_velocity
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "u"  [Unused] (CMOR equivalent is "uo")
+    ! long_name: Zonal velocity
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean z_l:mean
+"ocean_model_z_d2", "u_xyave"  [Unused] (CMOR equivalent is "uo_xyave")
+    ! long_name: Zonal velocity
+    ! units: m s-1
+    ! cell_methods: z_l:mean
+"ocean_model_z_d2", "uo"  [Unused] (native name is "u")
+    ! long_name: Sea Water X Velocity
+    ! units: m s-1
+    ! standard_name: sea_water_x_velocity
+    ! cell_methods: xq:point yh:mean z_l:mean
+"ocean_model_z_d2", "uo_xyave"  [Unused] (native name is "u_xyave")
+    ! long_name: Sea Water X Velocity
+    ! units: m s-1
+    ! standard_name: sea_water_x_velocity
+    ! cell_methods: z_l:mean
 "ocean_model", "v"  [Used] (CMOR equivalent is "vo")
     ! long_name: Meridional velocity
     ! units: m s-1
@@ -1532,6 +2876,42 @@
     ! units: m s-1
     ! standard_name: sea_water_y_velocity
     ! cell_methods: z_l:mean
+"ocean_model_d2", "v"  [Unused] (CMOR equivalent is "vo")
+    ! long_name: Meridional velocity
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point zl:mean
+"ocean_model_d2", "v_xyave"  [Unused] (CMOR equivalent is "vo_xyave")
+    ! long_name: Meridional velocity
+    ! units: m s-1
+    ! cell_methods: zl:mean
+"ocean_model_d2", "vo"  [Unused] (native name is "v")
+    ! long_name: Sea Water Y Velocity
+    ! units: m s-1
+    ! standard_name: sea_water_y_velocity
+    ! cell_methods: xh:mean yq:point zl:mean
+"ocean_model_d2", "vo_xyave"  [Unused] (native name is "v_xyave")
+    ! long_name: Sea Water Y Velocity
+    ! units: m s-1
+    ! standard_name: sea_water_y_velocity
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "v"  [Unused] (CMOR equivalent is "vo")
+    ! long_name: Meridional velocity
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point z_l:mean
+"ocean_model_z_d2", "v_xyave"  [Unused] (CMOR equivalent is "vo_xyave")
+    ! long_name: Meridional velocity
+    ! units: m s-1
+    ! cell_methods: z_l:mean
+"ocean_model_z_d2", "vo"  [Unused] (native name is "v")
+    ! long_name: Sea Water Y Velocity
+    ! units: m s-1
+    ! standard_name: sea_water_y_velocity
+    ! cell_methods: xh:mean yq:point z_l:mean
+"ocean_model_z_d2", "vo_xyave"  [Unused] (native name is "v_xyave")
+    ! long_name: Sea Water Y Velocity
+    ! units: m s-1
+    ! standard_name: sea_water_y_velocity
+    ! cell_methods: z_l:mean
 "ocean_model", "h"  [Used]
     ! long_name: Layer Thickness
     ! units: m
@@ -1545,6 +2925,22 @@
     ! units: m
     ! cell_methods: xh:mean yh:mean z_l:sum area:mean
 "ocean_model_z", "h_xyave"  [Unused]
+    ! long_name: Layer Thickness
+    ! units: m
+    ! cell_methods: z_l:sum
+"ocean_model_d2", "h"  [Unused]
+    ! long_name: Layer Thickness
+    ! units: m
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "h_xyave"  [Unused]
+    ! long_name: Layer Thickness
+    ! units: m
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "h"  [Unused]
+    ! long_name: Layer Thickness
+    ! units: m
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "h_xyave"  [Unused]
     ! long_name: Layer Thickness
     ! units: m
     ! cell_methods: z_l:sum
@@ -1564,6 +2960,22 @@
     ! long_name: Interface Height Relative to Mean Sea Level
     ! units: m
     ! cell_methods: z_i:point
+"ocean_model_d2", "e"  [Unused]
+    ! long_name: Interface Height Relative to Mean Sea Level
+    ! units: m
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "e_xyave"  [Unused]
+    ! long_name: Interface Height Relative to Mean Sea Level
+    ! units: m
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "e"  [Unused]
+    ! long_name: Interface Height Relative to Mean Sea Level
+    ! units: m
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "e_xyave"  [Unused]
+    ! long_name: Interface Height Relative to Mean Sea Level
+    ! units: m
+    ! cell_methods: z_i:point
 "ocean_model", "e_D"  [Unused]
     ! long_name: Interface Height above the Seafloor
     ! units: m
@@ -1577,6 +2989,22 @@
     ! units: m
     ! cell_methods: xh:mean yh:mean z_i:point area:mean
 "ocean_model_z", "e_D_xyave"  [Unused]
+    ! long_name: Interface Height above the Seafloor
+    ! units: m
+    ! cell_methods: z_i:point
+"ocean_model_d2", "e_D"  [Unused]
+    ! long_name: Interface Height above the Seafloor
+    ! units: m
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "e_D_xyave"  [Unused]
+    ! long_name: Interface Height above the Seafloor
+    ! units: m
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "e_D"  [Unused]
+    ! long_name: Interface Height above the Seafloor
+    ! units: m
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "e_D_xyave"  [Unused]
     ! long_name: Interface Height above the Seafloor
     ! units: m
     ! cell_methods: z_i:point
@@ -1596,6 +3024,22 @@
     ! long_name: Mixed Layer Coordinate Potential Density
     ! units: kg m-3
     ! cell_methods: z_l:mean
+"ocean_model_d2", "Rml"  [Unused]
+    ! long_name: Mixed Layer Coordinate Potential Density
+    ! units: kg m-3
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "Rml_xyave"  [Unused]
+    ! long_name: Mixed Layer Coordinate Potential Density
+    ! units: kg m-3
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "Rml"  [Unused]
+    ! long_name: Mixed Layer Coordinate Potential Density
+    ! units: kg m-3
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "Rml_xyave"  [Unused]
+    ! long_name: Mixed Layer Coordinate Potential Density
+    ! units: kg m-3
+    ! cell_methods: z_l:mean
 "ocean_model", "Rho_cv"  [Unused]
     ! long_name: Coordinate Potential Density
     ! units: kg m-3
@@ -1609,6 +3053,22 @@
     ! units: kg m-3
     ! cell_methods: xh:mean yh:mean z_l:mean area:mean
 "ocean_model_z", "Rho_cv_xyave"  [Unused]
+    ! long_name: Coordinate Potential Density
+    ! units: kg m-3
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "Rho_cv"  [Unused]
+    ! long_name: Coordinate Potential Density
+    ! units: kg m-3
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "Rho_cv_xyave"  [Unused]
+    ! long_name: Coordinate Potential Density
+    ! units: kg m-3
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "Rho_cv"  [Unused]
+    ! long_name: Coordinate Potential Density
+    ! units: kg m-3
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "Rho_cv_xyave"  [Unused]
     ! long_name: Coordinate Potential Density
     ! units: kg m-3
     ! cell_methods: z_l:mean
@@ -1628,6 +3088,22 @@
     ! long_name: Potential density referenced to surface
     ! units: kg m-3
     ! cell_methods: z_l:mean
+"ocean_model_d2", "rhopot0"  [Unused]
+    ! long_name: Potential density referenced to surface
+    ! units: kg m-3
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "rhopot0_xyave"  [Unused]
+    ! long_name: Potential density referenced to surface
+    ! units: kg m-3
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "rhopot0"  [Unused]
+    ! long_name: Potential density referenced to surface
+    ! units: kg m-3
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "rhopot0_xyave"  [Unused]
+    ! long_name: Potential density referenced to surface
+    ! units: kg m-3
+    ! cell_methods: z_l:mean
 "ocean_model", "rhopot2"  [Unused]
     ! long_name: Potential density referenced to 2000 dbar
     ! units: kg m-3
@@ -1641,6 +3117,22 @@
     ! units: kg m-3
     ! cell_methods: xh:mean yh:mean z_l:mean area:mean
 "ocean_model_z", "rhopot2_xyave"  [Unused]
+    ! long_name: Potential density referenced to 2000 dbar
+    ! units: kg m-3
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "rhopot2"  [Unused]
+    ! long_name: Potential density referenced to 2000 dbar
+    ! units: kg m-3
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "rhopot2_xyave"  [Unused]
+    ! long_name: Potential density referenced to 2000 dbar
+    ! units: kg m-3
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "rhopot2"  [Unused]
+    ! long_name: Potential density referenced to 2000 dbar
+    ! units: kg m-3
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "rhopot2_xyave"  [Unused]
     ! long_name: Potential density referenced to 2000 dbar
     ! units: kg m-3
     ! cell_methods: z_l:mean
@@ -1660,6 +3152,22 @@
     ! long_name: In situ density
     ! units: kg m-3
     ! cell_methods: z_l:mean
+"ocean_model_d2", "rhoinsitu"  [Unused]
+    ! long_name: In situ density
+    ! units: kg m-3
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "rhoinsitu_xyave"  [Unused]
+    ! long_name: In situ density
+    ! units: kg m-3
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "rhoinsitu"  [Unused]
+    ! long_name: In situ density
+    ! units: kg m-3
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "rhoinsitu_xyave"  [Unused]
+    ! long_name: In situ density
+    ! units: kg m-3
+    ! cell_methods: z_l:mean
 "ocean_model", "dudt"  [Unused]
     ! long_name: Zonal Acceleration
     ! units: m s-2
@@ -1673,6 +3181,22 @@
     ! units: m s-2
     ! cell_methods: xq:point yh:mean z_l:mean
 "ocean_model_z", "dudt_xyave"  [Unused]
+    ! long_name: Zonal Acceleration
+    ! units: m s-2
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "dudt"  [Unused]
+    ! long_name: Zonal Acceleration
+    ! units: m s-2
+    ! cell_methods: xq:point yh:mean zl:mean
+"ocean_model_d2", "dudt_xyave"  [Unused]
+    ! long_name: Zonal Acceleration
+    ! units: m s-2
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "dudt"  [Unused]
+    ! long_name: Zonal Acceleration
+    ! units: m s-2
+    ! cell_methods: xq:point yh:mean z_l:mean
+"ocean_model_z_d2", "dudt_xyave"  [Unused]
     ! long_name: Zonal Acceleration
     ! units: m s-2
     ! cell_methods: z_l:mean
@@ -1692,6 +3216,22 @@
     ! long_name: Meridional Acceleration
     ! units: m s-2
     ! cell_methods: z_l:mean
+"ocean_model_d2", "dvdt"  [Unused]
+    ! long_name: Meridional Acceleration
+    ! units: m s-2
+    ! cell_methods: xh:mean yq:point zl:mean
+"ocean_model_d2", "dvdt_xyave"  [Unused]
+    ! long_name: Meridional Acceleration
+    ! units: m s-2
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "dvdt"  [Unused]
+    ! long_name: Meridional Acceleration
+    ! units: m s-2
+    ! cell_methods: xh:mean yq:point z_l:mean
+"ocean_model_z_d2", "dvdt_xyave"  [Unused]
+    ! long_name: Meridional Acceleration
+    ! units: m s-2
+    ! cell_methods: z_l:mean
 "ocean_model", "dhdt"  [Unused]
     ! long_name: Thickness tendency
     ! units: m s-1
@@ -1705,6 +3245,22 @@
     ! units: m s-1
     ! cell_methods: xh:mean yh:mean z_l:sum area:mean
 "ocean_model_z", "dhdt_xyave"  [Unused]
+    ! long_name: Thickness tendency
+    ! units: m s-1
+    ! cell_methods: z_l:sum
+"ocean_model_d2", "dhdt"  [Unused]
+    ! long_name: Thickness tendency
+    ! units: m s-1
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "dhdt_xyave"  [Unused]
+    ! long_name: Thickness tendency
+    ! units: m s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "dhdt"  [Unused]
+    ! long_name: Thickness tendency
+    ! units: m s-1
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "dhdt_xyave"  [Unused]
     ! long_name: Thickness tendency
     ! units: m s-1
     ! cell_methods: z_l:sum
@@ -1724,6 +3280,22 @@
     ! long_name: Layer thicknesses in pure potential density coordinates
     ! units: m
     ! cell_methods: z_l:mean
+"ocean_model_d2", "h_rho"  [Unused]
+    ! long_name: Layer thicknesses in pure potential density coordinates
+    ! units: m
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "h_rho_xyave"  [Unused]
+    ! long_name: Layer thicknesses in pure potential density coordinates
+    ! units: m
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "h_rho"  [Unused]
+    ! long_name: Layer thicknesses in pure potential density coordinates
+    ! units: m
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "h_rho_xyave"  [Unused]
+    ! long_name: Layer thicknesses in pure potential density coordinates
+    ! units: m
+    ! cell_methods: z_l:mean
 "ocean_model", "uh_rho"  [Used]
     ! long_name: Zonal volume transport in pure potential density coordinates
     ! units: m3 s-1
@@ -1737,6 +3309,22 @@
     ! units: m3 s-1
     ! cell_methods: xq:point yh:mean z_l:mean
 "ocean_model_z", "uh_rho_xyave"  [Unused]
+    ! long_name: Zonal volume transport in pure potential density coordinates
+    ! units: m3 s-1
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "uh_rho"  [Unused]
+    ! long_name: Zonal volume transport in pure potential density coordinates
+    ! units: m3 s-1
+    ! cell_methods: xq:point yh:mean zl:mean
+"ocean_model_d2", "uh_rho_xyave"  [Unused]
+    ! long_name: Zonal volume transport in pure potential density coordinates
+    ! units: m3 s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "uh_rho"  [Unused]
+    ! long_name: Zonal volume transport in pure potential density coordinates
+    ! units: m3 s-1
+    ! cell_methods: xq:point yh:mean z_l:mean
+"ocean_model_z_d2", "uh_rho_xyave"  [Unused]
     ! long_name: Zonal volume transport in pure potential density coordinates
     ! units: m3 s-1
     ! cell_methods: z_l:mean
@@ -1756,6 +3344,22 @@
     ! long_name: Meridional volume transport in pure potential density coordinates
     ! units: m3 s-1
     ! cell_methods: z_l:mean
+"ocean_model_d2", "vh_rho"  [Unused]
+    ! long_name: Meridional volume transport in pure potential density coordinates
+    ! units: m3 s-1
+    ! cell_methods: xh:mean yq:point zl:mean
+"ocean_model_d2", "vh_rho_xyave"  [Unused]
+    ! long_name: Meridional volume transport in pure potential density coordinates
+    ! units: m3 s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "vh_rho"  [Unused]
+    ! long_name: Meridional volume transport in pure potential density coordinates
+    ! units: m3 s-1
+    ! cell_methods: xh:mean yq:point z_l:mean
+"ocean_model_z_d2", "vh_rho_xyave"  [Unused]
+    ! long_name: Meridional volume transport in pure potential density coordinates
+    ! units: m3 s-1
+    ! cell_methods: z_l:mean
 "ocean_model", "uhGM_rho"  [Used]
     ! long_name: Zonal volume transport due to interface height diffusion in pure potential density coordinates
     ! units: m3 s-1
@@ -1769,6 +3373,22 @@
     ! units: m3 s-1
     ! cell_methods: xq:point yh:mean z_l:mean
 "ocean_model_z", "uhGM_rho_xyave"  [Unused]
+    ! long_name: Zonal volume transport due to interface height diffusion in pure potential density coordinates
+    ! units: m3 s-1
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "uhGM_rho"  [Unused]
+    ! long_name: Zonal volume transport due to interface height diffusion in pure potential density coordinates
+    ! units: m3 s-1
+    ! cell_methods: xq:point yh:mean zl:mean
+"ocean_model_d2", "uhGM_rho_xyave"  [Unused]
+    ! long_name: Zonal volume transport due to interface height diffusion in pure potential density coordinates
+    ! units: m3 s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "uhGM_rho"  [Unused]
+    ! long_name: Zonal volume transport due to interface height diffusion in pure potential density coordinates
+    ! units: m3 s-1
+    ! cell_methods: xq:point yh:mean z_l:mean
+"ocean_model_z_d2", "uhGM_rho_xyave"  [Unused]
     ! long_name: Zonal volume transport due to interface height diffusion in pure potential density coordinates
     ! units: m3 s-1
     ! cell_methods: z_l:mean
@@ -1788,6 +3408,22 @@
     ! long_name: Meridional volume transport due to interface height diffusion in pure potential density coordinates
     ! units: m3 s-1
     ! cell_methods: z_l:mean
+"ocean_model_d2", "vhGM_rho"  [Unused]
+    ! long_name: Meridional volume transport due to interface height diffusion in pure potential density coordinates
+    ! units: m3 s-1
+    ! cell_methods: xh:mean yq:point zl:mean
+"ocean_model_d2", "vhGM_rho_xyave"  [Unused]
+    ! long_name: Meridional volume transport due to interface height diffusion in pure potential density coordinates
+    ! units: m3 s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "vhGM_rho"  [Unused]
+    ! long_name: Meridional volume transport due to interface height diffusion in pure potential density coordinates
+    ! units: m3 s-1
+    ! cell_methods: xh:mean yq:point z_l:mean
+"ocean_model_z_d2", "vhGM_rho_xyave"  [Unused]
+    ! long_name: Meridional volume transport due to interface height diffusion in pure potential density coordinates
+    ! units: m3 s-1
+    ! cell_methods: z_l:mean
 "ocean_model", "KE"  [Unused]
     ! long_name: Layer kinetic energy per unit mass
     ! units: m2 s-2
@@ -1801,6 +3437,22 @@
     ! units: m2 s-2
     ! cell_methods: xh:mean yh:mean z_l:mean area:mean
 "ocean_model_z", "KE_xyave"  [Unused]
+    ! long_name: Layer kinetic energy per unit mass
+    ! units: m2 s-2
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "KE"  [Unused]
+    ! long_name: Layer kinetic energy per unit mass
+    ! units: m2 s-2
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "KE_xyave"  [Unused]
+    ! long_name: Layer kinetic energy per unit mass
+    ! units: m2 s-2
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "KE"  [Unused]
+    ! long_name: Layer kinetic energy per unit mass
+    ! units: m2 s-2
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "KE_xyave"  [Unused]
     ! long_name: Layer kinetic energy per unit mass
     ! units: m2 s-2
     ! cell_methods: z_l:mean
@@ -1820,6 +3472,22 @@
     ! long_name: Kinetic Energy Tendency of Layer
     ! units: m3 s-3
     ! cell_methods: z_l:mean
+"ocean_model_d2", "dKE_dt"  [Unused]
+    ! long_name: Kinetic Energy Tendency of Layer
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "dKE_dt_xyave"  [Unused]
+    ! long_name: Kinetic Energy Tendency of Layer
+    ! units: m3 s-3
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "dKE_dt"  [Unused]
+    ! long_name: Kinetic Energy Tendency of Layer
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "dKE_dt_xyave"  [Unused]
+    ! long_name: Kinetic Energy Tendency of Layer
+    ! units: m3 s-3
+    ! cell_methods: z_l:mean
 "ocean_model", "PE_to_KE"  [Unused]
     ! long_name: Potential to Kinetic Energy Conversion of Layer
     ! units: m3 s-3
@@ -1833,6 +3501,22 @@
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean z_l:mean area:mean
 "ocean_model_z", "PE_to_KE_xyave"  [Unused]
+    ! long_name: Potential to Kinetic Energy Conversion of Layer
+    ! units: m3 s-3
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "PE_to_KE"  [Unused]
+    ! long_name: Potential to Kinetic Energy Conversion of Layer
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "PE_to_KE_xyave"  [Unused]
+    ! long_name: Potential to Kinetic Energy Conversion of Layer
+    ! units: m3 s-3
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "PE_to_KE"  [Unused]
+    ! long_name: Potential to Kinetic Energy Conversion of Layer
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "PE_to_KE_xyave"  [Unused]
     ! long_name: Potential to Kinetic Energy Conversion of Layer
     ! units: m3 s-3
     ! cell_methods: z_l:mean
@@ -1852,6 +3536,22 @@
     ! long_name: Kinetic Energy Source from Coriolis and Advection
     ! units: m3 s-3
     ! cell_methods: z_l:mean
+"ocean_model_d2", "KE_Coradv"  [Unused]
+    ! long_name: Kinetic Energy Source from Coriolis and Advection
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "KE_Coradv_xyave"  [Unused]
+    ! long_name: Kinetic Energy Source from Coriolis and Advection
+    ! units: m3 s-3
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "KE_Coradv"  [Unused]
+    ! long_name: Kinetic Energy Source from Coriolis and Advection
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "KE_Coradv_xyave"  [Unused]
+    ! long_name: Kinetic Energy Source from Coriolis and Advection
+    ! units: m3 s-3
+    ! cell_methods: z_l:mean
 "ocean_model", "KE_adv"  [Unused]
     ! long_name: Kinetic Energy Source from Advection
     ! units: m3 s-3
@@ -1865,6 +3565,22 @@
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean z_l:mean area:mean
 "ocean_model_z", "KE_adv_xyave"  [Unused]
+    ! long_name: Kinetic Energy Source from Advection
+    ! units: m3 s-3
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "KE_adv"  [Unused]
+    ! long_name: Kinetic Energy Source from Advection
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "KE_adv_xyave"  [Unused]
+    ! long_name: Kinetic Energy Source from Advection
+    ! units: m3 s-3
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "KE_adv"  [Unused]
+    ! long_name: Kinetic Energy Source from Advection
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "KE_adv_xyave"  [Unused]
     ! long_name: Kinetic Energy Source from Advection
     ! units: m3 s-3
     ! cell_methods: z_l:mean
@@ -1884,6 +3600,22 @@
     ! long_name: Kinetic Energy Source from Vertical Viscosity and Stresses
     ! units: m3 s-3
     ! cell_methods: z_l:mean
+"ocean_model_d2", "KE_visc"  [Unused]
+    ! long_name: Kinetic Energy Source from Vertical Viscosity and Stresses
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "KE_visc_xyave"  [Unused]
+    ! long_name: Kinetic Energy Source from Vertical Viscosity and Stresses
+    ! units: m3 s-3
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "KE_visc"  [Unused]
+    ! long_name: Kinetic Energy Source from Vertical Viscosity and Stresses
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "KE_visc_xyave"  [Unused]
+    ! long_name: Kinetic Energy Source from Vertical Viscosity and Stresses
+    ! units: m3 s-3
+    ! cell_methods: z_l:mean
 "ocean_model", "KE_horvisc"  [Unused]
     ! long_name: Kinetic Energy Source from Horizontal Viscosity
     ! units: m3 s-3
@@ -1897,6 +3629,22 @@
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean z_l:mean area:mean
 "ocean_model_z", "KE_horvisc_xyave"  [Unused]
+    ! long_name: Kinetic Energy Source from Horizontal Viscosity
+    ! units: m3 s-3
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "KE_horvisc"  [Unused]
+    ! long_name: Kinetic Energy Source from Horizontal Viscosity
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "KE_horvisc_xyave"  [Unused]
+    ! long_name: Kinetic Energy Source from Horizontal Viscosity
+    ! units: m3 s-3
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "KE_horvisc"  [Unused]
+    ! long_name: Kinetic Energy Source from Horizontal Viscosity
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "KE_horvisc_xyave"  [Unused]
     ! long_name: Kinetic Energy Source from Horizontal Viscosity
     ! units: m3 s-3
     ! cell_methods: z_l:mean
@@ -1916,7 +3664,27 @@
     ! long_name: Kinetic Energy Source from Diapycnal Diffusion
     ! units: m3 s-3
     ! cell_methods: z_l:mean
+"ocean_model_d2", "KE_dia"  [Unused]
+    ! long_name: Kinetic Energy Source from Diapycnal Diffusion
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "KE_dia_xyave"  [Unused]
+    ! long_name: Kinetic Energy Source from Diapycnal Diffusion
+    ! units: m3 s-3
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "KE_dia"  [Unused]
+    ! long_name: Kinetic Energy Source from Diapycnal Diffusion
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "KE_dia_xyave"  [Unused]
+    ! long_name: Kinetic Energy Source from Diapycnal Diffusion
+    ! units: m3 s-3
+    ! cell_methods: z_l:mean
 "ocean_model", "cg1"  [Unused]
+    ! long_name: First baroclinic gravity wave speed
+    ! units: m s-1
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "cg1"  [Unused]
     ! long_name: First baroclinic gravity wave speed
     ! units: m s-1
     ! cell_methods: xh:mean yh:mean area:mean
@@ -1924,7 +3692,15 @@
     ! long_name: First baroclinic deformation radius
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "Rd1"  [Unused]
+    ! long_name: First baroclinic deformation radius
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "CFL_cg1"  [Unused]
+    ! long_name: CFL of first baroclinic gravity wave = dt*cg1*(1/dx+1/dy)
+    ! units: nondim
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "CFL_cg1"  [Unused]
     ! long_name: CFL of first baroclinic gravity wave = dt*cg1*(1/dx+1/dy)
     ! units: nondim
     ! cell_methods: xh:mean yh:mean area:mean
@@ -1932,7 +3708,15 @@
     ! long_name: i-component of CFL of first baroclinic gravity wave = dt*cg1*/dx
     ! units: nondim
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "CFL_cg1_x"  [Unused]
+    ! long_name: i-component of CFL of first baroclinic gravity wave = dt*cg1*/dx
+    ! units: nondim
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "CFL_cg1_y"  [Unused]
+    ! long_name: j-component of CFL of first baroclinic gravity wave = dt*cg1*/dy
+    ! units: nondim
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "CFL_cg1_y"  [Unused]
     ! long_name: j-component of CFL of first baroclinic gravity wave = dt*cg1*/dy
     ! units: nondim
     ! cell_methods: xh:mean yh:mean area:mean
@@ -1940,7 +3724,15 @@
     ! long_name: Equivalent barotropic gravity wave speed
     ! units: m s-1
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "cg_ebt"  [Unused]
+    ! long_name: Equivalent barotropic gravity wave speed
+    ! units: m s-1
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "Rd_ebt"  [Unused]
+    ! long_name: Equivalent barotropic deformation radius
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "Rd_ebt"  [Unused]
     ! long_name: Equivalent barotropic deformation radius
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
@@ -1960,7 +3752,27 @@
     ! long_name: Equivalent barotropic modal strcuture
     ! units: nondim
     ! cell_methods: z_l:mean
-"ocean_model", "mass_wt"  [Used]
+"ocean_model_d2", "p_ebt"  [Unused]
+    ! long_name: Equivalent barotropic modal strcuture
+    ! units: nondim
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "p_ebt_xyave"  [Unused]
+    ! long_name: Equivalent barotropic modal strcuture
+    ! units: nondim
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "p_ebt"  [Unused]
+    ! long_name: Equivalent barotropic modal strcuture
+    ! units: nondim
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "p_ebt_xyave"  [Unused]
+    ! long_name: Equivalent barotropic modal strcuture
+    ! units: nondim
+    ! cell_methods: z_l:mean
+"ocean_model", "mass_wt"  [Unused]
+    ! long_name: The column mass for calculating mass-weighted average properties
+    ! units: kg m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "mass_wt"  [Unused]
     ! long_name: The column mass for calculating mass-weighted average properties
     ! units: kg m-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -1969,6 +3781,15 @@
     ! units: degC kg m-2
     ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "opottempmint"  [Used] (native name is "temp_int")
+    ! long_name: integral_wrt_depth_of_product_of_sea_water_density_and_potential_temperature
+    ! units: degC kg m-2
+    ! standard_name: Depth integrated density times potential temperature
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "temp_int"  [Unused] (CMOR equivalent is "opottempmint")
+    ! long_name: Density weighted column integrated potential temperature
+    ! units: degC kg m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "opottempmint"  [Unused] (native name is "temp_int")
     ! long_name: integral_wrt_depth_of_product_of_sea_water_density_and_potential_temperature
     ! units: degC kg m-2
     ! standard_name: Depth integrated density times potential temperature
@@ -1982,7 +3803,20 @@
     ! units: psu kg m-2
     ! standard_name: Depth integrated density times salinity
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "salt_int"  [Unused] (CMOR equivalent is "somint")
+    ! long_name: Density weighted column integrated salinity
+    ! units: psu kg m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "somint"  [Unused] (native name is "salt_int")
+    ! long_name: integral_wrt_depth_of_product_of_sea_water_density_and_salinity
+    ! units: psu kg m-2
+    ! standard_name: Depth integrated density times salinity
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "col_mass"  [Unused]
+    ! long_name: The column integrated in situ density
+    ! units: kg m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "col_mass"  [Unused]
     ! long_name: The column integrated in situ density
     ! units: kg m-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -1990,7 +3824,16 @@
     ! long_name: The height of the water column
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "col_height"  [Unused]
+    ! long_name: The height of the water column
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "pbo"  [Used]
+    ! long_name: Sea Water Pressure at Sea Floor
+    ! units: Pa
+    ! standard_name: sea_water_pressure_at_sea_floor
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "pbo"  [Unused]
     ! long_name: Sea Water Pressure at Sea Floor
     ! units: Pa
     ! standard_name: sea_water_pressure_at_sea_floor
@@ -2031,6 +3874,22 @@
     ! long_name: Layer (heat) entrainment from above per timestep
     ! units: m
     ! cell_methods: z_l:mean
+"ocean_model_d2", "ea_t"  [Unused]
+    ! long_name: Layer (heat) entrainment from above per timestep
+    ! units: m
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "ea_t_xyave"  [Unused]
+    ! long_name: Layer (heat) entrainment from above per timestep
+    ! units: m
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "ea_t"  [Unused]
+    ! long_name: Layer (heat) entrainment from above per timestep
+    ! units: m
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "ea_t_xyave"  [Unused]
+    ! long_name: Layer (heat) entrainment from above per timestep
+    ! units: m
+    ! cell_methods: z_l:mean
 "ocean_model", "eb_t"  [Unused]
     ! long_name: Layer (heat) entrainment from below per timestep
     ! units: m
@@ -2044,6 +3903,22 @@
     ! units: m
     ! cell_methods: xh:mean yh:mean z_l:mean area:mean
 "ocean_model_z", "eb_t_xyave"  [Unused]
+    ! long_name: Layer (heat) entrainment from below per timestep
+    ! units: m
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "eb_t"  [Unused]
+    ! long_name: Layer (heat) entrainment from below per timestep
+    ! units: m
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "eb_t_xyave"  [Unused]
+    ! long_name: Layer (heat) entrainment from below per timestep
+    ! units: m
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "eb_t"  [Unused]
+    ! long_name: Layer (heat) entrainment from below per timestep
+    ! units: m
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "eb_t_xyave"  [Unused]
     ! long_name: Layer (heat) entrainment from below per timestep
     ! units: m
     ! cell_methods: z_l:mean
@@ -2063,6 +3938,22 @@
     ! long_name: Layer (salt) entrainment from above per timestep
     ! units: m
     ! cell_methods: z_l:mean
+"ocean_model_d2", "ea_s"  [Unused]
+    ! long_name: Layer (salt) entrainment from above per timestep
+    ! units: m
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "ea_s_xyave"  [Unused]
+    ! long_name: Layer (salt) entrainment from above per timestep
+    ! units: m
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "ea_s"  [Unused]
+    ! long_name: Layer (salt) entrainment from above per timestep
+    ! units: m
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "ea_s_xyave"  [Unused]
+    ! long_name: Layer (salt) entrainment from above per timestep
+    ! units: m
+    ! cell_methods: z_l:mean
 "ocean_model", "eb_s"  [Unused]
     ! long_name: Layer (salt) entrainment from below per timestep
     ! units: m
@@ -2076,6 +3967,22 @@
     ! units: m
     ! cell_methods: xh:mean yh:mean z_l:mean area:mean
 "ocean_model_z", "eb_s_xyave"  [Unused]
+    ! long_name: Layer (salt) entrainment from below per timestep
+    ! units: m
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "eb_s"  [Unused]
+    ! long_name: Layer (salt) entrainment from below per timestep
+    ! units: m
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "eb_s_xyave"  [Unused]
+    ! long_name: Layer (salt) entrainment from below per timestep
+    ! units: m
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "eb_s"  [Unused]
+    ! long_name: Layer (salt) entrainment from below per timestep
+    ! units: m
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "eb_s_xyave"  [Unused]
     ! long_name: Layer (salt) entrainment from below per timestep
     ! units: m
     ! cell_methods: z_l:mean
@@ -2095,6 +4002,22 @@
     ! long_name: Layer entrainment from above per timestep
     ! units: m
     ! cell_methods: z_l:mean
+"ocean_model_d2", "ea"  [Unused]
+    ! long_name: Layer entrainment from above per timestep
+    ! units: m
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "ea_xyave"  [Unused]
+    ! long_name: Layer entrainment from above per timestep
+    ! units: m
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "ea"  [Unused]
+    ! long_name: Layer entrainment from above per timestep
+    ! units: m
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "ea_xyave"  [Unused]
+    ! long_name: Layer entrainment from above per timestep
+    ! units: m
+    ! cell_methods: z_l:mean
 "ocean_model", "eb"  [Unused]
     ! long_name: Layer entrainment from below per timestep
     ! units: m
@@ -2108,6 +4031,22 @@
     ! units: m
     ! cell_methods: xh:mean yh:mean z_l:mean area:mean
 "ocean_model_z", "eb_xyave"  [Unused]
+    ! long_name: Layer entrainment from below per timestep
+    ! units: m
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "eb"  [Unused]
+    ! long_name: Layer entrainment from below per timestep
+    ! units: m
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "eb_xyave"  [Unused]
+    ! long_name: Layer entrainment from below per timestep
+    ! units: m
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "eb"  [Unused]
+    ! long_name: Layer entrainment from below per timestep
+    ! units: m
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "eb_xyave"  [Unused]
     ! long_name: Layer entrainment from below per timestep
     ! units: m
     ! cell_methods: z_l:mean
@@ -2127,6 +4066,22 @@
     ! long_name: Diapycnal velocity
     ! units: m s-1
     ! cell_methods: z_i:point
+"ocean_model_d2", "wd"  [Unused]
+    ! long_name: Diapycnal velocity
+    ! units: m s-1
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "wd_xyave"  [Unused]
+    ! long_name: Diapycnal velocity
+    ! units: m s-1
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "wd"  [Unused]
+    ! long_name: Diapycnal velocity
+    ! units: m s-1
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "wd_xyave"  [Unused]
+    ! long_name: Diapycnal velocity
+    ! units: m s-1
+    ! cell_methods: z_i:point
 "ocean_model", "dudt_dia"  [Unused]
     ! long_name: Zonal Acceleration from Diapycnal Mixing
     ! units: m s-2
@@ -2140,6 +4095,22 @@
     ! units: m s-2
     ! cell_methods: xq:point yh:mean z_l:mean
 "ocean_model_z", "dudt_dia_xyave"  [Unused]
+    ! long_name: Zonal Acceleration from Diapycnal Mixing
+    ! units: m s-2
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "dudt_dia"  [Unused]
+    ! long_name: Zonal Acceleration from Diapycnal Mixing
+    ! units: m s-2
+    ! cell_methods: xq:point yh:mean zl:mean
+"ocean_model_d2", "dudt_dia_xyave"  [Unused]
+    ! long_name: Zonal Acceleration from Diapycnal Mixing
+    ! units: m s-2
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "dudt_dia"  [Unused]
+    ! long_name: Zonal Acceleration from Diapycnal Mixing
+    ! units: m s-2
+    ! cell_methods: xq:point yh:mean z_l:mean
+"ocean_model_z_d2", "dudt_dia_xyave"  [Unused]
     ! long_name: Zonal Acceleration from Diapycnal Mixing
     ! units: m s-2
     ! cell_methods: z_l:mean
@@ -2159,6 +4130,22 @@
     ! long_name: Meridional Acceleration from Diapycnal Mixing
     ! units: m s-2
     ! cell_methods: z_l:mean
+"ocean_model_d2", "dvdt_dia"  [Unused]
+    ! long_name: Meridional Acceleration from Diapycnal Mixing
+    ! units: m s-2
+    ! cell_methods: xh:mean yq:point zl:mean
+"ocean_model_d2", "dvdt_dia_xyave"  [Unused]
+    ! long_name: Meridional Acceleration from Diapycnal Mixing
+    ! units: m s-2
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "dvdt_dia"  [Unused]
+    ! long_name: Meridional Acceleration from Diapycnal Mixing
+    ! units: m s-2
+    ! cell_methods: xh:mean yq:point z_l:mean
+"ocean_model_z_d2", "dvdt_dia_xyave"  [Unused]
+    ! long_name: Meridional Acceleration from Diapycnal Mixing
+    ! units: m s-2
+    ! cell_methods: z_l:mean
 "ocean_model", "Tflx_dia_diff"  [Unused]
     ! long_name: Diffusive diapycnal temperature flux across interfaces
     ! units: degC m s-1
@@ -2172,6 +4159,22 @@
     ! units: degC m s-1
     ! cell_methods: xh:mean yh:mean z_i:point area:mean
 "ocean_model_z", "Tflx_dia_diff_xyave"  [Unused]
+    ! long_name: Diffusive diapycnal temperature flux across interfaces
+    ! units: degC m s-1
+    ! cell_methods: z_i:point
+"ocean_model_d2", "Tflx_dia_diff"  [Unused]
+    ! long_name: Diffusive diapycnal temperature flux across interfaces
+    ! units: degC m s-1
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "Tflx_dia_diff_xyave"  [Unused]
+    ! long_name: Diffusive diapycnal temperature flux across interfaces
+    ! units: degC m s-1
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "Tflx_dia_diff"  [Unused]
+    ! long_name: Diffusive diapycnal temperature flux across interfaces
+    ! units: degC m s-1
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "Tflx_dia_diff_xyave"  [Unused]
     ! long_name: Diffusive diapycnal temperature flux across interfaces
     ! units: degC m s-1
     ! cell_methods: z_i:point
@@ -2191,6 +4194,22 @@
     ! long_name: Advective diapycnal temperature flux across interfaces
     ! units: degC m s-1
     ! cell_methods: z_i:point
+"ocean_model_d2", "Tflx_dia_adv"  [Unused]
+    ! long_name: Advective diapycnal temperature flux across interfaces
+    ! units: degC m s-1
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "Tflx_dia_adv_xyave"  [Unused]
+    ! long_name: Advective diapycnal temperature flux across interfaces
+    ! units: degC m s-1
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "Tflx_dia_adv"  [Unused]
+    ! long_name: Advective diapycnal temperature flux across interfaces
+    ! units: degC m s-1
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "Tflx_dia_adv_xyave"  [Unused]
+    ! long_name: Advective diapycnal temperature flux across interfaces
+    ! units: degC m s-1
+    ! cell_methods: z_i:point
 "ocean_model", "Sflx_dia_diff"  [Unused]
     ! long_name: Diffusive diapycnal salnity flux across interfaces
     ! units: psu m s-1
@@ -2204,6 +4223,22 @@
     ! units: psu m s-1
     ! cell_methods: xh:mean yh:mean z_i:point area:mean
 "ocean_model_z", "Sflx_dia_diff_xyave"  [Unused]
+    ! long_name: Diffusive diapycnal salnity flux across interfaces
+    ! units: psu m s-1
+    ! cell_methods: z_i:point
+"ocean_model_d2", "Sflx_dia_diff"  [Unused]
+    ! long_name: Diffusive diapycnal salnity flux across interfaces
+    ! units: psu m s-1
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "Sflx_dia_diff_xyave"  [Unused]
+    ! long_name: Diffusive diapycnal salnity flux across interfaces
+    ! units: psu m s-1
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "Sflx_dia_diff"  [Unused]
+    ! long_name: Diffusive diapycnal salnity flux across interfaces
+    ! units: psu m s-1
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "Sflx_dia_diff_xyave"  [Unused]
     ! long_name: Diffusive diapycnal salnity flux across interfaces
     ! units: psu m s-1
     ! cell_methods: z_i:point
@@ -2223,6 +4258,22 @@
     ! long_name: Advective diapycnal salnity flux across interfaces
     ! units: psu m s-1
     ! cell_methods: z_i:point
+"ocean_model_d2", "Sflx_dia_adv"  [Unused]
+    ! long_name: Advective diapycnal salnity flux across interfaces
+    ! units: psu m s-1
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "Sflx_dia_adv_xyave"  [Unused]
+    ! long_name: Advective diapycnal salnity flux across interfaces
+    ! units: psu m s-1
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "Sflx_dia_adv"  [Unused]
+    ! long_name: Advective diapycnal salnity flux across interfaces
+    ! units: psu m s-1
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "Sflx_dia_adv_xyave"  [Unused]
+    ! long_name: Advective diapycnal salnity flux across interfaces
+    ! units: psu m s-1
+    ! cell_methods: z_i:point
 "ocean_model", "MLD_003"  [Used] (CMOR equivalent is "mlotst")
     ! long_name: Mixed layer depth (delta rho = 0.03)
     ! units: m
@@ -2232,7 +4283,21 @@
     ! units: m
     ! standard_name: ocean_mixed_layer_thickness_defined_by_sigma_t
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "MLD_003"  [Unused] (CMOR equivalent is "mlotst")
+    ! long_name: Mixed layer depth (delta rho = 0.03)
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "mlotst"  [Unused] (native name is "MLD_003")
+    ! long_name: Ocean Mixed Layer Thickness Defined by Sigma T
+    ! units: m
+    ! standard_name: ocean_mixed_layer_thickness_defined_by_sigma_t
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "mlotstsq"  [Used]
+    ! long_name: Square of Ocean Mixed Layer Thickness Defined by Sigma T
+    ! units: m2
+    ! standard_name: square_of_ocean_mixed_layer_thickness_defined_by_sigma_t
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "mlotstsq"  [Unused]
     ! long_name: Square of Ocean Mixed Layer Thickness Defined by Sigma T
     ! units: m2
     ! standard_name: square_of_ocean_mixed_layer_thickness_defined_by_sigma_t
@@ -2241,11 +4306,23 @@
     ! long_name: Mixed layer depth (delta rho = 0.125)
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "MLD_0125"  [Unused]
+    ! long_name: Mixed layer depth (delta rho = 0.125)
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "subML_N2"  [Used]
     ! long_name: Squared buoyancy frequency below mixed layer
     ! units: s-2
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "subML_N2"  [Unused]
+    ! long_name: Squared buoyancy frequency below mixed layer
+    ! units: s-2
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "MLD_user"  [Unused]
+    ! long_name: Mixed layer depth (used defined)
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "MLD_user"  [Unused]
     ! long_name: Mixed layer depth (used defined)
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
@@ -2280,6 +4357,22 @@
     ! long_name: Zonal velocity before diabatic forcing
     ! units: m s-1
     ! cell_methods: z_l:mean
+"ocean_model_d2", "u_predia"  [Unused]
+    ! long_name: Zonal velocity before diabatic forcing
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean zl:mean
+"ocean_model_d2", "u_predia_xyave"  [Unused]
+    ! long_name: Zonal velocity before diabatic forcing
+    ! units: m s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "u_predia"  [Unused]
+    ! long_name: Zonal velocity before diabatic forcing
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean z_l:mean
+"ocean_model_z_d2", "u_predia_xyave"  [Unused]
+    ! long_name: Zonal velocity before diabatic forcing
+    ! units: m s-1
+    ! cell_methods: z_l:mean
 "ocean_model", "v_predia"  [Unused]
     ! long_name: Meridional velocity before diabatic forcing
     ! units: m s-1
@@ -2293,6 +4386,22 @@
     ! units: m s-1
     ! cell_methods: xh:mean yq:point z_l:mean
 "ocean_model_z", "v_predia_xyave"  [Unused]
+    ! long_name: Meridional velocity before diabatic forcing
+    ! units: m s-1
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "v_predia"  [Unused]
+    ! long_name: Meridional velocity before diabatic forcing
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point zl:mean
+"ocean_model_d2", "v_predia_xyave"  [Unused]
+    ! long_name: Meridional velocity before diabatic forcing
+    ! units: m s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "v_predia"  [Unused]
+    ! long_name: Meridional velocity before diabatic forcing
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point z_l:mean
+"ocean_model_z_d2", "v_predia_xyave"  [Unused]
     ! long_name: Meridional velocity before diabatic forcing
     ! units: m s-1
     ! cell_methods: z_l:mean
@@ -2312,6 +4421,22 @@
     ! long_name: Layer Thickness before diabatic forcing
     ! units: m
     ! cell_methods: z_l:sum
+"ocean_model_d2", "h_predia"  [Unused]
+    ! long_name: Layer Thickness before diabatic forcing
+    ! units: m
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "h_predia_xyave"  [Unused]
+    ! long_name: Layer Thickness before diabatic forcing
+    ! units: m
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "h_predia"  [Unused]
+    ! long_name: Layer Thickness before diabatic forcing
+    ! units: m
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "h_predia_xyave"  [Unused]
+    ! long_name: Layer Thickness before diabatic forcing
+    ! units: m
+    ! cell_methods: z_l:sum
 "ocean_model", "e_predia"  [Unused]
     ! long_name: Interface Heights before diabatic forcing
     ! units: m
@@ -2325,6 +4450,22 @@
     ! units: m
     ! cell_methods: xh:mean yh:mean z_i:point area:mean
 "ocean_model_z", "e_predia_xyave"  [Unused]
+    ! long_name: Interface Heights before diabatic forcing
+    ! units: m
+    ! cell_methods: z_i:point
+"ocean_model_d2", "e_predia"  [Unused]
+    ! long_name: Interface Heights before diabatic forcing
+    ! units: m
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "e_predia_xyave"  [Unused]
+    ! long_name: Interface Heights before diabatic forcing
+    ! units: m
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "e_predia"  [Unused]
+    ! long_name: Interface Heights before diabatic forcing
+    ! units: m
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "e_predia_xyave"  [Unused]
     ! long_name: Interface Heights before diabatic forcing
     ! units: m
     ! cell_methods: z_i:point
@@ -2344,6 +4485,22 @@
     ! long_name: Potential Temperature
     ! units: degC
     ! cell_methods: z_l:mean
+"ocean_model_d2", "temp_predia"  [Unused]
+    ! long_name: Potential Temperature
+    ! units: degC
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "temp_predia_xyave"  [Unused]
+    ! long_name: Potential Temperature
+    ! units: degC
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "temp_predia"  [Unused]
+    ! long_name: Potential Temperature
+    ! units: degC
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "temp_predia_xyave"  [Unused]
+    ! long_name: Potential Temperature
+    ! units: degC
+    ! cell_methods: z_l:mean
 "ocean_model", "salt_predia"  [Unused]
     ! long_name: Salinity
     ! units: PSU
@@ -2360,6 +4517,22 @@
     ! long_name: Salinity
     ! units: PSU
     ! cell_methods: z_l:mean
+"ocean_model_d2", "salt_predia"  [Unused]
+    ! long_name: Salinity
+    ! units: PSU
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "salt_predia_xyave"  [Unused]
+    ! long_name: Salinity
+    ! units: PSU
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "salt_predia"  [Unused]
+    ! long_name: Salinity
+    ! units: PSU
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "salt_predia_xyave"  [Unused]
+    ! long_name: Salinity
+    ! units: PSU
+    ! cell_methods: z_l:mean
 "ocean_model", "Kd_interface"  [Used]
     ! long_name: Total diapycnal diffusivity at interfaces
     ! units: m2 s-1
@@ -2373,6 +4546,22 @@
     ! units: m2 s-1
     ! cell_methods: xh:mean yh:mean z_i:point area:mean
 "ocean_model_z", "Kd_interface_xyave"  [Unused]
+    ! long_name: Total diapycnal diffusivity at interfaces
+    ! units: m2 s-1
+    ! cell_methods: z_i:point
+"ocean_model_d2", "Kd_interface"  [Unused]
+    ! long_name: Total diapycnal diffusivity at interfaces
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "Kd_interface_xyave"  [Unused]
+    ! long_name: Total diapycnal diffusivity at interfaces
+    ! units: m2 s-1
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "Kd_interface"  [Unused]
+    ! long_name: Total diapycnal diffusivity at interfaces
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "Kd_interface_xyave"  [Unused]
     ! long_name: Total diapycnal diffusivity at interfaces
     ! units: m2 s-1
     ! cell_methods: z_i:point
@@ -2408,6 +4597,42 @@
     ! standard_name: ocean_vertical_heat_diffusivity
     ! cell_methods: xh:mean yh:mean z_i:point area:mean
 "ocean_model_z", "difvho_xyave"  [Unused] (native name is "Kd_heat_xyave")
+    ! long_name: Ocean vertical heat diffusivity
+    ! units: m2 s-1
+    ! standard_name: ocean_vertical_heat_diffusivity
+    ! cell_methods: z_i:point
+"ocean_model_d2", "Kd_heat"  [Unused] (CMOR equivalent is "difvho")
+    ! long_name: Total diapycnal diffusivity for heat at interfaces
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "Kd_heat_xyave"  [Unused] (CMOR equivalent is "difvho_xyave")
+    ! long_name: Total diapycnal diffusivity for heat at interfaces
+    ! units: m2 s-1
+    ! cell_methods: zi:point
+"ocean_model_d2", "difvho"  [Unused] (native name is "Kd_heat")
+    ! long_name: Ocean vertical heat diffusivity
+    ! units: m2 s-1
+    ! standard_name: ocean_vertical_heat_diffusivity
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "difvho_xyave"  [Unused] (native name is "Kd_heat_xyave")
+    ! long_name: Ocean vertical heat diffusivity
+    ! units: m2 s-1
+    ! standard_name: ocean_vertical_heat_diffusivity
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "Kd_heat"  [Unused] (CMOR equivalent is "difvho")
+    ! long_name: Total diapycnal diffusivity for heat at interfaces
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "Kd_heat_xyave"  [Unused] (CMOR equivalent is "difvho_xyave")
+    ! long_name: Total diapycnal diffusivity for heat at interfaces
+    ! units: m2 s-1
+    ! cell_methods: z_i:point
+"ocean_model_z_d2", "difvho"  [Unused] (native name is "Kd_heat")
+    ! long_name: Ocean vertical heat diffusivity
+    ! units: m2 s-1
+    ! standard_name: ocean_vertical_heat_diffusivity
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "difvho_xyave"  [Unused] (native name is "Kd_heat_xyave")
     ! long_name: Ocean vertical heat diffusivity
     ! units: m2 s-1
     ! standard_name: ocean_vertical_heat_diffusivity
@@ -2448,6 +4673,42 @@
     ! units: m2 s-1
     ! standard_name: ocean_vertical_salt_diffusivity
     ! cell_methods: z_i:point
+"ocean_model_d2", "Kd_salt"  [Unused] (CMOR equivalent is "difvso")
+    ! long_name: Total diapycnal diffusivity for salt at interfaces
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "Kd_salt_xyave"  [Unused] (CMOR equivalent is "difvso_xyave")
+    ! long_name: Total diapycnal diffusivity for salt at interfaces
+    ! units: m2 s-1
+    ! cell_methods: zi:point
+"ocean_model_d2", "difvso"  [Unused] (native name is "Kd_salt")
+    ! long_name: Ocean vertical salt diffusivity
+    ! units: m2 s-1
+    ! standard_name: ocean_vertical_salt_diffusivity
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "difvso_xyave"  [Unused] (native name is "Kd_salt_xyave")
+    ! long_name: Ocean vertical salt diffusivity
+    ! units: m2 s-1
+    ! standard_name: ocean_vertical_salt_diffusivity
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "Kd_salt"  [Unused] (CMOR equivalent is "difvso")
+    ! long_name: Total diapycnal diffusivity for salt at interfaces
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "Kd_salt_xyave"  [Unused] (CMOR equivalent is "difvso_xyave")
+    ! long_name: Total diapycnal diffusivity for salt at interfaces
+    ! units: m2 s-1
+    ! cell_methods: z_i:point
+"ocean_model_z_d2", "difvso"  [Unused] (native name is "Kd_salt")
+    ! long_name: Ocean vertical salt diffusivity
+    ! units: m2 s-1
+    ! standard_name: ocean_vertical_salt_diffusivity
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "difvso_xyave"  [Unused] (native name is "Kd_salt_xyave")
+    ! long_name: Ocean vertical salt diffusivity
+    ! units: m2 s-1
+    ! standard_name: ocean_vertical_salt_diffusivity
+    ! cell_methods: z_i:point
 "ocean_model", "diabatic_diff_h"  [Unused]
     ! long_name: Cell thickness used during diabatic diffusion
     ! units: m
@@ -2461,6 +4722,22 @@
     ! units: m
     ! cell_methods: xh:mean yh:mean z_l:sum area:mean
 "ocean_model_z", "diabatic_diff_h_xyave"  [Unused]
+    ! long_name: Cell thickness used during diabatic diffusion
+    ! units: m
+    ! cell_methods: z_l:sum
+"ocean_model_d2", "diabatic_diff_h"  [Unused]
+    ! long_name: Cell thickness used during diabatic diffusion
+    ! units: m
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "diabatic_diff_h_xyave"  [Unused]
+    ! long_name: Cell thickness used during diabatic diffusion
+    ! units: m
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "diabatic_diff_h"  [Unused]
+    ! long_name: Cell thickness used during diabatic diffusion
+    ! units: m
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "diabatic_diff_h_xyave"  [Unused]
     ! long_name: Cell thickness used during diabatic diffusion
     ! units: m
     ! cell_methods: z_l:sum
@@ -2484,6 +4761,26 @@
     ! units: m
     ! standard_name: cell_thickness
     ! cell_methods: z_l:sum
+"ocean_model_d2", "frazil_h"  [Unused]
+    ! long_name: Cell Thickness
+    ! units: m
+    ! standard_name: cell_thickness
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "frazil_h_xyave"  [Unused]
+    ! long_name: Cell Thickness
+    ! units: m
+    ! standard_name: cell_thickness
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "frazil_h"  [Unused]
+    ! long_name: Cell Thickness
+    ! units: m
+    ! standard_name: cell_thickness
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "frazil_h_xyave"  [Unused]
+    ! long_name: Cell Thickness
+    ! units: m
+    ! standard_name: cell_thickness
+    ! cell_methods: z_l:sum
 "ocean_model", "frazil_temp_tendency"  [Used]
     ! long_name: Temperature tendency due to frazil formation
     ! units: degC s-1
@@ -2497,6 +4794,22 @@
     ! units: degC s-1
     ! cell_methods: xh:mean yh:mean z_l:mean area:mean
 "ocean_model_z", "frazil_temp_tendency_xyave"  [Unused]
+    ! long_name: Temperature tendency due to frazil formation
+    ! units: degC s-1
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "frazil_temp_tendency"  [Unused]
+    ! long_name: Temperature tendency due to frazil formation
+    ! units: degC s-1
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "frazil_temp_tendency_xyave"  [Unused]
+    ! long_name: Temperature tendency due to frazil formation
+    ! units: degC s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "frazil_temp_tendency"  [Unused]
+    ! long_name: Temperature tendency due to frazil formation
+    ! units: degC s-1
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "frazil_temp_tendency_xyave"  [Unused]
     ! long_name: Temperature tendency due to frazil formation
     ! units: degC s-1
     ! cell_methods: z_l:mean
@@ -2516,7 +4829,27 @@
     ! long_name: Heat tendency due to frazil formation
     ! units: W m-2
     ! cell_methods: z_l:sum
+"ocean_model_d2", "frazil_heat_tendency"  [Unused]
+    ! long_name: Heat tendency due to frazil formation
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "frazil_heat_tendency_xyave"  [Unused]
+    ! long_name: Heat tendency due to frazil formation
+    ! units: W m-2
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "frazil_heat_tendency"  [Unused]
+    ! long_name: Heat tendency due to frazil formation
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "frazil_heat_tendency_xyave"  [Unused]
+    ! long_name: Heat tendency due to frazil formation
+    ! units: W m-2
+    ! cell_methods: z_l:sum
 "ocean_model", "frazil_heat_tendency_2d"  [Used]
+    ! long_name: Depth integrated heat tendency due to frazil formation
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "frazil_heat_tendency_2d"  [Unused]
     ! long_name: Depth integrated heat tendency due to frazil formation
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -2536,11 +4869,35 @@
     ! long_name: Internal Tide Driven Diffusivity
     ! units: m2 s-1
     ! cell_methods: z_i:point
+"ocean_model_d2", "Kd_itides"  [Unused]
+    ! long_name: Internal Tide Driven Diffusivity
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "Kd_itides_xyave"  [Unused]
+    ! long_name: Internal Tide Driven Diffusivity
+    ! units: m2 s-1
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "Kd_itides"  [Unused]
+    ! long_name: Internal Tide Driven Diffusivity
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "Kd_itides_xyave"  [Unused]
+    ! long_name: Internal Tide Driven Diffusivity
+    ! units: m2 s-1
+    ! cell_methods: z_i:point
 "ocean_model", "TKE_itidal"  [Unused]
     ! long_name: Internal Tide Driven Turbulent Kinetic Energy
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "TKE_itidal"  [Unused]
+    ! long_name: Internal Tide Driven Turbulent Kinetic Energy
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "Nb"  [Unused]
+    ! long_name: Bottom Buoyancy Frequency
+    ! units: s-1
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "Nb"  [Unused]
     ! long_name: Bottom Buoyancy Frequency
     ! units: s-1
     ! cell_methods: xh:mean yh:mean area:mean
@@ -2560,6 +4917,22 @@
     ! long_name: Internal Tide Driven Diffusivity (from propagating low modes)
     ! units: m2 s-1
     ! cell_methods: z_i:point
+"ocean_model_d2", "Kd_lowmode"  [Unused]
+    ! long_name: Internal Tide Driven Diffusivity (from propagating low modes)
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "Kd_lowmode_xyave"  [Unused]
+    ! long_name: Internal Tide Driven Diffusivity (from propagating low modes)
+    ! units: m2 s-1
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "Kd_lowmode"  [Unused]
+    ! long_name: Internal Tide Driven Diffusivity (from propagating low modes)
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "Kd_lowmode_xyave"  [Unused]
+    ! long_name: Internal Tide Driven Diffusivity (from propagating low modes)
+    ! units: m2 s-1
+    ! cell_methods: z_i:point
 "ocean_model", "Fl_itides"  [Unused]
     ! long_name: Vertical flux of tidal turbulent dissipation
     ! units: m3 s-3
@@ -2573,6 +4946,22 @@
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean z_i:point area:mean
 "ocean_model_z", "Fl_itides_xyave"  [Unused]
+    ! long_name: Vertical flux of tidal turbulent dissipation
+    ! units: m3 s-3
+    ! cell_methods: z_i:point
+"ocean_model_d2", "Fl_itides"  [Unused]
+    ! long_name: Vertical flux of tidal turbulent dissipation
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "Fl_itides_xyave"  [Unused]
+    ! long_name: Vertical flux of tidal turbulent dissipation
+    ! units: m3 s-3
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "Fl_itides"  [Unused]
+    ! long_name: Vertical flux of tidal turbulent dissipation
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "Fl_itides_xyave"  [Unused]
     ! long_name: Vertical flux of tidal turbulent dissipation
     ! units: m3 s-3
     ! cell_methods: z_i:point
@@ -2592,7 +4981,27 @@
     ! long_name: Vertical flux of tidal turbulent dissipation (from propagating low modes)
     ! units: m3 s-3
     ! cell_methods: z_i:point
+"ocean_model_d2", "Fl_lowmode"  [Unused]
+    ! long_name: Vertical flux of tidal turbulent dissipation (from propagating low modes)
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "Fl_lowmode_xyave"  [Unused]
+    ! long_name: Vertical flux of tidal turbulent dissipation (from propagating low modes)
+    ! units: m3 s-3
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "Fl_lowmode"  [Unused]
+    ! long_name: Vertical flux of tidal turbulent dissipation (from propagating low modes)
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "Fl_lowmode_xyave"  [Unused]
+    ! long_name: Vertical flux of tidal turbulent dissipation (from propagating low modes)
+    ! units: m3 s-3
+    ! cell_methods: z_i:point
 "ocean_model", "Polzin_decay_scale"  [Unused]
+    ! long_name: Vertical decay scale for the tidal turbulent dissipation with Polzin scheme
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "Polzin_decay_scale"  [Unused]
     ! long_name: Vertical decay scale for the tidal turbulent dissipation with Polzin scheme
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
@@ -2600,11 +5009,23 @@
     ! long_name: Vertical decay scale for the tidal turbulent dissipation with Polzin scheme, scaled by N2_bot/N2_meanz
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "Polzin_decay_scale_scaled"  [Unused]
+    ! long_name: Vertical decay scale for the tidal turbulent dissipation with Polzin scheme, scaled by N2_bot/N2_meanz
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "N2_b"  [Unused]
     ! long_name: Bottom Buoyancy frequency squared
     ! units: s-2
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "N2_b"  [Unused]
+    ! long_name: Bottom Buoyancy frequency squared
+    ! units: s-2
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "N2_meanz"  [Unused]
+    ! long_name: Buoyancy frequency squared averaged over the water column
+    ! units: s-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "N2_meanz"  [Unused]
     ! long_name: Buoyancy frequency squared averaged over the water column
     ! units: s-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -2624,6 +5045,22 @@
     ! long_name: Work done by Internal Tide Diapycnal Mixing
     ! units: W m-2
     ! cell_methods: z_l:mean
+"ocean_model_d2", "Kd_Itidal_Work"  [Unused]
+    ! long_name: Work done by Internal Tide Diapycnal Mixing
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "Kd_Itidal_Work_xyave"  [Unused]
+    ! long_name: Work done by Internal Tide Diapycnal Mixing
+    ! units: W m-2
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "Kd_Itidal_Work"  [Unused]
+    ! long_name: Work done by Internal Tide Diapycnal Mixing
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "Kd_Itidal_Work_xyave"  [Unused]
+    ! long_name: Work done by Internal Tide Diapycnal Mixing
+    ! units: W m-2
+    ! cell_methods: z_l:mean
 "ocean_model", "Kd_Nikurashin_Work"  [Unused]
     ! long_name: Work done by Nikurashin Lee Wave Drag Scheme
     ! units: W m-2
@@ -2640,6 +5077,22 @@
     ! long_name: Work done by Nikurashin Lee Wave Drag Scheme
     ! units: W m-2
     ! cell_methods: z_l:mean
+"ocean_model_d2", "Kd_Nikurashin_Work"  [Unused]
+    ! long_name: Work done by Nikurashin Lee Wave Drag Scheme
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "Kd_Nikurashin_Work_xyave"  [Unused]
+    ! long_name: Work done by Nikurashin Lee Wave Drag Scheme
+    ! units: W m-2
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "Kd_Nikurashin_Work"  [Unused]
+    ! long_name: Work done by Nikurashin Lee Wave Drag Scheme
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "Kd_Nikurashin_Work_xyave"  [Unused]
+    ! long_name: Work done by Nikurashin Lee Wave Drag Scheme
+    ! units: W m-2
+    ! cell_methods: z_l:mean
 "ocean_model", "Kd_Lowmode_Work"  [Unused]
     ! long_name: Work done by Internal Tide Diapycnal Mixing (low modes)
     ! units: W m-2
@@ -2653,6 +5106,22 @@
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean z_l:mean area:mean
 "ocean_model_z", "Kd_Lowmode_Work_xyave"  [Unused]
+    ! long_name: Work done by Internal Tide Diapycnal Mixing (low modes)
+    ! units: W m-2
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "Kd_Lowmode_Work"  [Unused]
+    ! long_name: Work done by Internal Tide Diapycnal Mixing (low modes)
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "Kd_Lowmode_Work_xyave"  [Unused]
+    ! long_name: Work done by Internal Tide Diapycnal Mixing (low modes)
+    ! units: W m-2
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "Kd_Lowmode_Work"  [Unused]
+    ! long_name: Work done by Internal Tide Diapycnal Mixing (low modes)
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "Kd_Lowmode_Work_xyave"  [Unused]
     ! long_name: Work done by Internal Tide Diapycnal Mixing (low modes)
     ! units: W m-2
     ! cell_methods: z_l:mean
@@ -2675,6 +5144,22 @@
     ! long_name: Diapycnal diffusivity as applied
     ! units: m2 s-1
     ! cell_methods: z_l:mean
+"ocean_model_d2", "Kd_effective"  [Unused]
+    ! long_name: Diapycnal diffusivity as applied
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "Kd_effective_xyave"  [Unused]
+    ! long_name: Diapycnal diffusivity as applied
+    ! units: m2 s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "Kd_effective"  [Unused]
+    ! long_name: Diapycnal diffusivity as applied
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "Kd_effective_xyave"  [Unused]
+    ! long_name: Diapycnal diffusivity as applied
+    ! units: m2 s-1
+    ! cell_methods: z_l:mean
 "ocean_model", "diff_work"  [Unused]
     ! long_name: Work actually done by diapycnal diffusion across each interface
     ! units: W m-2
@@ -2688,6 +5173,22 @@
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean z_i:point area:mean
 "ocean_model_z", "diff_work_xyave"  [Unused]
+    ! long_name: Work actually done by diapycnal diffusion across each interface
+    ! units: W m-2
+    ! cell_methods: z_i:point
+"ocean_model_d2", "diff_work"  [Unused]
+    ! long_name: Work actually done by diapycnal diffusion across each interface
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "diff_work_xyave"  [Unused]
+    ! long_name: Work actually done by diapycnal diffusion across each interface
+    ! units: W m-2
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "diff_work"  [Unused]
+    ! long_name: Work actually done by diapycnal diffusion across each interface
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "diff_work_xyave"  [Unused]
     ! long_name: Work actually done by diapycnal diffusion across each interface
     ! units: W m-2
     ! cell_methods: z_i:point
@@ -2714,6 +5215,22 @@
     ! long_name: Bottom Boundary Layer Diffusivity
     ! units: m2 s-1
     ! cell_methods: z_i:point
+"ocean_model_d2", "Kd_BBL"  [Unused]
+    ! long_name: Bottom Boundary Layer Diffusivity
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "Kd_BBL_xyave"  [Unused]
+    ! long_name: Bottom Boundary Layer Diffusivity
+    ! units: m2 s-1
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "Kd_BBL"  [Unused]
+    ! long_name: Bottom Boundary Layer Diffusivity
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "Kd_BBL_xyave"  [Unused]
+    ! long_name: Bottom Boundary Layer Diffusivity
+    ! units: m2 s-1
+    ! cell_methods: z_i:point
 "ocean_model", "Kd_bkgnd"  [Unused]
     ! long_name: Background diffusivity added by MOM_bkgnd_mixing module
     ! units: m2/s
@@ -2727,6 +5244,22 @@
     ! units: m2/s
     ! cell_methods: xh:mean yh:mean z_i:point area:mean
 "ocean_model_z", "Kd_bkgnd_xyave"  [Unused]
+    ! long_name: Background diffusivity added by MOM_bkgnd_mixing module
+    ! units: m2/s
+    ! cell_methods: z_i:point
+"ocean_model_d2", "Kd_bkgnd"  [Unused]
+    ! long_name: Background diffusivity added by MOM_bkgnd_mixing module
+    ! units: m2/s
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "Kd_bkgnd_xyave"  [Unused]
+    ! long_name: Background diffusivity added by MOM_bkgnd_mixing module
+    ! units: m2/s
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "Kd_bkgnd"  [Unused]
+    ! long_name: Background diffusivity added by MOM_bkgnd_mixing module
+    ! units: m2/s
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "Kd_bkgnd_xyave"  [Unused]
     ! long_name: Background diffusivity added by MOM_bkgnd_mixing module
     ! units: m2/s
     ! cell_methods: z_i:point
@@ -2746,6 +5279,22 @@
     ! long_name: Background viscosity added by MOM_bkgnd_mixing module
     ! units: m2/s
     ! cell_methods: z_i:point
+"ocean_model_d2", "Kv_bkgnd"  [Unused]
+    ! long_name: Background viscosity added by MOM_bkgnd_mixing module
+    ! units: m2/s
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "Kv_bkgnd_xyave"  [Unused]
+    ! long_name: Background viscosity added by MOM_bkgnd_mixing module
+    ! units: m2/s
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "Kv_bkgnd"  [Unused]
+    ! long_name: Background viscosity added by MOM_bkgnd_mixing module
+    ! units: m2/s
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "Kv_bkgnd_xyave"  [Unused]
+    ! long_name: Background viscosity added by MOM_bkgnd_mixing module
+    ! units: m2/s
+    ! cell_methods: z_i:point
 "ocean_model", "Kd_layer"  [Used]
     ! long_name: Diapycnal diffusivity of layers (as set)
     ! units: m2 s-1
@@ -2759,6 +5308,22 @@
     ! units: m2 s-1
     ! cell_methods: xh:mean yh:mean z_l:mean area:mean
 "ocean_model_z", "Kd_layer_xyave"  [Unused]
+    ! long_name: Diapycnal diffusivity of layers (as set)
+    ! units: m2 s-1
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "Kd_layer"  [Unused]
+    ! long_name: Diapycnal diffusivity of layers (as set)
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "Kd_layer_xyave"  [Unused]
+    ! long_name: Diapycnal diffusivity of layers (as set)
+    ! units: m2 s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "Kd_layer"  [Unused]
+    ! long_name: Diapycnal diffusivity of layers (as set)
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "Kd_layer_xyave"  [Unused]
     ! long_name: Diapycnal diffusivity of layers (as set)
     ! units: m2 s-1
     ! cell_methods: z_l:mean
@@ -2778,6 +5343,22 @@
     ! long_name: Work done by Diapycnal Mixing
     ! units: W m-2
     ! cell_methods: z_l:mean
+"ocean_model_d2", "Kd_Work"  [Unused]
+    ! long_name: Work done by Diapycnal Mixing
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "Kd_Work_xyave"  [Unused]
+    ! long_name: Work done by Diapycnal Mixing
+    ! units: W m-2
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "Kd_Work"  [Unused]
+    ! long_name: Work done by Diapycnal Mixing
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "Kd_Work_xyave"  [Unused]
+    ! long_name: Work done by Diapycnal Mixing
+    ! units: W m-2
+    ! cell_methods: z_l:mean
 "ocean_model", "maxTKE"  [Unused]
     ! long_name: Maximum layer TKE
     ! units: m3 s-3
@@ -2794,6 +5375,22 @@
     ! long_name: Maximum layer TKE
     ! units: m3 s-3
     ! cell_methods: z_l:mean
+"ocean_model_d2", "maxTKE"  [Unused]
+    ! long_name: Maximum layer TKE
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "maxTKE_xyave"  [Unused]
+    ! long_name: Maximum layer TKE
+    ! units: m3 s-3
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "maxTKE"  [Unused]
+    ! long_name: Maximum layer TKE
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "maxTKE_xyave"  [Unused]
+    ! long_name: Maximum layer TKE
+    ! units: m3 s-3
+    ! cell_methods: z_l:mean
 "ocean_model", "TKE_to_Kd"  [Unused]
     ! long_name: Convert TKE to Kd
     ! units: s2 m
@@ -2807,6 +5404,22 @@
     ! units: s2 m
     ! cell_methods: xh:mean yh:mean z_l:mean area:mean
 "ocean_model_z", "TKE_to_Kd_xyave"  [Unused]
+    ! long_name: Convert TKE to Kd
+    ! units: s2 m
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "TKE_to_Kd"  [Unused]
+    ! long_name: Convert TKE to Kd
+    ! units: s2 m
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "TKE_to_Kd_xyave"  [Unused]
+    ! long_name: Convert TKE to Kd
+    ! units: s2 m
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "TKE_to_Kd"  [Unused]
+    ! long_name: Convert TKE to Kd
+    ! units: s2 m
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "TKE_to_Kd_xyave"  [Unused]
     ! long_name: Convert TKE to Kd
     ! units: s2 m
     ! cell_methods: z_l:mean
@@ -2846,6 +5459,42 @@
     ! units: s-2
     ! standard_name: square_of_brunt_vaisala_frequency_in_sea_water
     ! cell_methods: z_i:point
+"ocean_model_d2", "N2"  [Unused] (CMOR equivalent is "obvfsq")
+    ! long_name: Buoyancy frequency squared
+    ! units: s-2
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "N2_xyave"  [Unused] (CMOR equivalent is "obvfsq_xyave")
+    ! long_name: Buoyancy frequency squared
+    ! units: s-2
+    ! cell_methods: zi:point
+"ocean_model_d2", "obvfsq"  [Unused] (native name is "N2")
+    ! long_name: Square of seawater buoyancy frequency
+    ! units: s-2
+    ! standard_name: square_of_brunt_vaisala_frequency_in_sea_water
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "obvfsq_xyave"  [Unused] (native name is "N2_xyave")
+    ! long_name: Square of seawater buoyancy frequency
+    ! units: s-2
+    ! standard_name: square_of_brunt_vaisala_frequency_in_sea_water
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "N2"  [Unused] (CMOR equivalent is "obvfsq")
+    ! long_name: Buoyancy frequency squared
+    ! units: s-2
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "N2_xyave"  [Unused] (CMOR equivalent is "obvfsq_xyave")
+    ! long_name: Buoyancy frequency squared
+    ! units: s-2
+    ! cell_methods: z_i:point
+"ocean_model_z_d2", "obvfsq"  [Unused] (native name is "N2")
+    ! long_name: Square of seawater buoyancy frequency
+    ! units: s-2
+    ! standard_name: square_of_brunt_vaisala_frequency_in_sea_water
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "obvfsq_xyave"  [Unused] (native name is "N2_xyave")
+    ! long_name: Square of seawater buoyancy frequency
+    ! units: s-2
+    ! standard_name: square_of_brunt_vaisala_frequency_in_sea_water
+    ! cell_methods: z_i:point
 "ocean_model_zold", "N2"  [Unused]
     ! long_name: Buoyancy frequency, interpolated to z
     ! units: s-2
@@ -2865,6 +5514,22 @@
     ! long_name: Shear-driven Diapycnal Diffusivity
     ! units: m2 s-1
     ! cell_methods: z_i:point
+"ocean_model_d2", "Kd_shear"  [Unused]
+    ! long_name: Shear-driven Diapycnal Diffusivity
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "Kd_shear_xyave"  [Unused]
+    ! long_name: Shear-driven Diapycnal Diffusivity
+    ! units: m2 s-1
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "Kd_shear"  [Unused]
+    ! long_name: Shear-driven Diapycnal Diffusivity
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "Kd_shear_xyave"  [Unused]
+    ! long_name: Shear-driven Diapycnal Diffusivity
+    ! units: m2 s-1
+    ! cell_methods: z_i:point
 "ocean_model", "TKE_shear"  [Unused]
     ! long_name: Shear-driven Turbulent Kinetic Energy
     ! units: m2 s-2
@@ -2881,7 +5546,27 @@
     ! long_name: Shear-driven Turbulent Kinetic Energy
     ! units: m2 s-2
     ! cell_methods: z_i:point
+"ocean_model_d2", "TKE_shear"  [Unused]
+    ! long_name: Shear-driven Turbulent Kinetic Energy
+    ! units: m2 s-2
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "TKE_shear_xyave"  [Unused]
+    ! long_name: Shear-driven Turbulent Kinetic Energy
+    ! units: m2 s-2
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "TKE_shear"  [Unused]
+    ! long_name: Shear-driven Turbulent Kinetic Energy
+    ! units: m2 s-2
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "TKE_shear_xyave"  [Unused]
+    ! long_name: Shear-driven Turbulent Kinetic Energy
+    ! units: m2 s-2
+    ! cell_methods: z_i:point
 "ocean_model", "h_ML"  [Unused]
+    ! long_name: Surface mixed layer depth
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "h_ML"  [Unused]
     ! long_name: Surface mixed layer depth
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
@@ -2889,7 +5574,15 @@
     ! long_name: Wind-stirring source of mixed layer TKE
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "TKE_wind"  [Unused]
+    ! long_name: Wind-stirring source of mixed layer TKE
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "TKE_RiBulk"  [Unused]
+    ! long_name: Mean kinetic energy source of mixed layer TKE
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "TKE_RiBulk"  [Unused]
     ! long_name: Mean kinetic energy source of mixed layer TKE
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean area:mean
@@ -2897,7 +5590,15 @@
     ! long_name: Convective source of mixed layer TKE
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "TKE_conv"  [Unused]
+    ! long_name: Convective source of mixed layer TKE
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "TKE_pen_SW"  [Unused]
+    ! long_name: TKE consumed by mixing penetrative shortwave radation through the mixed layer
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "TKE_pen_SW"  [Unused]
     ! long_name: TKE consumed by mixing penetrative shortwave radation through the mixed layer
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean area:mean
@@ -2905,7 +5606,15 @@
     ! long_name: TKE consumed by mixing that deepens the mixed layer
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "TKE_mixing"  [Unused]
+    ! long_name: TKE consumed by mixing that deepens the mixed layer
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "TKE_mech_decay"  [Unused]
+    ! long_name: Mechanical energy decay sink of mixed layer TKE
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "TKE_mech_decay"  [Unused]
     ! long_name: Mechanical energy decay sink of mixed layer TKE
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean area:mean
@@ -2913,7 +5622,15 @@
     ! long_name: Convective energy decay sink of mixed layer TKE
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "TKE_conv_decay"  [Unused]
+    ! long_name: Convective energy decay sink of mixed layer TKE
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "TKE_conv_s2"  [Unused]
+    ! long_name: Spurious source of mixed layer TKE from sigma2
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "TKE_conv_s2"  [Unused]
     ! long_name: Spurious source of mixed layer TKE from sigma2
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean area:mean
@@ -2921,7 +5638,15 @@
     ! long_name: Spurious source of potential energy from mixed layer detrainment
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "PE_detrain"  [Unused]
+    ! long_name: Spurious source of potential energy from mixed layer detrainment
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "PE_detrain2"  [Unused]
+    ! long_name: Spurious source of potential energy from mixed layer only detrainment
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "PE_detrain2"  [Unused]
     ! long_name: Spurious source of potential energy from mixed layer only detrainment
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -2929,7 +5654,15 @@
     ! long_name: Summed absolute mismatch in entrainment terms
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "h_miss_ML"  [Unused]
+    ! long_name: Summed absolute mismatch in entrainment terms
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "Hs_used"  [Unused]
+    ! long_name: Surface region thickness that is used
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "Hs_used"  [Unused]
     ! long_name: Surface region thickness that is used
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
@@ -2937,7 +5670,15 @@
     ! long_name: Maximum surface region thickness
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "Hs_max"  [Unused]
+    ! long_name: Maximum surface region thickness
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "Hs_min"  [Unused]
+    ! long_name: Minimum surface region thickness
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "Hs_min"  [Unused]
     ! long_name: Minimum surface region thickness
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
@@ -2945,11 +5686,23 @@
     ! long_name: Max face thickness deficit ratio
     ! units: nondim
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "deficit_ratio"  [Unused]
+    ! long_name: Max face thickness deficit ratio
+    ! units: nondim
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "SW_pen"  [Unused]
     ! long_name: Penetrating shortwave radiation flux into ocean
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "SW_pen"  [Unused]
+    ! long_name: Penetrating shortwave radiation flux into ocean
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "SW_vis_pen"  [Unused]
+    ! long_name: Visible penetrating shortwave radiation flux into ocean
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "SW_vis_pen"  [Unused]
     ! long_name: Visible penetrating shortwave radiation flux into ocean
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -2969,6 +5722,22 @@
     ! long_name: Opacity for shortwave radiation in band 1
     ! units: m-1
     ! cell_methods: z_l:mean
+"ocean_model_d2", "opac_1"  [Unused]
+    ! long_name: Opacity for shortwave radiation in band 1
+    ! units: m-1
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "opac_1_xyave"  [Unused]
+    ! long_name: Opacity for shortwave radiation in band 1
+    ! units: m-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "opac_1"  [Unused]
+    ! long_name: Opacity for shortwave radiation in band 1
+    ! units: m-1
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "opac_1_xyave"  [Unused]
+    ! long_name: Opacity for shortwave radiation in band 1
+    ! units: m-1
+    ! cell_methods: z_l:mean
 "ocean_model", "opac_2"  [Unused]
     ! long_name: Opacity for shortwave radiation in band 2
     ! units: m-1
@@ -2982,6 +5751,22 @@
     ! units: m-1
     ! cell_methods: xh:mean yh:mean z_l:mean area:mean
 "ocean_model_z", "opac_2_xyave"  [Unused]
+    ! long_name: Opacity for shortwave radiation in band 2
+    ! units: m-1
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "opac_2"  [Unused]
+    ! long_name: Opacity for shortwave radiation in band 2
+    ! units: m-1
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "opac_2_xyave"  [Unused]
+    ! long_name: Opacity for shortwave radiation in band 2
+    ! units: m-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "opac_2"  [Unused]
+    ! long_name: Opacity for shortwave radiation in band 2
+    ! units: m-1
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "opac_2_xyave"  [Unused]
     ! long_name: Opacity for shortwave radiation in band 2
     ! units: m-1
     ! cell_methods: z_l:mean
@@ -3001,7 +5786,27 @@
     ! long_name: Opacity for shortwave radiation in band 3
     ! units: m-1
     ! cell_methods: z_l:mean
+"ocean_model_d2", "opac_3"  [Unused]
+    ! long_name: Opacity for shortwave radiation in band 3
+    ! units: m-1
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "opac_3_xyave"  [Unused]
+    ! long_name: Opacity for shortwave radiation in band 3
+    ! units: m-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "opac_3"  [Unused]
+    ! long_name: Opacity for shortwave radiation in band 3
+    ! units: m-1
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "opac_3_xyave"  [Unused]
+    ! long_name: Opacity for shortwave radiation in band 3
+    ! units: m-1
+    ! cell_methods: z_l:mean
 "ocean_model", "Chl_opac"  [Unused]
+    ! long_name: Surface chlorophyll A concentration used to find opacity
+    ! units: mg m-3
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "Chl_opac"  [Unused]
     ! long_name: Surface chlorophyll A concentration used to find opacity
     ! units: mg m-3
     ! cell_methods: xh:mean yh:mean area:mean
@@ -3009,7 +5814,15 @@
     ! long_name: Epipycnal tracer diffusivity at zonal faces of tracer cell
     ! units: m2 s-1
     ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "KHTR_u"  [Unused]
+    ! long_name: Epipycnal tracer diffusivity at zonal faces of tracer cell
+    ! units: m2 s-1
+    ! cell_methods: xq:point yh:mean
 "ocean_model", "KHTR_v"  [Used]
+    ! long_name: Epipycnal tracer diffusivity at meridional faces of tracer cell
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "KHTR_v"  [Unused]
     ! long_name: Epipycnal tracer diffusivity at meridional faces of tracer cell
     ! units: m2 s-1
     ! cell_methods: xh:mean yq:point
@@ -3022,11 +5835,28 @@
     ! units: m2 s-1
     ! standard_name: ocean_tracer_epineutral_laplacian_diffusivity
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "KHTR_h"  [Unused] (CMOR equivalent is "diftrelo")
+    ! long_name: Epipycnal tracer diffusivity at tracer cell center
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "diftrelo"  [Unused] (native name is "KHTR_h")
+    ! long_name: Ocean Tracer Epineutral Laplacian Diffusivity
+    ! units: m2 s-1
+    ! standard_name: ocean_tracer_epineutral_laplacian_diffusivity
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "KHDT_x"  [Unused]
     ! long_name: Epipycnal tracer diffusivity operator at zonal faces of tracer cell
     ! units: m2
     ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "KHDT_x"  [Unused]
+    ! long_name: Epipycnal tracer diffusivity operator at zonal faces of tracer cell
+    ! units: m2
+    ! cell_methods: xq:point yh:mean
 "ocean_model", "KHDT_y"  [Unused]
+    ! long_name: Epipycnal tracer diffusivity operator at meridional faces of tracer cell
+    ! units: m2
+    ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "KHDT_y"  [Unused]
     ! long_name: Epipycnal tracer diffusivity operator at meridional faces of tracer cell
     ! units: m2
     ! cell_methods: xh:mean yq:point
@@ -3039,12 +5869,26 @@
     ! units: m
     ! standard_name: sea_surface_height_above_geoid
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "zos"  [Unused]
+    ! long_name: Sea surface height above geoid
+    ! units: m
+    ! standard_name: sea_surface_height_above_geoid
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "zossq"  [Used]
     ! long_name: Square of sea surface height above geoid
     ! units: m2
     ! standard_name: square_of_sea_surface_height_above_geoid
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "zossq"  [Unused]
+    ! long_name: Square of sea surface height above geoid
+    ! units: m2
+    ! standard_name: square_of_sea_surface_height_above_geoid
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "SSH"  [Used]
+    ! long_name: Sea Surface Height
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "SSH"  [Unused]
     ! long_name: Sea Surface Height
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
@@ -3056,11 +5900,23 @@
     ! long_name: Sea Surface Zonal Velocity
     ! units: m s-1
     ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "SSU"  [Unused]
+    ! long_name: Sea Surface Zonal Velocity
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean
 "ocean_model", "SSV"  [Used]
     ! long_name: Sea Surface Meridional Velocity
     ! units: m s-1
     ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "SSV"  [Unused]
+    ! long_name: Sea Surface Meridional Velocity
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point
 "ocean_model", "speed"  [Used]
+    ! long_name: Sea Surface Speed
+    ! units: m s-1
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "speed"  [Unused]
     ! long_name: Sea Surface Speed
     ! units: m s-1
     ! cell_methods: xh:mean yh:mean area:mean
@@ -3069,6 +5925,15 @@
     ! units: degC
     ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "tos"  [Unused] (native name is "SST")
+    ! long_name: Sea Surface Temperature
+    ! units: degC
+    ! standard_name: sea_surface_temperature
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "SST"  [Unused] (CMOR equivalent is "tos")
+    ! long_name: Sea Surface Temperature
+    ! units: degC
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "tos"  [Unused] (native name is "SST")
     ! long_name: Sea Surface Temperature
     ! units: degC
     ! standard_name: sea_surface_temperature
@@ -3082,11 +5947,29 @@
     ! units: degC2
     ! standard_name: square_of_sea_surface_temperature
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "SST_sq"  [Unused] (CMOR equivalent is "tossq")
+    ! long_name: Sea Surface Temperature Squared
+    ! units: degC2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "tossq"  [Unused] (native name is "SST_sq")
+    ! long_name: Square of Sea Surface Temperature
+    ! units: degC2
+    ! standard_name: square_of_sea_surface_temperature
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "SSS"  [Used] (CMOR equivalent is "sos")
     ! long_name: Sea Surface Salinity
     ! units: psu
     ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "sos"  [Unused] (native name is "SSS")
+    ! long_name: Sea Surface Salinity
+    ! units: psu
+    ! standard_name: sea_surface_salinity
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "SSS"  [Unused] (CMOR equivalent is "sos")
+    ! long_name: Sea Surface Salinity
+    ! units: psu
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "sos"  [Unused] (native name is "SSS")
     ! long_name: Sea Surface Salinity
     ! units: psu
     ! standard_name: sea_surface_salinity
@@ -3100,6 +5983,15 @@
     ! units: psu
     ! standard_name: square_of_sea_surface_salinity
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "SSS_sq"  [Unused] (CMOR equivalent is "sossq")
+    ! long_name: Sea Surface Salinity Squared
+    ! units: psu
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "sossq"  [Unused] (native name is "SSS_sq")
+    ! long_name: Square of Sea Surface Salinity
+    ! units: psu
+    ! standard_name: square_of_sea_surface_salinity
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "frazil"  [Used] (CMOR equivalent is "hfsifrazil")
     ! long_name: Heat from frazil formation
     ! units: W m-2
@@ -3109,7 +6001,20 @@
     ! units: W m-2
     ! standard_name: heat_flux_into_sea_water_due_to_frazil_ice_formation
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "frazil"  [Unused] (CMOR equivalent is "hfsifrazil")
+    ! long_name: Heat from frazil formation
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "hfsifrazil"  [Unused] (native name is "frazil")
+    ! long_name: Heat Flux into Sea Water due to Frazil Ice Formation
+    ! units: W m-2
+    ! standard_name: heat_flux_into_sea_water_due_to_frazil_ice_formation
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "salt_deficit"  [Unused]
+    ! long_name: Salt sink in ocean due to ice flux
+    ! units: psu m-2 s-1
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "salt_deficit"  [Unused]
     ! long_name: Salt sink in ocean due to ice flux
     ! units: psu m-2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
@@ -3117,7 +6022,15 @@
     ! long_name: Heat flux into ocean from mass flux into ocean
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
-"ocean_model", "internal_heat"  [Used]
+"ocean_model_d2", "Heat_PmE"  [Unused]
+    ! long_name: Heat flux into ocean from mass flux into ocean
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model", "internal_heat"  [Unused]
+    ! long_name: Heat flux into ocean from geothermal or other internal sources
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "internal_heat"  [Unused]
     ! long_name: Heat flux into ocean from geothermal or other internal sources
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -3137,6 +6050,22 @@
     ! long_name: Zonal velocity after the dynamics update
     ! units: m s-1
     ! cell_methods: z_l:mean
+"ocean_model_d2", "u_dyn"  [Unused]
+    ! long_name: Zonal velocity after the dynamics update
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean zl:mean
+"ocean_model_d2", "u_dyn_xyave"  [Unused]
+    ! long_name: Zonal velocity after the dynamics update
+    ! units: m s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "u_dyn"  [Unused]
+    ! long_name: Zonal velocity after the dynamics update
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean z_l:mean
+"ocean_model_z_d2", "u_dyn_xyave"  [Unused]
+    ! long_name: Zonal velocity after the dynamics update
+    ! units: m s-1
+    ! cell_methods: z_l:mean
 "ocean_model", "v_dyn"  [Unused]
     ! long_name: Meridional velocity after the dynamics update
     ! units: m s-1
@@ -3150,6 +6079,22 @@
     ! units: m s-1
     ! cell_methods: xh:mean yq:point z_l:mean
 "ocean_model_z", "v_dyn_xyave"  [Unused]
+    ! long_name: Meridional velocity after the dynamics update
+    ! units: m s-1
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "v_dyn"  [Unused]
+    ! long_name: Meridional velocity after the dynamics update
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point zl:mean
+"ocean_model_d2", "v_dyn_xyave"  [Unused]
+    ! long_name: Meridional velocity after the dynamics update
+    ! units: m s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "v_dyn"  [Unused]
+    ! long_name: Meridional velocity after the dynamics update
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point z_l:mean
+"ocean_model_z_d2", "v_dyn_xyave"  [Unused]
     ! long_name: Meridional velocity after the dynamics update
     ! units: m s-1
     ! cell_methods: z_l:mean
@@ -3169,7 +6114,27 @@
     ! long_name: Layer Thickness after the dynamics update
     ! units: m
     ! cell_methods: z_l:sum
+"ocean_model_d2", "h_dyn"  [Unused]
+    ! long_name: Layer Thickness after the dynamics update
+    ! units: m
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "h_dyn_xyave"  [Unused]
+    ! long_name: Layer Thickness after the dynamics update
+    ! units: m
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "h_dyn"  [Unused]
+    ! long_name: Layer Thickness after the dynamics update
+    ! units: m
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "h_dyn_xyave"  [Unused]
+    ! long_name: Layer Thickness after the dynamics update
+    ! units: m
+    ! cell_methods: z_l:sum
 "ocean_model", "SSH_inst"  [Unused]
+    ! long_name: Instantaneous Sea Surface Height
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "SSH_inst"  [Unused]
     ! long_name: Instantaneous Sea Surface Height
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
@@ -3189,6 +6154,22 @@
     ! long_name: Accumulated zonal thickness fluxes to advect tracers
     ! units: kg
     ! cell_methods: z_l:sum
+"ocean_model_d2", "uhtr"  [Unused]
+    ! long_name: Accumulated zonal thickness fluxes to advect tracers
+    ! units: kg
+    ! cell_methods: xq:point yh:sum zl:sum
+"ocean_model_d2", "uhtr_xyave"  [Unused]
+    ! long_name: Accumulated zonal thickness fluxes to advect tracers
+    ! units: kg
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "uhtr"  [Unused]
+    ! long_name: Accumulated zonal thickness fluxes to advect tracers
+    ! units: kg
+    ! cell_methods: xq:point yh:sum z_l:sum
+"ocean_model_z_d2", "uhtr_xyave"  [Unused]
+    ! long_name: Accumulated zonal thickness fluxes to advect tracers
+    ! units: kg
+    ! cell_methods: z_l:sum
 "ocean_model", "vhtr"  [Unused]
     ! long_name: Accumulated meridional thickness fluxes to advect tracers
     ! units: kg
@@ -3202,6 +6183,22 @@
     ! units: kg
     ! cell_methods: xh:sum yq:point z_l:sum
 "ocean_model_z", "vhtr_xyave"  [Unused]
+    ! long_name: Accumulated meridional thickness fluxes to advect tracers
+    ! units: kg
+    ! cell_methods: z_l:sum
+"ocean_model_d2", "vhtr"  [Unused]
+    ! long_name: Accumulated meridional thickness fluxes to advect tracers
+    ! units: kg
+    ! cell_methods: xh:sum yq:point zl:sum
+"ocean_model_d2", "vhtr_xyave"  [Unused]
+    ! long_name: Accumulated meridional thickness fluxes to advect tracers
+    ! units: kg
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "vhtr"  [Unused]
+    ! long_name: Accumulated meridional thickness fluxes to advect tracers
+    ! units: kg
+    ! cell_methods: xh:sum yq:point z_l:sum
+"ocean_model_z_d2", "vhtr_xyave"  [Unused]
     ! long_name: Accumulated meridional thickness fluxes to advect tracers
     ! units: kg
     ! cell_methods: z_l:sum
@@ -3221,6 +6218,26 @@
     ! standard_name: ocean_mass_x_transport
     ! cell_methods: xq:point yh:sum z_l:sum
 "ocean_model_z", "umo_xyave"  [Unused]
+    ! long_name: Ocean Mass X Transport
+    ! units: kg s-1
+    ! standard_name: ocean_mass_x_transport
+    ! cell_methods: z_l:sum
+"ocean_model_d2", "umo"  [Unused]
+    ! long_name: Ocean Mass X Transport
+    ! units: kg s-1
+    ! standard_name: ocean_mass_x_transport
+    ! cell_methods: xq:point yh:sum zl:sum
+"ocean_model_d2", "umo_xyave"  [Unused]
+    ! long_name: Ocean Mass X Transport
+    ! units: kg s-1
+    ! standard_name: ocean_mass_x_transport
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "umo"  [Unused]
+    ! long_name: Ocean Mass X Transport
+    ! units: kg s-1
+    ! standard_name: ocean_mass_x_transport
+    ! cell_methods: xq:point yh:sum z_l:sum
+"ocean_model_z_d2", "umo_xyave"  [Unused]
     ! long_name: Ocean Mass X Transport
     ! units: kg s-1
     ! standard_name: ocean_mass_x_transport
@@ -3245,12 +6262,42 @@
     ! units: kg s-1
     ! standard_name: ocean_mass_y_transport
     ! cell_methods: z_l:sum
+"ocean_model_d2", "vmo"  [Unused]
+    ! long_name: Ocean Mass Y Transport
+    ! units: kg s-1
+    ! standard_name: ocean_mass_y_transport
+    ! cell_methods: xh:sum yq:point zl:sum
+"ocean_model_d2", "vmo_xyave"  [Unused]
+    ! long_name: Ocean Mass Y Transport
+    ! units: kg s-1
+    ! standard_name: ocean_mass_y_transport
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "vmo"  [Unused]
+    ! long_name: Ocean Mass Y Transport
+    ! units: kg s-1
+    ! standard_name: ocean_mass_y_transport
+    ! cell_methods: xh:sum yq:point z_l:sum
+"ocean_model_z_d2", "vmo_xyave"  [Unused]
+    ! long_name: Ocean Mass Y Transport
+    ! units: kg s-1
+    ! standard_name: ocean_mass_y_transport
+    ! cell_methods: z_l:sum
 "ocean_model", "umo_2d"  [Used]
     ! long_name: Ocean Mass X Transport Vertical Sum
     ! units: kg s-1
     ! standard_name: ocean_mass_x_transport_vertical_sum
     ! cell_methods: xq:point yh:sum
+"ocean_model_d2", "umo_2d"  [Unused]
+    ! long_name: Ocean Mass X Transport Vertical Sum
+    ! units: kg s-1
+    ! standard_name: ocean_mass_x_transport_vertical_sum
+    ! cell_methods: xq:point yh:sum
 "ocean_model", "vmo_2d"  [Used]
+    ! long_name: Ocean Mass Y Transport Vertical Sum
+    ! units: kg s-1
+    ! standard_name: ocean_mass_y_transport_vertical_sum
+    ! cell_methods: xh:sum yq:point
+"ocean_model_d2", "vmo_2d"  [Unused]
     ! long_name: Ocean Mass Y Transport Vertical Sum
     ! units: kg s-1
     ! standard_name: ocean_mass_y_transport_vertical_sum
@@ -3271,6 +6318,22 @@
     ! long_name: Change in layer thicknesses due to horizontal dynamics
     ! units: m s-1
     ! cell_methods: z_l:sum
+"ocean_model_d2", "dynamics_h"  [Unused]
+    ! long_name: Change in layer thicknesses due to horizontal dynamics
+    ! units: m s-1
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "dynamics_h_xyave"  [Unused]
+    ! long_name: Change in layer thicknesses due to horizontal dynamics
+    ! units: m s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "dynamics_h"  [Unused]
+    ! long_name: Change in layer thicknesses due to horizontal dynamics
+    ! units: m s-1
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "dynamics_h_xyave"  [Unused]
+    ! long_name: Change in layer thicknesses due to horizontal dynamics
+    ! units: m s-1
+    ! cell_methods: z_l:sum
 "ocean_model", "dynamics_h_tendency"  [Unused]
     ! long_name: Change in layer thicknesses due to horizontal dynamics
     ! units: m s-1
@@ -3284,6 +6347,22 @@
     ! units: m s-1
     ! cell_methods: xh:mean yh:mean z_l:sum area:mean
 "ocean_model_z", "dynamics_h_tendency_xyave"  [Unused]
+    ! long_name: Change in layer thicknesses due to horizontal dynamics
+    ! units: m s-1
+    ! cell_methods: z_l:sum
+"ocean_model_d2", "dynamics_h_tendency"  [Unused]
+    ! long_name: Change in layer thicknesses due to horizontal dynamics
+    ! units: m s-1
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "dynamics_h_tendency_xyave"  [Unused]
+    ! long_name: Change in layer thicknesses due to horizontal dynamics
+    ! units: m s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "dynamics_h_tendency"  [Unused]
+    ! long_name: Change in layer thicknesses due to horizontal dynamics
+    ! units: m s-1
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "dynamics_h_tendency_xyave"  [Unused]
     ! long_name: Change in layer thicknesses due to horizontal dynamics
     ! units: m s-1
     ! cell_methods: z_l:sum
@@ -3323,6 +6402,42 @@
     ! units: degC
     ! standard_name: sea_water_potential_temperature
     ! cell_methods: z_l:mean
+"ocean_model_d2", "temp"  [Unused] (CMOR equivalent is "thetao")
+    ! long_name: Potential Temperature
+    ! units: degC
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "temp_xyave"  [Unused] (CMOR equivalent is "thetao_xyave")
+    ! long_name: Potential Temperature
+    ! units: degC
+    ! cell_methods: zl:mean
+"ocean_model_d2", "thetao"  [Unused] (native name is "temp")
+    ! long_name: Sea Water Potential Temperature
+    ! units: degC
+    ! standard_name: sea_water_potential_temperature
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "thetao_xyave"  [Unused] (native name is "temp_xyave")
+    ! long_name: Sea Water Potential Temperature
+    ! units: degC
+    ! standard_name: sea_water_potential_temperature
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "temp"  [Unused] (CMOR equivalent is "thetao")
+    ! long_name: Potential Temperature
+    ! units: degC
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "temp_xyave"  [Unused] (CMOR equivalent is "thetao_xyave")
+    ! long_name: Potential Temperature
+    ! units: degC
+    ! cell_methods: z_l:mean
+"ocean_model_z_d2", "thetao"  [Unused] (native name is "temp")
+    ! long_name: Sea Water Potential Temperature
+    ! units: degC
+    ! standard_name: sea_water_potential_temperature
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "thetao_xyave"  [Unused] (native name is "temp_xyave")
+    ! long_name: Sea Water Potential Temperature
+    ! units: degC
+    ! standard_name: sea_water_potential_temperature
+    ! cell_methods: z_l:mean
 "ocean_model", "T_adx"  [Used]
     ! long_name: Advective (by residual mean) Zonal Flux of Heat
     ! units: W m-2
@@ -3336,6 +6451,22 @@
     ! units: W m-2
     ! cell_methods: xq:point yh:sum z_l:sum
 "ocean_model_z", "T_adx_xyave"  [Unused]
+    ! long_name: Advective (by residual mean) Zonal Flux of Heat
+    ! units: W m-2
+    ! cell_methods: z_l:sum
+"ocean_model_d2", "T_adx"  [Unused]
+    ! long_name: Advective (by residual mean) Zonal Flux of Heat
+    ! units: W m-2
+    ! cell_methods: xq:point yh:sum zl:sum
+"ocean_model_d2", "T_adx_xyave"  [Unused]
+    ! long_name: Advective (by residual mean) Zonal Flux of Heat
+    ! units: W m-2
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "T_adx"  [Unused]
+    ! long_name: Advective (by residual mean) Zonal Flux of Heat
+    ! units: W m-2
+    ! cell_methods: xq:point yh:sum z_l:sum
+"ocean_model_z_d2", "T_adx_xyave"  [Unused]
     ! long_name: Advective (by residual mean) Zonal Flux of Heat
     ! units: W m-2
     ! cell_methods: z_l:sum
@@ -3355,6 +6486,22 @@
     ! long_name: Advective (by residual mean) Meridional Flux of Heat
     ! units: W m-2
     ! cell_methods: z_l:sum
+"ocean_model_d2", "T_ady"  [Unused]
+    ! long_name: Advective (by residual mean) Meridional Flux of Heat
+    ! units: W m-2
+    ! cell_methods: xh:sum yq:point zl:sum
+"ocean_model_d2", "T_ady_xyave"  [Unused]
+    ! long_name: Advective (by residual mean) Meridional Flux of Heat
+    ! units: W m-2
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "T_ady"  [Unused]
+    ! long_name: Advective (by residual mean) Meridional Flux of Heat
+    ! units: W m-2
+    ! cell_methods: xh:sum yq:point z_l:sum
+"ocean_model_z_d2", "T_ady_xyave"  [Unused]
+    ! long_name: Advective (by residual mean) Meridional Flux of Heat
+    ! units: W m-2
+    ! cell_methods: z_l:sum
 "ocean_model", "T_diffx"  [Used]
     ! long_name: Diffusive Zonal Flux of Heat
     ! units: W m-2
@@ -3368,6 +6515,22 @@
     ! units: W m-2
     ! cell_methods: xq:point yh:sum z_l:sum
 "ocean_model_z", "T_diffx_xyave"  [Unused]
+    ! long_name: Diffusive Zonal Flux of Heat
+    ! units: W m-2
+    ! cell_methods: z_l:sum
+"ocean_model_d2", "T_diffx"  [Unused]
+    ! long_name: Diffusive Zonal Flux of Heat
+    ! units: W m-2
+    ! cell_methods: xq:point yh:sum zl:sum
+"ocean_model_d2", "T_diffx_xyave"  [Unused]
+    ! long_name: Diffusive Zonal Flux of Heat
+    ! units: W m-2
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "T_diffx"  [Unused]
+    ! long_name: Diffusive Zonal Flux of Heat
+    ! units: W m-2
+    ! cell_methods: xq:point yh:sum z_l:sum
+"ocean_model_z_d2", "T_diffx_xyave"  [Unused]
     ! long_name: Diffusive Zonal Flux of Heat
     ! units: W m-2
     ! cell_methods: z_l:sum
@@ -3387,7 +6550,27 @@
     ! long_name: Diffusive Meridional Flux of Heat
     ! units: W m-2
     ! cell_methods: z_l:sum
+"ocean_model_d2", "T_diffy"  [Unused]
+    ! long_name: Diffusive Meridional Flux of Heat
+    ! units: W m-2
+    ! cell_methods: xh:sum yq:point zl:sum
+"ocean_model_d2", "T_diffy_xyave"  [Unused]
+    ! long_name: Diffusive Meridional Flux of Heat
+    ! units: W m-2
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "T_diffy"  [Unused]
+    ! long_name: Diffusive Meridional Flux of Heat
+    ! units: W m-2
+    ! cell_methods: xh:sum yq:point z_l:sum
+"ocean_model_z_d2", "T_diffy_xyave"  [Unused]
+    ! long_name: Diffusive Meridional Flux of Heat
+    ! units: W m-2
+    ! cell_methods: z_l:sum
 "ocean_model", "T_adx_2d"  [Unused]
+    ! long_name: Vertically Integrated Advective Zonal Flux of Heat
+    ! units: W m-2
+    ! cell_methods: xq:point yh:sum
+"ocean_model_d2", "T_adx_2d"  [Unused]
     ! long_name: Vertically Integrated Advective Zonal Flux of Heat
     ! units: W m-2
     ! cell_methods: xq:point yh:sum
@@ -3395,11 +6578,23 @@
     ! long_name: Vertically Integrated Advective Meridional Flux of Heat
     ! units: W m-2
     ! cell_methods: xh:sum yq:point
+"ocean_model_d2", "T_ady_2d"  [Unused]
+    ! long_name: Vertically Integrated Advective Meridional Flux of Heat
+    ! units: W m-2
+    ! cell_methods: xh:sum yq:point
 "ocean_model", "T_diffx_2d"  [Unused]
     ! long_name: Vertically Integrated Diffusive Zonal Flux of Heat
     ! units: W m-2
     ! cell_methods: xq:point yh:sum
+"ocean_model_d2", "T_diffx_2d"  [Unused]
+    ! long_name: Vertically Integrated Diffusive Zonal Flux of Heat
+    ! units: W m-2
+    ! cell_methods: xq:point yh:sum
 "ocean_model", "T_diffy_2d"  [Unused]
+    ! long_name: Vertically Integrated Diffusive Meridional Flux of Heat
+    ! units: W m-2
+    ! cell_methods: xh:sum yq:point
+"ocean_model_d2", "T_diffy_2d"  [Unused]
     ! long_name: Vertically Integrated Diffusive Meridional Flux of Heat
     ! units: W m-2
     ! cell_methods: xh:sum yq:point
@@ -3419,7 +6614,27 @@
     ! long_name: Horizontal convergence of residual mean advective fluxes of heat
     ! units: W m-2
     ! cell_methods: z_l:sum
+"ocean_model_d2", "T_advection_xy"  [Unused]
+    ! long_name: Horizontal convergence of residual mean advective fluxes of heat
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "T_advection_xy_xyave"  [Unused]
+    ! long_name: Horizontal convergence of residual mean advective fluxes of heat
+    ! units: W m-2
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "T_advection_xy"  [Unused]
+    ! long_name: Horizontal convergence of residual mean advective fluxes of heat
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "T_advection_xy_xyave"  [Unused]
+    ! long_name: Horizontal convergence of residual mean advective fluxes of heat
+    ! units: W m-2
+    ! cell_methods: z_l:sum
 "ocean_model", "T_advection_xy_2d"  [Used]
+    ! long_name: Vertical sum of horizontal convergence of residual mean advective fluxes of heat
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "T_advection_xy_2d"  [Unused]
     ! long_name: Vertical sum of horizontal convergence of residual mean advective fluxes of heat
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -3436,6 +6651,22 @@
     ! units: degC s-1
     ! cell_methods: xh:mean yh:mean z_l:mean area:mean
 "ocean_model_z", "T_tendency_xyave"  [Unused]
+    ! long_name: Net time tendency for potential temperature
+    ! units: degC s-1
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "T_tendency"  [Unused]
+    ! long_name: Net time tendency for potential temperature
+    ! units: degC s-1
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "T_tendency_xyave"  [Unused]
+    ! long_name: Net time tendency for potential temperature
+    ! units: degC s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "T_tendency"  [Unused]
+    ! long_name: Net time tendency for potential temperature
+    ! units: degC s-1
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "T_tendency_xyave"  [Unused]
     ! long_name: Net time tendency for potential temperature
     ! units: degC s-1
     ! cell_methods: z_l:mean
@@ -3475,11 +6706,56 @@
     ! units: W m-2
     ! standard_name: tendency_of_sea_water_potential_temperature_expressed_as_heat_content_due_to_parameterized_mesoscale_diffusion
     ! cell_methods: z_l:sum
+"ocean_model_d2", "T_dfxy_cont_tendency"  [Unused] (CMOR equivalent is "opottemppmdiff")
+    ! long_name: Lateral or neutral diffusion tracer concentration tendency for T
+    ! units: W m-2
+    ! cell_methods: xh:sum yh:sum zl:sum area:sum
+"ocean_model_d2", "T_dfxy_cont_tendency_xyave"  [Unused] (CMOR equivalent is "opottemppmdiff_xyave")
+    ! long_name: Lateral or neutral diffusion tracer concentration tendency for T
+    ! units: W m-2
+    ! cell_methods: zl:sum
+"ocean_model_d2", "opottemppmdiff"  [Unused] (native name is "T_dfxy_cont_tendency")
+    ! long_name: Tendency of sea water potential temperature expressed as heat content due to parameterized mesoscale diffusion
+    ! units: W m-2
+    ! standard_name: tendency_of_sea_water_potential_temperature_expressed_as_heat_content_due_to_parameterized_mesoscale_diffusion
+    ! cell_methods: xh:sum yh:sum zl:sum area:sum
+"ocean_model_d2", "opottemppmdiff_xyave"  [Unused] (native name is "T_dfxy_cont_tendency_xyave")
+    ! long_name: Tendency of sea water potential temperature expressed as heat content due to parameterized mesoscale diffusion
+    ! units: W m-2
+    ! standard_name: tendency_of_sea_water_potential_temperature_expressed_as_heat_content_due_to_parameterized_mesoscale_diffusion
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "T_dfxy_cont_tendency"  [Unused] (CMOR equivalent is "opottemppmdiff")
+    ! long_name: Lateral or neutral diffusion tracer concentration tendency for T
+    ! units: W m-2
+    ! cell_methods: xh:sum yh:sum z_l:sum area:sum
+"ocean_model_z_d2", "T_dfxy_cont_tendency_xyave"  [Unused] (CMOR equivalent is "opottemppmdiff_xyave")
+    ! long_name: Lateral or neutral diffusion tracer concentration tendency for T
+    ! units: W m-2
+    ! cell_methods: z_l:sum
+"ocean_model_z_d2", "opottemppmdiff"  [Unused] (native name is "T_dfxy_cont_tendency")
+    ! long_name: Tendency of sea water potential temperature expressed as heat content due to parameterized mesoscale diffusion
+    ! units: W m-2
+    ! standard_name: tendency_of_sea_water_potential_temperature_expressed_as_heat_content_due_to_parameterized_mesoscale_diffusion
+    ! cell_methods: xh:sum yh:sum z_l:sum area:sum
+"ocean_model_z_d2", "opottemppmdiff_xyave"  [Unused] (native name is "T_dfxy_cont_tendency_xyave")
+    ! long_name: Tendency of sea water potential temperature expressed as heat content due to parameterized mesoscale diffusion
+    ! units: W m-2
+    ! standard_name: tendency_of_sea_water_potential_temperature_expressed_as_heat_content_due_to_parameterized_mesoscale_diffusion
+    ! cell_methods: z_l:sum
 "ocean_model", "T_dfxy_cont_tendency_2d"  [Unused] (CMOR equivalent is "opottemppmdiff_2d")
     ! long_name: Depth integrated lateral or neutral diffusion tracer concentration tendency for T
     ! units: W m-2
     ! cell_methods: xh:sum yh:sum area:sum
 "ocean_model", "opottemppmdiff_2d"  [Unused] (native name is "T_dfxy_cont_tendency_2d")
+    ! long_name: Tendency of sea water potential temperature expressed as heat content due to parameterized mesoscale diffusion
+    ! units: W m-2
+    ! standard_name: tendency_of_sea_water_potential_temperature_expressed_as_heat_content_due_to_parameterized_mesoscale_diffusion
+    ! cell_methods: xh:sum yh:sum area:sum
+"ocean_model_d2", "T_dfxy_cont_tendency_2d"  [Unused] (CMOR equivalent is "opottemppmdiff_2d")
+    ! long_name: Depth integrated lateral or neutral diffusion tracer concentration tendency for T
+    ! units: W m-2
+    ! cell_methods: xh:sum yh:sum area:sum
+"ocean_model_d2", "opottemppmdiff_2d"  [Unused] (native name is "T_dfxy_cont_tendency_2d")
     ! long_name: Tendency of sea water potential temperature expressed as heat content due to parameterized mesoscale diffusion
     ! units: W m-2
     ! standard_name: tendency_of_sea_water_potential_temperature_expressed_as_heat_content_due_to_parameterized_mesoscale_diffusion
@@ -3497,6 +6773,22 @@
     ! units: degC s-1
     ! cell_methods: xh:mean yh:mean z_l:mean area:mean
 "ocean_model_z", "T_dfxy_conc_tendency_xyave"  [Unused]
+    ! long_name: Lateral (neutral) tracer concentration tendency for T
+    ! units: degC s-1
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "T_dfxy_conc_tendency"  [Unused]
+    ! long_name: Lateral (neutral) tracer concentration tendency for T
+    ! units: degC s-1
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "T_dfxy_conc_tendency_xyave"  [Unused]
+    ! long_name: Lateral (neutral) tracer concentration tendency for T
+    ! units: degC s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "T_dfxy_conc_tendency"  [Unused]
+    ! long_name: Lateral (neutral) tracer concentration tendency for T
+    ! units: degC s-1
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "T_dfxy_conc_tendency_xyave"  [Unused]
     ! long_name: Lateral (neutral) tracer concentration tendency for T
     ! units: degC s-1
     ! cell_methods: z_l:mean
@@ -3536,11 +6828,56 @@
     ! units: W m-2
     ! standard_name: tendency_of_sea_water_potential_temperature_expressed_as_heat_content
     ! cell_methods: z_l:sum
+"ocean_model_d2", "Th_tendency"  [Unused] (CMOR equivalent is "opottemptend")
+    ! long_name: Net time tendency for heat
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "Th_tendency_xyave"  [Unused] (CMOR equivalent is "opottemptend_xyave")
+    ! long_name: Net time tendency for heat
+    ! units: W m-2
+    ! cell_methods: zl:sum
+"ocean_model_d2", "opottemptend"  [Unused] (native name is "Th_tendency")
+    ! long_name: Tendency of Sea Water Potential Temperature Expressed as Heat Content
+    ! units: W m-2
+    ! standard_name: tendency_of_sea_water_potential_temperature_expressed_as_heat_content
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "opottemptend_xyave"  [Unused] (native name is "Th_tendency_xyave")
+    ! long_name: Tendency of Sea Water Potential Temperature Expressed as Heat Content
+    ! units: W m-2
+    ! standard_name: tendency_of_sea_water_potential_temperature_expressed_as_heat_content
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "Th_tendency"  [Unused] (CMOR equivalent is "opottemptend")
+    ! long_name: Net time tendency for heat
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "Th_tendency_xyave"  [Unused] (CMOR equivalent is "opottemptend_xyave")
+    ! long_name: Net time tendency for heat
+    ! units: W m-2
+    ! cell_methods: z_l:sum
+"ocean_model_z_d2", "opottemptend"  [Unused] (native name is "Th_tendency")
+    ! long_name: Tendency of Sea Water Potential Temperature Expressed as Heat Content
+    ! units: W m-2
+    ! standard_name: tendency_of_sea_water_potential_temperature_expressed_as_heat_content
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "opottemptend_xyave"  [Unused] (native name is "Th_tendency_xyave")
+    ! long_name: Tendency of Sea Water Potential Temperature Expressed as Heat Content
+    ! units: W m-2
+    ! standard_name: tendency_of_sea_water_potential_temperature_expressed_as_heat_content
+    ! cell_methods: z_l:sum
 "ocean_model", "Th_tendency_2d"  [Unused] (CMOR equivalent is "opottemptend_2d")
     ! long_name: Vertical sum of net time tendency for heat
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "opottemptend_2d"  [Used] (native name is "Th_tendency_2d")
+    ! long_name: Tendency of Sea Water Potential Temperature Expressed as Heat Content Vertical Sum
+    ! units: W m-2
+    ! standard_name: tendency_of_sea_water_potential_temperature_expressed_as_heat_content_vertical_sum
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "Th_tendency_2d"  [Unused] (CMOR equivalent is "opottemptend_2d")
+    ! long_name: Vertical sum of net time tendency for heat
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "opottemptend_2d"  [Unused] (native name is "Th_tendency_2d")
     ! long_name: Tendency of Sea Water Potential Temperature Expressed as Heat Content Vertical Sum
     ! units: W m-2
     ! standard_name: tendency_of_sea_water_potential_temperature_expressed_as_heat_content_vertical_sum
@@ -3553,11 +6890,19 @@
     ! long_name: Potential Temperature
     ! units: degC
     ! standard_name: not provided
+"ocean_model_zold_d2", "temp_xyave"  [Unused]
+    ! long_name: Potential Temperature
+    ! units: degC
+    ! standard_name: not provided
 "ocean_model_zold", "thetao"  [Unused]
     ! long_name: Sea Water Potential Temperature
     ! units: degC
     ! standard_name: sea_water_potential_temperature
 "ocean_model_zold", "thetao_xyave"  [Unused]
+    ! long_name: Sea Water Potential Temperature
+    ! units: degC
+    ! standard_name: sea_water_potential_temperature
+"ocean_model_zold_d2", "thetao_xyave"  [Unused]
     ! long_name: Sea Water Potential Temperature
     ! units: degC
     ! standard_name: sea_water_potential_temperature
@@ -3597,6 +6942,42 @@
     ! units: psu
     ! standard_name: sea_water_salinity
     ! cell_methods: z_l:mean
+"ocean_model_d2", "salt"  [Unused] (CMOR equivalent is "so")
+    ! long_name: Salinity
+    ! units: psu
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "salt_xyave"  [Unused] (CMOR equivalent is "so_xyave")
+    ! long_name: Salinity
+    ! units: psu
+    ! cell_methods: zl:mean
+"ocean_model_d2", "so"  [Unused] (native name is "salt")
+    ! long_name: Sea Water Salinity
+    ! units: psu
+    ! standard_name: sea_water_salinity
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "so_xyave"  [Unused] (native name is "salt_xyave")
+    ! long_name: Sea Water Salinity
+    ! units: psu
+    ! standard_name: sea_water_salinity
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "salt"  [Unused] (CMOR equivalent is "so")
+    ! long_name: Salinity
+    ! units: psu
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "salt_xyave"  [Unused] (CMOR equivalent is "so_xyave")
+    ! long_name: Salinity
+    ! units: psu
+    ! cell_methods: z_l:mean
+"ocean_model_z_d2", "so"  [Unused] (native name is "salt")
+    ! long_name: Sea Water Salinity
+    ! units: psu
+    ! standard_name: sea_water_salinity
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "so_xyave"  [Unused] (native name is "salt_xyave")
+    ! long_name: Sea Water Salinity
+    ! units: psu
+    ! standard_name: sea_water_salinity
+    ! cell_methods: z_l:mean
 "ocean_model", "S_adx"  [Used]
     ! long_name: Advective (by residual mean) Zonal Flux of Salt
     ! units: psu m3 s-1
@@ -3610,6 +6991,22 @@
     ! units: psu m3 s-1
     ! cell_methods: xq:point yh:sum z_l:sum
 "ocean_model_z", "S_adx_xyave"  [Unused]
+    ! long_name: Advective (by residual mean) Zonal Flux of Salt
+    ! units: psu m3 s-1
+    ! cell_methods: z_l:sum
+"ocean_model_d2", "S_adx"  [Unused]
+    ! long_name: Advective (by residual mean) Zonal Flux of Salt
+    ! units: psu m3 s-1
+    ! cell_methods: xq:point yh:sum zl:sum
+"ocean_model_d2", "S_adx_xyave"  [Unused]
+    ! long_name: Advective (by residual mean) Zonal Flux of Salt
+    ! units: psu m3 s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "S_adx"  [Unused]
+    ! long_name: Advective (by residual mean) Zonal Flux of Salt
+    ! units: psu m3 s-1
+    ! cell_methods: xq:point yh:sum z_l:sum
+"ocean_model_z_d2", "S_adx_xyave"  [Unused]
     ! long_name: Advective (by residual mean) Zonal Flux of Salt
     ! units: psu m3 s-1
     ! cell_methods: z_l:sum
@@ -3629,6 +7026,22 @@
     ! long_name: Advective (by residual mean) Meridional Flux of Salt
     ! units: psu m3 s-1
     ! cell_methods: z_l:sum
+"ocean_model_d2", "S_ady"  [Unused]
+    ! long_name: Advective (by residual mean) Meridional Flux of Salt
+    ! units: psu m3 s-1
+    ! cell_methods: xh:sum yq:point zl:sum
+"ocean_model_d2", "S_ady_xyave"  [Unused]
+    ! long_name: Advective (by residual mean) Meridional Flux of Salt
+    ! units: psu m3 s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "S_ady"  [Unused]
+    ! long_name: Advective (by residual mean) Meridional Flux of Salt
+    ! units: psu m3 s-1
+    ! cell_methods: xh:sum yq:point z_l:sum
+"ocean_model_z_d2", "S_ady_xyave"  [Unused]
+    ! long_name: Advective (by residual mean) Meridional Flux of Salt
+    ! units: psu m3 s-1
+    ! cell_methods: z_l:sum
 "ocean_model", "S_diffx"  [Used]
     ! long_name: Diffusive Zonal Flux of Salt
     ! units: psu m3 s-1
@@ -3642,6 +7055,22 @@
     ! units: psu m3 s-1
     ! cell_methods: xq:point yh:sum z_l:sum
 "ocean_model_z", "S_diffx_xyave"  [Unused]
+    ! long_name: Diffusive Zonal Flux of Salt
+    ! units: psu m3 s-1
+    ! cell_methods: z_l:sum
+"ocean_model_d2", "S_diffx"  [Unused]
+    ! long_name: Diffusive Zonal Flux of Salt
+    ! units: psu m3 s-1
+    ! cell_methods: xq:point yh:sum zl:sum
+"ocean_model_d2", "S_diffx_xyave"  [Unused]
+    ! long_name: Diffusive Zonal Flux of Salt
+    ! units: psu m3 s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "S_diffx"  [Unused]
+    ! long_name: Diffusive Zonal Flux of Salt
+    ! units: psu m3 s-1
+    ! cell_methods: xq:point yh:sum z_l:sum
+"ocean_model_z_d2", "S_diffx_xyave"  [Unused]
     ! long_name: Diffusive Zonal Flux of Salt
     ! units: psu m3 s-1
     ! cell_methods: z_l:sum
@@ -3661,7 +7090,27 @@
     ! long_name: Diffusive Meridional Flux of Salt
     ! units: psu m3 s-1
     ! cell_methods: z_l:sum
+"ocean_model_d2", "S_diffy"  [Unused]
+    ! long_name: Diffusive Meridional Flux of Salt
+    ! units: psu m3 s-1
+    ! cell_methods: xh:sum yq:point zl:sum
+"ocean_model_d2", "S_diffy_xyave"  [Unused]
+    ! long_name: Diffusive Meridional Flux of Salt
+    ! units: psu m3 s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "S_diffy"  [Unused]
+    ! long_name: Diffusive Meridional Flux of Salt
+    ! units: psu m3 s-1
+    ! cell_methods: xh:sum yq:point z_l:sum
+"ocean_model_z_d2", "S_diffy_xyave"  [Unused]
+    ! long_name: Diffusive Meridional Flux of Salt
+    ! units: psu m3 s-1
+    ! cell_methods: z_l:sum
 "ocean_model", "S_adx_2d"  [Unused]
+    ! long_name: Vertically Integrated Advective Zonal Flux of Salt
+    ! units: psu m3 s-1
+    ! cell_methods: xq:point yh:sum
+"ocean_model_d2", "S_adx_2d"  [Unused]
     ! long_name: Vertically Integrated Advective Zonal Flux of Salt
     ! units: psu m3 s-1
     ! cell_methods: xq:point yh:sum
@@ -3669,11 +7118,23 @@
     ! long_name: Vertically Integrated Advective Meridional Flux of Salt
     ! units: psu m3 s-1
     ! cell_methods: xh:sum yq:point
+"ocean_model_d2", "S_ady_2d"  [Unused]
+    ! long_name: Vertically Integrated Advective Meridional Flux of Salt
+    ! units: psu m3 s-1
+    ! cell_methods: xh:sum yq:point
 "ocean_model", "S_diffx_2d"  [Unused]
     ! long_name: Vertically Integrated Diffusive Zonal Flux of Salt
     ! units: psu m3 s-1
     ! cell_methods: xq:point yh:sum
+"ocean_model_d2", "S_diffx_2d"  [Unused]
+    ! long_name: Vertically Integrated Diffusive Zonal Flux of Salt
+    ! units: psu m3 s-1
+    ! cell_methods: xq:point yh:sum
 "ocean_model", "S_diffy_2d"  [Unused]
+    ! long_name: Vertically Integrated Diffusive Meridional Flux of Salt
+    ! units: psu m3 s-1
+    ! cell_methods: xh:sum yq:point
+"ocean_model_d2", "S_diffy_2d"  [Unused]
     ! long_name: Vertically Integrated Diffusive Meridional Flux of Salt
     ! units: psu m3 s-1
     ! cell_methods: xh:sum yq:point
@@ -3693,7 +7154,27 @@
     ! long_name: Horizontal convergence of residual mean advective fluxes of salt
     ! units: kg m-2 s-1
     ! cell_methods: z_l:sum
+"ocean_model_d2", "S_advection_xy"  [Unused]
+    ! long_name: Horizontal convergence of residual mean advective fluxes of salt
+    ! units: kg m-2 s-1
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "S_advection_xy_xyave"  [Unused]
+    ! long_name: Horizontal convergence of residual mean advective fluxes of salt
+    ! units: kg m-2 s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "S_advection_xy"  [Unused]
+    ! long_name: Horizontal convergence of residual mean advective fluxes of salt
+    ! units: kg m-2 s-1
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "S_advection_xy_xyave"  [Unused]
+    ! long_name: Horizontal convergence of residual mean advective fluxes of salt
+    ! units: kg m-2 s-1
+    ! cell_methods: z_l:sum
 "ocean_model", "S_advection_xy_2d"  [Used]
+    ! long_name: Vertical sum of horizontal convergence of residual mean advective fluxes of salt
+    ! units: kg m-2 s-1
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "S_advection_xy_2d"  [Unused]
     ! long_name: Vertical sum of horizontal convergence of residual mean advective fluxes of salt
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
@@ -3710,6 +7191,22 @@
     ! units: psu s-1
     ! cell_methods: xh:mean yh:mean z_l:mean area:mean
 "ocean_model_z", "S_tendency_xyave"  [Unused]
+    ! long_name: Net time tendency for salinity
+    ! units: psu s-1
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "S_tendency"  [Unused]
+    ! long_name: Net time tendency for salinity
+    ! units: psu s-1
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "S_tendency_xyave"  [Unused]
+    ! long_name: Net time tendency for salinity
+    ! units: psu s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "S_tendency"  [Unused]
+    ! long_name: Net time tendency for salinity
+    ! units: psu s-1
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "S_tendency_xyave"  [Unused]
     ! long_name: Net time tendency for salinity
     ! units: psu s-1
     ! cell_methods: z_l:mean
@@ -3749,11 +7246,56 @@
     ! units: kg m-2 s-1
     ! standard_name: tendency_of_sea_water_salinity_expressed_as_salt_content_due_to_parameterized_mesoscale_diffusion
     ! cell_methods: z_l:sum
+"ocean_model_d2", "S_dfxy_cont_tendency"  [Unused] (CMOR equivalent is "osaltpmdiff")
+    ! long_name: Lateral or neutral diffusion tracer concentration tendency for S
+    ! units: kg m-2 s-1
+    ! cell_methods: xh:sum yh:sum zl:sum area:sum
+"ocean_model_d2", "S_dfxy_cont_tendency_xyave"  [Unused] (CMOR equivalent is "osaltpmdiff_xyave")
+    ! long_name: Lateral or neutral diffusion tracer concentration tendency for S
+    ! units: kg m-2 s-1
+    ! cell_methods: zl:sum
+"ocean_model_d2", "osaltpmdiff"  [Unused] (native name is "S_dfxy_cont_tendency")
+    ! long_name: Tendency of sea water salinity expressed as salt content due to parameterized mesoscale diffusion
+    ! units: kg m-2 s-1
+    ! standard_name: tendency_of_sea_water_salinity_expressed_as_salt_content_due_to_parameterized_mesoscale_diffusion
+    ! cell_methods: xh:sum yh:sum zl:sum area:sum
+"ocean_model_d2", "osaltpmdiff_xyave"  [Unused] (native name is "S_dfxy_cont_tendency_xyave")
+    ! long_name: Tendency of sea water salinity expressed as salt content due to parameterized mesoscale diffusion
+    ! units: kg m-2 s-1
+    ! standard_name: tendency_of_sea_water_salinity_expressed_as_salt_content_due_to_parameterized_mesoscale_diffusion
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "S_dfxy_cont_tendency"  [Unused] (CMOR equivalent is "osaltpmdiff")
+    ! long_name: Lateral or neutral diffusion tracer concentration tendency for S
+    ! units: kg m-2 s-1
+    ! cell_methods: xh:sum yh:sum z_l:sum area:sum
+"ocean_model_z_d2", "S_dfxy_cont_tendency_xyave"  [Unused] (CMOR equivalent is "osaltpmdiff_xyave")
+    ! long_name: Lateral or neutral diffusion tracer concentration tendency for S
+    ! units: kg m-2 s-1
+    ! cell_methods: z_l:sum
+"ocean_model_z_d2", "osaltpmdiff"  [Unused] (native name is "S_dfxy_cont_tendency")
+    ! long_name: Tendency of sea water salinity expressed as salt content due to parameterized mesoscale diffusion
+    ! units: kg m-2 s-1
+    ! standard_name: tendency_of_sea_water_salinity_expressed_as_salt_content_due_to_parameterized_mesoscale_diffusion
+    ! cell_methods: xh:sum yh:sum z_l:sum area:sum
+"ocean_model_z_d2", "osaltpmdiff_xyave"  [Unused] (native name is "S_dfxy_cont_tendency_xyave")
+    ! long_name: Tendency of sea water salinity expressed as salt content due to parameterized mesoscale diffusion
+    ! units: kg m-2 s-1
+    ! standard_name: tendency_of_sea_water_salinity_expressed_as_salt_content_due_to_parameterized_mesoscale_diffusion
+    ! cell_methods: z_l:sum
 "ocean_model", "S_dfxy_cont_tendency_2d"  [Unused] (CMOR equivalent is "osaltpmdiff_2d")
     ! long_name: Depth integrated lateral or neutral diffusion tracer concentration tendency for S
     ! units: kg m-2 s-1
     ! cell_methods: xh:sum yh:sum area:sum
 "ocean_model", "osaltpmdiff_2d"  [Unused] (native name is "S_dfxy_cont_tendency_2d")
+    ! long_name: Tendency of sea water salinity expressed as salt content due to parameterized mesoscale diffusion
+    ! units: kg m-2 s-1
+    ! standard_name: tendency_of_sea_water_salinity_expressed_as_salt_content_due_to_parameterized_mesoscale_diffusion
+    ! cell_methods: xh:sum yh:sum area:sum
+"ocean_model_d2", "S_dfxy_cont_tendency_2d"  [Unused] (CMOR equivalent is "osaltpmdiff_2d")
+    ! long_name: Depth integrated lateral or neutral diffusion tracer concentration tendency for S
+    ! units: kg m-2 s-1
+    ! cell_methods: xh:sum yh:sum area:sum
+"ocean_model_d2", "osaltpmdiff_2d"  [Unused] (native name is "S_dfxy_cont_tendency_2d")
     ! long_name: Tendency of sea water salinity expressed as salt content due to parameterized mesoscale diffusion
     ! units: kg m-2 s-1
     ! standard_name: tendency_of_sea_water_salinity_expressed_as_salt_content_due_to_parameterized_mesoscale_diffusion
@@ -3771,6 +7313,22 @@
     ! units: psu s-1
     ! cell_methods: xh:mean yh:mean z_l:mean area:mean
 "ocean_model_z", "S_dfxy_conc_tendency_xyave"  [Unused]
+    ! long_name: Lateral (neutral) tracer concentration tendency for S
+    ! units: psu s-1
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "S_dfxy_conc_tendency"  [Unused]
+    ! long_name: Lateral (neutral) tracer concentration tendency for S
+    ! units: psu s-1
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "S_dfxy_conc_tendency_xyave"  [Unused]
+    ! long_name: Lateral (neutral) tracer concentration tendency for S
+    ! units: psu s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "S_dfxy_conc_tendency"  [Unused]
+    ! long_name: Lateral (neutral) tracer concentration tendency for S
+    ! units: psu s-1
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "S_dfxy_conc_tendency_xyave"  [Unused]
     ! long_name: Lateral (neutral) tracer concentration tendency for S
     ! units: psu s-1
     ! cell_methods: z_l:mean
@@ -3810,11 +7368,56 @@
     ! units: kg m-2 s-1
     ! standard_name: tendency_of_sea_water_salinity_expressed_as_salt_content
     ! cell_methods: z_l:sum
+"ocean_model_d2", "Sh_tendency"  [Unused] (CMOR equivalent is "osalttend")
+    ! long_name: Net time tendency for salt
+    ! units: kg m-2 s-1
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "Sh_tendency_xyave"  [Unused] (CMOR equivalent is "osalttend_xyave")
+    ! long_name: Net time tendency for salt
+    ! units: kg m-2 s-1
+    ! cell_methods: zl:sum
+"ocean_model_d2", "osalttend"  [Unused] (native name is "Sh_tendency")
+    ! long_name: Tendency of Sea Water Salinity Expressed as Salt Content
+    ! units: kg m-2 s-1
+    ! standard_name: tendency_of_sea_water_salinity_expressed_as_salt_content
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "osalttend_xyave"  [Unused] (native name is "Sh_tendency_xyave")
+    ! long_name: Tendency of Sea Water Salinity Expressed as Salt Content
+    ! units: kg m-2 s-1
+    ! standard_name: tendency_of_sea_water_salinity_expressed_as_salt_content
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "Sh_tendency"  [Unused] (CMOR equivalent is "osalttend")
+    ! long_name: Net time tendency for salt
+    ! units: kg m-2 s-1
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "Sh_tendency_xyave"  [Unused] (CMOR equivalent is "osalttend_xyave")
+    ! long_name: Net time tendency for salt
+    ! units: kg m-2 s-1
+    ! cell_methods: z_l:sum
+"ocean_model_z_d2", "osalttend"  [Unused] (native name is "Sh_tendency")
+    ! long_name: Tendency of Sea Water Salinity Expressed as Salt Content
+    ! units: kg m-2 s-1
+    ! standard_name: tendency_of_sea_water_salinity_expressed_as_salt_content
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "osalttend_xyave"  [Unused] (native name is "Sh_tendency_xyave")
+    ! long_name: Tendency of Sea Water Salinity Expressed as Salt Content
+    ! units: kg m-2 s-1
+    ! standard_name: tendency_of_sea_water_salinity_expressed_as_salt_content
+    ! cell_methods: z_l:sum
 "ocean_model", "Sh_tendency_2d"  [Unused] (CMOR equivalent is "osalttend_2d")
     ! long_name: Vertical sum of net time tendency for salt
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "osalttend_2d"  [Used] (native name is "Sh_tendency_2d")
+    ! long_name: Tendency of Sea Water Salinity Expressed as Salt Content Vertical Sum
+    ! units: kg m-2 s-1
+    ! standard_name: tendency_of_sea_water_salinity_expressed_as_salt_content_vertical_sum
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "Sh_tendency_2d"  [Unused] (CMOR equivalent is "osalttend_2d")
+    ! long_name: Vertical sum of net time tendency for salt
+    ! units: kg m-2 s-1
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "osalttend_2d"  [Unused] (native name is "Sh_tendency_2d")
     ! long_name: Tendency of Sea Water Salinity Expressed as Salt Content Vertical Sum
     ! units: kg m-2 s-1
     ! standard_name: tendency_of_sea_water_salinity_expressed_as_salt_content_vertical_sum
@@ -3827,11 +7430,19 @@
     ! long_name: Salinity
     ! units: psu
     ! standard_name: not provided
+"ocean_model_zold_d2", "salt_xyave"  [Unused]
+    ! long_name: Salinity
+    ! units: psu
+    ! standard_name: not provided
 "ocean_model_zold", "so"  [Unused]
     ! long_name: Sea Water Salinity
     ! units: psu
     ! standard_name: sea_water_salinity
 "ocean_model_zold", "so_xyave"  [Unused]
+    ! long_name: Sea Water Salinity
+    ! units: psu
+    ! standard_name: sea_water_salinity
+"ocean_model_zold_d2", "so_xyave"  [Unused]
     ! long_name: Sea Water Salinity
     ! units: psu
     ! standard_name: sea_water_salinity
@@ -3871,6 +7482,42 @@
     ! units: yr
     ! standard_name: ideal_age_tracer
     ! cell_methods: z_l:mean
+"ocean_model_d2", "age"  [Unused] (CMOR equivalent is "agessc")
+    ! long_name: Ideal Age Tracer
+    ! units: yr
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "age_xyave"  [Unused] (CMOR equivalent is "agessc_xyave")
+    ! long_name: Ideal Age Tracer
+    ! units: yr
+    ! cell_methods: zl:mean
+"ocean_model_d2", "agessc"  [Unused] (native name is "age")
+    ! long_name: Ideal Age Tracer
+    ! units: yr
+    ! standard_name: ideal_age_tracer
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "agessc_xyave"  [Unused] (native name is "age_xyave")
+    ! long_name: Ideal Age Tracer
+    ! units: yr
+    ! standard_name: ideal_age_tracer
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "age"  [Unused] (CMOR equivalent is "agessc")
+    ! long_name: Ideal Age Tracer
+    ! units: yr
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "age_xyave"  [Unused] (CMOR equivalent is "agessc_xyave")
+    ! long_name: Ideal Age Tracer
+    ! units: yr
+    ! cell_methods: z_l:mean
+"ocean_model_z_d2", "agessc"  [Unused] (native name is "age")
+    ! long_name: Ideal Age Tracer
+    ! units: yr
+    ! standard_name: ideal_age_tracer
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "agessc_xyave"  [Unused] (native name is "age_xyave")
+    ! long_name: Ideal Age Tracer
+    ! units: yr
+    ! standard_name: ideal_age_tracer
+    ! cell_methods: z_l:mean
 "ocean_model", "age_adx"  [Unused]
     ! long_name: Ideal Age Tracer advective zonal flux
     ! units: yr m3 s-1
@@ -3884,6 +7531,22 @@
     ! units: yr m3 s-1
     ! cell_methods: xq:point yh:sum z_l:sum
 "ocean_model_z", "age_adx_xyave"  [Unused]
+    ! long_name: Ideal Age Tracer advective zonal flux
+    ! units: yr m3 s-1
+    ! cell_methods: z_l:sum
+"ocean_model_d2", "age_adx"  [Unused]
+    ! long_name: Ideal Age Tracer advective zonal flux
+    ! units: yr m3 s-1
+    ! cell_methods: xq:point yh:sum zl:sum
+"ocean_model_d2", "age_adx_xyave"  [Unused]
+    ! long_name: Ideal Age Tracer advective zonal flux
+    ! units: yr m3 s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "age_adx"  [Unused]
+    ! long_name: Ideal Age Tracer advective zonal flux
+    ! units: yr m3 s-1
+    ! cell_methods: xq:point yh:sum z_l:sum
+"ocean_model_z_d2", "age_adx_xyave"  [Unused]
     ! long_name: Ideal Age Tracer advective zonal flux
     ! units: yr m3 s-1
     ! cell_methods: z_l:sum
@@ -3903,6 +7566,22 @@
     ! long_name: Ideal Age Tracer advective meridional flux
     ! units: yr m3 s-1
     ! cell_methods: z_l:sum
+"ocean_model_d2", "age_ady"  [Unused]
+    ! long_name: Ideal Age Tracer advective meridional flux
+    ! units: yr m3 s-1
+    ! cell_methods: xh:sum yq:point zl:sum
+"ocean_model_d2", "age_ady_xyave"  [Unused]
+    ! long_name: Ideal Age Tracer advective meridional flux
+    ! units: yr m3 s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "age_ady"  [Unused]
+    ! long_name: Ideal Age Tracer advective meridional flux
+    ! units: yr m3 s-1
+    ! cell_methods: xh:sum yq:point z_l:sum
+"ocean_model_z_d2", "age_ady_xyave"  [Unused]
+    ! long_name: Ideal Age Tracer advective meridional flux
+    ! units: yr m3 s-1
+    ! cell_methods: z_l:sum
 "ocean_model", "age_dfx"  [Unused]
     ! long_name: Ideal Age Tracer diffusive zonal flux
     ! units: yr m3 s-1
@@ -3916,6 +7595,22 @@
     ! units: yr m3 s-1
     ! cell_methods: xq:point yh:sum z_l:sum
 "ocean_model_z", "age_dfx_xyave"  [Unused]
+    ! long_name: Ideal Age Tracer diffusive zonal flux
+    ! units: yr m3 s-1
+    ! cell_methods: z_l:sum
+"ocean_model_d2", "age_dfx"  [Unused]
+    ! long_name: Ideal Age Tracer diffusive zonal flux
+    ! units: yr m3 s-1
+    ! cell_methods: xq:point yh:sum zl:sum
+"ocean_model_d2", "age_dfx_xyave"  [Unused]
+    ! long_name: Ideal Age Tracer diffusive zonal flux
+    ! units: yr m3 s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "age_dfx"  [Unused]
+    ! long_name: Ideal Age Tracer diffusive zonal flux
+    ! units: yr m3 s-1
+    ! cell_methods: xq:point yh:sum z_l:sum
+"ocean_model_z_d2", "age_dfx_xyave"  [Unused]
     ! long_name: Ideal Age Tracer diffusive zonal flux
     ! units: yr m3 s-1
     ! cell_methods: z_l:sum
@@ -3935,7 +7630,27 @@
     ! long_name: Ideal Age Tracer diffusive zonal flux
     ! units: yr m3 s-1
     ! cell_methods: z_l:sum
+"ocean_model_d2", "age_dfy"  [Unused]
+    ! long_name: Ideal Age Tracer diffusive zonal flux
+    ! units: yr m3 s-1
+    ! cell_methods: xh:sum yq:point zl:sum
+"ocean_model_d2", "age_dfy_xyave"  [Unused]
+    ! long_name: Ideal Age Tracer diffusive zonal flux
+    ! units: yr m3 s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "age_dfy"  [Unused]
+    ! long_name: Ideal Age Tracer diffusive zonal flux
+    ! units: yr m3 s-1
+    ! cell_methods: xh:sum yq:point z_l:sum
+"ocean_model_z_d2", "age_dfy_xyave"  [Unused]
+    ! long_name: Ideal Age Tracer diffusive zonal flux
+    ! units: yr m3 s-1
+    ! cell_methods: z_l:sum
 "ocean_model", "age_adx_2d"  [Unused]
+    ! long_name: Vertically Integrated Advective Zonal Flux of Ideal Age Tracer
+    ! units: yr m3 s-1
+    ! cell_methods: xq:point yh:sum
+"ocean_model_d2", "age_adx_2d"  [Unused]
     ! long_name: Vertically Integrated Advective Zonal Flux of Ideal Age Tracer
     ! units: yr m3 s-1
     ! cell_methods: xq:point yh:sum
@@ -3943,11 +7658,23 @@
     ! long_name: Vertically Integrated Advective Meridional Flux of Ideal Age Tracer
     ! units: yr m3 s-1
     ! cell_methods: xh:sum yq:point
+"ocean_model_d2", "age_ady_2d"  [Unused]
+    ! long_name: Vertically Integrated Advective Meridional Flux of Ideal Age Tracer
+    ! units: yr m3 s-1
+    ! cell_methods: xh:sum yq:point
 "ocean_model", "age_diffx_2d"  [Unused]
     ! long_name: Vertically Integrated Diffusive Zonal Flux of Ideal Age Tracer
     ! units: yr m3 s-1
     ! cell_methods: xq:point yh:sum
+"ocean_model_d2", "age_diffx_2d"  [Unused]
+    ! long_name: Vertically Integrated Diffusive Zonal Flux of Ideal Age Tracer
+    ! units: yr m3 s-1
+    ! cell_methods: xq:point yh:sum
 "ocean_model", "age_diffy_2d"  [Unused]
+    ! long_name: Vertically Integrated Diffusive Meridional Flux of Ideal Age Tracer
+    ! units: yr m3 s-1
+    ! cell_methods: xh:sum yq:point
+"ocean_model_d2", "age_diffy_2d"  [Unused]
     ! long_name: Vertically Integrated Diffusive Meridional Flux of Ideal Age Tracer
     ! units: yr m3 s-1
     ! cell_methods: xh:sum yq:point
@@ -3967,7 +7694,27 @@
     ! long_name: Horizontal convergence of residual mean advective fluxes of ideal age tracer
     ! units: yr m s-1
     ! cell_methods: z_l:sum
+"ocean_model_d2", "age_advection_xy"  [Unused]
+    ! long_name: Horizontal convergence of residual mean advective fluxes of ideal age tracer
+    ! units: yr m s-1
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "age_advection_xy_xyave"  [Unused]
+    ! long_name: Horizontal convergence of residual mean advective fluxes of ideal age tracer
+    ! units: yr m s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "age_advection_xy"  [Unused]
+    ! long_name: Horizontal convergence of residual mean advective fluxes of ideal age tracer
+    ! units: yr m s-1
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "age_advection_xy_xyave"  [Unused]
+    ! long_name: Horizontal convergence of residual mean advective fluxes of ideal age tracer
+    ! units: yr m s-1
+    ! cell_methods: z_l:sum
 "ocean_model", "age_advection_xy_2d"  [Unused]
+    ! long_name: Vertical sum of horizontal convergence of residual mean advective fluxes of ideal age tracer
+    ! units: yr m s-1
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "age_advection_xy_2d"  [Unused]
     ! long_name: Vertical sum of horizontal convergence of residual mean advective fluxes of ideal age tracer
     ! units: yr m s-1
     ! cell_methods: xh:mean yh:mean area:mean
@@ -3987,6 +7734,22 @@
     ! long_name: Net time tendency for ideal age tracer
     ! units: yr s-1
     ! cell_methods: z_l:mean
+"ocean_model_d2", "age_tendency"  [Unused]
+    ! long_name: Net time tendency for ideal age tracer
+    ! units: yr s-1
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "age_tendency_xyave"  [Unused]
+    ! long_name: Net time tendency for ideal age tracer
+    ! units: yr s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "age_tendency"  [Unused]
+    ! long_name: Net time tendency for ideal age tracer
+    ! units: yr s-1
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "age_tendency_xyave"  [Unused]
+    ! long_name: Net time tendency for ideal age tracer
+    ! units: yr s-1
+    ! cell_methods: z_l:mean
 "ocean_model", "age_dfxy_cont_tendency"  [Unused]
     ! long_name: Lateral or neutral diffusion tracer content tendency for age
     ! units: yr m s-1
@@ -4003,7 +7766,27 @@
     ! long_name: Lateral or neutral diffusion tracer content tendency for age
     ! units: yr m s-1
     ! cell_methods: z_l:sum
+"ocean_model_d2", "age_dfxy_cont_tendency"  [Unused]
+    ! long_name: Lateral or neutral diffusion tracer content tendency for age
+    ! units: yr m s-1
+    ! cell_methods: xh:sum yh:sum zl:sum area:sum
+"ocean_model_d2", "age_dfxy_cont_tendency_xyave"  [Unused]
+    ! long_name: Lateral or neutral diffusion tracer content tendency for age
+    ! units: yr m s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "age_dfxy_cont_tendency"  [Unused]
+    ! long_name: Lateral or neutral diffusion tracer content tendency for age
+    ! units: yr m s-1
+    ! cell_methods: xh:sum yh:sum z_l:sum area:sum
+"ocean_model_z_d2", "age_dfxy_cont_tendency_xyave"  [Unused]
+    ! long_name: Lateral or neutral diffusion tracer content tendency for age
+    ! units: yr m s-1
+    ! cell_methods: z_l:sum
 "ocean_model", "age_dfxy_cont_tendency_2d"  [Unused]
+    ! long_name: Depth integrated lateral or neutral diffusion tracer concentration tendency for age
+    ! units: yr m s-1
+    ! cell_methods: xh:sum yh:sum area:sum
+"ocean_model_d2", "age_dfxy_cont_tendency_2d"  [Unused]
     ! long_name: Depth integrated lateral or neutral diffusion tracer concentration tendency for age
     ! units: yr m s-1
     ! cell_methods: xh:sum yh:sum area:sum
@@ -4023,6 +7806,22 @@
     ! long_name: Lateral (neutral) tracer concentration tendency for age
     ! units: yr s-1
     ! cell_methods: z_l:mean
+"ocean_model_d2", "age_dfxy_conc_tendency"  [Unused]
+    ! long_name: Lateral (neutral) tracer concentration tendency for age
+    ! units: yr s-1
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "age_dfxy_conc_tendency_xyave"  [Unused]
+    ! long_name: Lateral (neutral) tracer concentration tendency for age
+    ! units: yr s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "age_dfxy_conc_tendency"  [Unused]
+    ! long_name: Lateral (neutral) tracer concentration tendency for age
+    ! units: yr s-1
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "age_dfxy_conc_tendency_xyave"  [Unused]
+    ! long_name: Lateral (neutral) tracer concentration tendency for age
+    ! units: yr s-1
+    ! cell_methods: z_l:mean
 "ocean_model", "ageh_tendency"  [Unused]
     ! long_name: Net time tendency for ideal age tracer
     ! units: yr m s-1
@@ -4039,7 +7838,27 @@
     ! long_name: Net time tendency for ideal age tracer
     ! units: yr m s-1
     ! cell_methods: z_l:sum
+"ocean_model_d2", "ageh_tendency"  [Unused]
+    ! long_name: Net time tendency for ideal age tracer
+    ! units: yr m s-1
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "ageh_tendency_xyave"  [Unused]
+    ! long_name: Net time tendency for ideal age tracer
+    ! units: yr m s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "ageh_tendency"  [Unused]
+    ! long_name: Net time tendency for ideal age tracer
+    ! units: yr m s-1
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "ageh_tendency_xyave"  [Unused]
+    ! long_name: Net time tendency for ideal age tracer
+    ! units: yr m s-1
+    ! cell_methods: z_l:sum
 "ocean_model", "ageh_tendency_2d"  [Unused]
+    ! long_name: Vertical sum of net time tendency for ideal age tracer
+    ! units: yr m s-1
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "ageh_tendency_2d"  [Unused]
     ! long_name: Vertical sum of net time tendency for ideal age tracer
     ! units: yr m s-1
     ! cell_methods: xh:mean yh:mean area:mean
@@ -4051,11 +7870,19 @@
     ! long_name: Ideal Age Tracer
     ! units: yr
     ! standard_name: not provided
+"ocean_model_zold_d2", "age_xyave"  [Unused]
+    ! long_name: Ideal Age Tracer
+    ! units: yr
+    ! standard_name: not provided
 "ocean_model_zold", "agessc"  [Unused]
     ! long_name: Ideal Age Tracer
     ! units: yr
     ! standard_name: ideal_age_tracer
 "ocean_model_zold", "agessc_xyave"  [Unused]
+    ! long_name: Ideal Age Tracer
+    ! units: yr
+    ! standard_name: ideal_age_tracer
+"ocean_model_zold_d2", "agessc_xyave"  [Unused]
     ! long_name: Ideal Age Tracer
     ! units: yr
     ! standard_name: ideal_age_tracer
@@ -4065,6 +7892,16 @@
     ! standard_name: surface_downward_x_stress
     ! cell_methods: xq:point yh:mean
 "ocean_model", "tauuo"  [Used] (native name is "taux")
+    ! long_name: Surface Downward X Stress
+    ! units: N m-2
+    ! standard_name: surface_downward_x_stress
+    ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "taux"  [Unused] (CMOR equivalent is "tauuo")
+    ! long_name: Zonal surface stress from ocean interactions with atmos and ice
+    ! units: Pa
+    ! standard_name: surface_downward_x_stress
+    ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "tauuo"  [Unused] (native name is "taux")
     ! long_name: Surface Downward X Stress
     ! units: N m-2
     ! standard_name: surface_downward_x_stress
@@ -4079,7 +7916,21 @@
     ! units: N m-2
     ! standard_name: surface_downward_y_stress
     ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "tauy"  [Unused] (CMOR equivalent is "tauvo")
+    ! long_name: Meridional surface stress ocean interactions with atmos and ice
+    ! units: Pa
+    ! standard_name: surface_downward_y_stress
+    ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "tauvo"  [Unused] (native name is "tauy")
+    ! long_name: Surface Downward Y Stress
+    ! units: N m-2
+    ! standard_name: surface_downward_y_stress
+    ! cell_methods: xh:mean yq:point
 "ocean_model", "ustar"  [Used]
+    ! long_name: Surface friction velocity = [(gustiness + tau_magnitude)/rho0]^(1/2)
+    ! units: m s-1
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "ustar"  [Unused]
     ! long_name: Surface friction velocity = [(gustiness + tau_magnitude)/rho0]^(1/2)
     ! units: m s-1
     ! cell_methods: xh:mean yh:mean area:mean
@@ -4092,7 +7943,20 @@
     ! units: Pa
     ! standard_name: sea_water_pressure_at_sea_water_surface
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "p_surf"  [Unused] (CMOR equivalent is "pso")
+    ! long_name: Pressure at ice-ocean or atmosphere-ocean interface
+    ! units: Pa
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "pso"  [Unused] (native name is "p_surf")
+    ! long_name: Sea Water Pressure at Sea Water Surface
+    ! units: Pa
+    ! standard_name: sea_water_pressure_at_sea_water_surface
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "TKE_tidal"  [Unused]
+    ! long_name: Tidal source of BBL mixing
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "TKE_tidal"  [Unused]
     ! long_name: Tidal source of BBL mixing
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -4102,6 +7966,16 @@
     ! standard_name: water_flux_into_sea_water
     ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "wfo"  [Used] (native name is "PRCmE")
+    ! long_name: Water Flux Into Sea Water
+    ! units: kg m-2 s-1
+    ! standard_name: water_flux_into_sea_water
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "PRCmE"  [Unused] (CMOR equivalent is "wfo")
+    ! long_name: Net surface water flux (precip+melt+lrunoff+ice calving-evap)
+    ! units: kg m-2 s-1
+    ! standard_name: water_flux_into_sea_water
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "wfo"  [Unused] (native name is "PRCmE")
     ! long_name: Water Flux Into Sea Water
     ! units: kg m-2 s-1
     ! standard_name: water_flux_into_sea_water
@@ -4116,6 +7990,16 @@
     ! units: kg m-2 s-1
     ! standard_name: water_evaporation_flux
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "evap"  [Unused] (CMOR equivalent is "evs")
+    ! long_name: Evaporation/condensation at ocean surface (evaporation is negative)
+    ! units: kg m-2 s-1
+    ! standard_name: water_evaporation_flux
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "evs"  [Unused] (native name is "evap")
+    ! long_name: Water Evaporation Flux Where Ice Free Ocean over Sea
+    ! units: kg m-2 s-1
+    ! standard_name: water_evaporation_flux
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "seaice_melt"  [Unused] (CMOR equivalent is "fsitherm")
     ! long_name: water flux to ocean from snow/sea ice melting(> 0) or formation(< 0)
     ! units: kg m-2 s-1
@@ -4126,7 +8010,21 @@
     ! units: kg m-2 s-1
     ! standard_name: water_flux_into_sea_water_due_to_sea_ice_thermodynamics
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "seaice_melt"  [Unused] (CMOR equivalent is "fsitherm")
+    ! long_name: water flux to ocean from snow/sea ice melting(> 0) or formation(< 0)
+    ! units: kg m-2 s-1
+    ! standard_name: water_flux_into_sea_water_due_to_sea_ice_thermodynamics
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "fsitherm"  [Unused] (native name is "seaice_melt")
+    ! long_name: water flux to ocean from sea ice melt(> 0) or form(< 0)
+    ! units: kg m-2 s-1
+    ! standard_name: water_flux_into_sea_water_due_to_sea_ice_thermodynamics
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "precip"  [Unused]
+    ! long_name: Liquid + frozen precipitation into ocean
+    ! units: kg m-2 s-1
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "precip"  [Unused]
     ! long_name: Liquid + frozen precipitation into ocean
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
@@ -4136,6 +8034,16 @@
     ! standard_name: snowfall_flux
     ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "prsn"  [Used] (native name is "fprec")
+    ! long_name: Snowfall Flux where Ice Free Ocean over Sea
+    ! units: kg m-2 s-1
+    ! standard_name: snowfall_flux
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "fprec"  [Unused] (CMOR equivalent is "prsn")
+    ! long_name: Frozen precipitation into ocean
+    ! units: kg m-2 s-1
+    ! standard_name: snowfall_flux
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "prsn"  [Unused] (native name is "fprec")
     ! long_name: Snowfall Flux where Ice Free Ocean over Sea
     ! units: kg m-2 s-1
     ! standard_name: snowfall_flux
@@ -4150,7 +8058,21 @@
     ! units: kg m-2 s-1
     ! standard_name: rainfall_flux
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "lprec"  [Unused] (CMOR equivalent is "prlq")
+    ! long_name: Liquid precipitation into ocean
+    ! units: kg m-2 s-1
+    ! standard_name: rainfall_flux
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "prlq"  [Unused] (native name is "lprec")
+    ! long_name: Rainfall Flux where Ice Free Ocean over Sea
+    ! units: kg m-2 s-1
+    ! standard_name: rainfall_flux
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "vprec"  [Used]
+    ! long_name: Virtual liquid precip into ocean due to SSS restoring
+    ! units: kg m-2 s-1
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "vprec"  [Unused]
     ! long_name: Virtual liquid precip into ocean due to SSS restoring
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
@@ -4160,6 +8082,16 @@
     ! standard_name: water_flux_into_sea_water_from_icebergs
     ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "ficeberg"  [Unused] (native name is "frunoff")
+    ! long_name: Water Flux into Seawater from Icebergs
+    ! units: kg m-2 s-1
+    ! standard_name: water_flux_into_sea_water_from_icebergs
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "frunoff"  [Unused] (CMOR equivalent is "ficeberg")
+    ! long_name: Frozen runoff (calving) and iceberg melt into ocean
+    ! units: kg m-2 s-1
+    ! standard_name: water_flux_into_sea_water_from_icebergs
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "ficeberg"  [Unused] (native name is "frunoff")
     ! long_name: Water Flux into Seawater from Icebergs
     ! units: kg m-2 s-1
     ! standard_name: water_flux_into_sea_water_from_icebergs
@@ -4174,7 +8106,21 @@
     ! units: kg m-2 s-1
     ! standard_name: water_flux_into_sea_water_from_rivers
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "lrunoff"  [Unused] (CMOR equivalent is "friver")
+    ! long_name: Liquid runoff (rivers) into ocean
+    ! units: kg m-2 s-1
+    ! standard_name: water_flux_into_sea_water_from_rivers
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "friver"  [Unused] (native name is "lrunoff")
+    ! long_name: Water Flux into Sea Water From Rivers
+    ! units: kg m-2 s-1
+    ! standard_name: water_flux_into_sea_water_from_rivers
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "net_massout"  [Used]
+    ! long_name: Net mass leaving the ocean due to evaporation, seaice formation
+    ! units: kg m-2 s-1
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "net_massout"  [Unused]
     ! long_name: Net mass leaving the ocean due to evaporation, seaice formation
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
@@ -4182,11 +8128,23 @@
     ! long_name: Net mass entering ocean due to precip, runoff, ice melt
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "net_massin"  [Unused]
+    ! long_name: Net mass entering ocean due to precip, runoff, ice melt
+    ! units: kg m-2 s-1
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "massout_flux"  [Unused]
     ! long_name: Net mass flux of freshwater out of the ocean (used in the boundary flux calculation)
     ! units: kg m-2
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "massout_flux"  [Unused]
+    ! long_name: Net mass flux of freshwater out of the ocean (used in the boundary flux calculation)
+    ! units: kg m-2
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "massin_flux"  [Unused]
+    ! long_name: Net mass flux of freshwater into the ocean (used in boundary flux calculation)
+    ! units: kg m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "massin_flux"  [Unused]
     ! long_name: Net mass flux of freshwater into the ocean (used in boundary flux calculation)
     ! units: kg m-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -4299,7 +8257,17 @@
     ! units: W m-2
     ! standard_name: temperature_flux_due_to_solid_runoff_expressed_as_heat_flux_into_sea_water
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "heat_content_frunoff"  [Unused]
+    ! long_name: Heat content (relative to 0C) of solid runoff into ocean
+    ! units: W m-2
+    ! standard_name: temperature_flux_due_to_solid_runoff_expressed_as_heat_flux_into_sea_water
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "heat_content_lrunoff"  [Used]
+    ! long_name: Heat content (relative to 0C) of liquid runoff into ocean
+    ! units: W m-2
+    ! standard_name: temperature_flux_due_to_runoff_expressed_as_heat_flux_into_sea_water
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "heat_content_lrunoff"  [Unused]
     ! long_name: Heat content (relative to 0C) of liquid runoff into ocean
     ! units: W m-2
     ! standard_name: temperature_flux_due_to_runoff_expressed_as_heat_flux_into_sea_water
@@ -4309,7 +8277,16 @@
     ! units: W m-2
     ! standard_name: temperature_flux_due_to_runoff_expressed_as_heat_flux_into_sea_water
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "hfrunoffds"  [Unused]
+    ! long_name: Heat content (relative to 0C) of liquid+solid runoff into ocean
+    ! units: W m-2
+    ! standard_name: temperature_flux_due_to_runoff_expressed_as_heat_flux_into_sea_water
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "heat_content_lprec"  [Used]
+    ! long_name: Heat content (relative to 0degC) of liquid precip entering ocean
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "heat_content_lprec"  [Unused]
     ! long_name: Heat content (relative to 0degC) of liquid precip entering ocean
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -4317,7 +8294,15 @@
     ! long_name: Heat content (relative to 0degC) of frozen prec entering ocean
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "heat_content_fprec"  [Unused]
+    ! long_name: Heat content (relative to 0degC) of frozen prec entering ocean
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "heat_content_icemelt"  [Unused]
+    ! long_name: Heat content (relative to 0degC) of water flux due to sea ice melting/freezing
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "heat_content_icemelt"  [Unused]
     ! long_name: Heat content (relative to 0degC) of water flux due to sea ice melting/freezing
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -4325,7 +8310,15 @@
     ! long_name: Heat content (relative to 0degC) of virtual precip entering ocean
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "heat_content_vprec"  [Unused]
+    ! long_name: Heat content (relative to 0degC) of virtual precip entering ocean
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "heat_content_cond"  [Used]
+    ! long_name: Heat content (relative to 0degC) of water condensing into ocean
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "heat_content_cond"  [Unused]
     ! long_name: Heat content (relative to 0degC) of water condensing into ocean
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -4334,7 +8327,16 @@
     ! units: W m-2
     ! standard_name: temperature_flux_due_to_rainfall_expressed_as_heat_flux_into_sea_water
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "hfrainds"  [Unused]
+    ! long_name: Heat content (relative to 0degC) of liquid+frozen precip entering ocean
+    ! units: W m-2
+    ! standard_name: temperature_flux_due_to_rainfall_expressed_as_heat_flux_into_sea_water
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "heat_content_surfwater"  [Used]
+    ! long_name: Heat content (relative to 0degC) of net water crossing ocean surface (frozen+liquid)
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "heat_content_surfwater"  [Unused]
     ! long_name: Heat content (relative to 0degC) of net water crossing ocean surface (frozen+liquid)
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -4347,11 +8349,28 @@
     ! units: W m-2
     ! standard_name: temperature_flux_due_to_evaporation_expressed_as_heat_flux_out_of_sea_water
     ! cell_methods: xh:mean yh:mean area:mean
-"ocean_model", "heat_content_massin"  [Used]
+"ocean_model_d2", "heat_content_massout"  [Unused] (CMOR equivalent is "hfevapds")
+    ! long_name: Heat content (relative to 0degC) of net mass leaving ocean ocean via evap and ice form
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "hfevapds"  [Unused] (native name is "heat_content_massout")
+    ! long_name: Heat Content (relative to 0degC) of Water Leaving Ocean via Evaporation and Ice Formation
+    ! units: W m-2
+    ! standard_name: temperature_flux_due_to_evaporation_expressed_as_heat_flux_out_of_sea_water
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model", "heat_content_massin"  [Unused]
+    ! long_name: Heat content (relative to 0degC) of net mass entering ocean ocean
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "heat_content_massin"  [Unused]
     ! long_name: Heat content (relative to 0degC) of net mass entering ocean ocean
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "net_heat_coupler"  [Used]
+    ! long_name: Surface ocean heat flux from SW+LW+latent+sensible+seaice_melt_heat (via the coupler)
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "net_heat_coupler"  [Unused]
     ! long_name: Surface ocean heat flux from SW+LW+latent+sensible+seaice_melt_heat (via the coupler)
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -4361,6 +8380,16 @@
     ! standard_name: surface_downward_heat_flux_in_sea_water
     ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "hfds"  [Used] (native name is "net_heat_surface")
+    ! long_name: Surface ocean heat flux from SW+LW+latent+sensible+masstransfer+frazil+seaice_melt_heat
+    ! units: W m-2
+    ! standard_name: surface_downward_heat_flux_in_sea_water
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "net_heat_surface"  [Unused] (CMOR equivalent is "hfds")
+    ! long_name: Surface ocean heat flux from SW+LW+lat+sens+mass transfer+frazil+restore+seaice_melt_heat or flux adjustments
+    ! units: W m-2
+    ! standard_name: surface_downward_heat_flux_in_sea_water
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "hfds"  [Unused] (native name is "net_heat_surface")
     ! long_name: Surface ocean heat flux from SW+LW+latent+sensible+masstransfer+frazil+seaice_melt_heat
     ! units: W m-2
     ! standard_name: surface_downward_heat_flux_in_sea_water
@@ -4375,7 +8404,21 @@
     ! units: W m-2
     ! standard_name: net_downward_shortwave_flux_at_sea_water_surface
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "SW"  [Unused] (CMOR equivalent is "rsntds")
+    ! long_name: Shortwave radiation flux into ocean
+    ! units: W m-2
+    ! standard_name: net_downward_shortwave_flux_at_sea_water_surface
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "rsntds"  [Unused] (native name is "SW")
+    ! long_name: Net Downward Shortwave Radiation at Sea Water Surface
+    ! units: W m-2
+    ! standard_name: net_downward_shortwave_flux_at_sea_water_surface
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "sw_vis"  [Unused]
+    ! long_name: Shortwave radiation direct and diffuse flux into the ocean in the visible band
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "sw_vis"  [Unused]
     ! long_name: Shortwave radiation direct and diffuse flux into the ocean in the visible band
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -4383,7 +8426,15 @@
     ! long_name: Shortwave radiation direct and diffuse flux into the ocean in the near-infrared band
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "sw_nir"  [Unused]
+    ! long_name: Shortwave radiation direct and diffuse flux into the ocean in the near-infrared band
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "LwLatSens"  [Used]
+    ! long_name: Combined longwave, latent, and sensible heating at ocean surface
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "LwLatSens"  [Unused]
     ! long_name: Combined longwave, latent, and sensible heating at ocean surface
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -4397,6 +8448,16 @@
     ! units: W m-2
     ! standard_name: surface_net_downward_longwave_flux
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "LW"  [Unused] (CMOR equivalent is "rlntds")
+    ! long_name: Longwave radiation flux into ocean
+    ! units: W m-2
+    ! standard_name: surface_net_downward_longwave_flux
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "rlntds"  [Unused] (native name is "LW")
+    ! long_name: Surface Net Downward Longwave Radiation
+    ! units: W m-2
+    ! standard_name: surface_net_downward_longwave_flux
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "latent"  [Unused] (CMOR equivalent is "hflso")
     ! long_name: Latent heat flux into ocean due to fusion and evaporation (negative means ocean heat loss)
     ! units: W m-2
@@ -4406,7 +8467,20 @@
     ! units: W m-2
     ! standard_name: surface_downward_latent_heat_flux
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "latent"  [Unused] (CMOR equivalent is "hflso")
+    ! long_name: Latent heat flux into ocean due to fusion and evaporation (negative means ocean heat loss)
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "hflso"  [Unused] (native name is "latent")
+    ! long_name: Surface Downward Latent Heat Flux due to Evap + Melt Snow/Ice
+    ! units: W m-2
+    ! standard_name: surface_downward_latent_heat_flux
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "latent_evap"  [Unused]
+    ! long_name: Latent heat flux into ocean due to evaporation/condensation
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "latent_evap"  [Unused]
     ! long_name: Latent heat flux into ocean due to evaporation/condensation
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -4419,11 +8493,29 @@
     ! units: W m-2
     ! standard_name: heat_flux_into_sea_water_due_to_snow_thermodynamics
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "latent_fprec_diag"  [Unused] (CMOR equivalent is "hfsnthermds")
+    ! long_name: Latent heat flux into ocean due to melting of frozen precipitation
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "hfsnthermds"  [Unused] (native name is "latent_fprec_diag")
+    ! long_name: Latent Heat to Melt Frozen Precipitation
+    ! units: W m-2
+    ! standard_name: heat_flux_into_sea_water_due_to_snow_thermodynamics
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "latent_frunoff"  [Unused] (CMOR equivalent is "hfibthermds")
     ! long_name: Latent heat flux into ocean due to melting of icebergs
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "hfibthermds"  [Used] (native name is "latent_frunoff")
+    ! long_name: Latent Heat to Melt Frozen Runoff/Iceberg
+    ! units: W m-2
+    ! standard_name: heat_flux_into_sea_water_due_to_iceberg_thermodynamics
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "latent_frunoff"  [Unused] (CMOR equivalent is "hfibthermds")
+    ! long_name: Latent heat flux into ocean due to melting of icebergs
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "hfibthermds"  [Unused] (native name is "latent_frunoff")
     ! long_name: Latent Heat to Melt Frozen Runoff/Iceberg
     ! units: W m-2
     ! standard_name: heat_flux_into_sea_water_due_to_iceberg_thermodynamics
@@ -4438,12 +8530,31 @@
     ! units: W m-2
     ! standard_name: surface_downward_sensible_heat_flux
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "sensible"  [Unused] (CMOR equivalent is "hfsso")
+    ! long_name: Sensible heat flux into ocean
+    ! units: W m-2
+    ! standard_name: surface_downward_sensible_heat_flux
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "hfsso"  [Unused] (native name is "sensible")
+    ! long_name: Surface Downward Sensible Heat Flux
+    ! units: W m-2
+    ! standard_name: surface_downward_sensible_heat_flux
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "seaice_melt_heat"  [Unused]
     ! long_name: Heat flux into ocean due to snow and sea ice melt/freeze
     ! units: W m-2
     ! standard_name: snow_ice_melt_heat_flux
     ! cell_methods: xh:mean yh:mean area:mean
-"ocean_model", "heat_added"  [Used]
+"ocean_model_d2", "seaice_melt_heat"  [Unused]
+    ! long_name: Heat flux into ocean due to snow and sea ice melt/freeze
+    ! units: W m-2
+    ! standard_name: snow_ice_melt_heat_flux
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model", "heat_added"  [Unused]
+    ! long_name: Flux Adjustment or restoring surface heat flux into ocean
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "heat_added"  [Unused]
     ! long_name: Flux Adjustment or restoring surface heat flux into ocean
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -4607,11 +8718,28 @@
     ! units: kg m-2 s-1
     ! standard_name: downward_sea_ice_basal_salt_flux
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "salt_flux"  [Unused] (CMOR equivalent is "sfdsi")
+    ! long_name: Net salt flux into ocean at surface (restoring + sea-ice)
+    ! units: kg m-2 s-1
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "sfdsi"  [Unused] (native name is "salt_flux")
+    ! long_name: Downward Sea Ice Basal Salt Flux
+    ! units: kg m-2 s-1
+    ! standard_name: downward_sea_ice_basal_salt_flux
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "salt_flux_in"  [Unused]
     ! long_name: Salt flux into ocean at surface from coupler
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "salt_flux_in"  [Unused]
+    ! long_name: Salt flux into ocean at surface from coupler
+    ! units: kg m-2 s-1
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "salt_flux_added"  [Unused]
+    ! long_name: Salt flux into ocean at surface due to restoring or flux adjustment
+    ! units: kg m-2 s-1
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "salt_flux_added"  [Unused]
     ! long_name: Salt flux into ocean at surface due to restoring or flux adjustment
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean area:mean

--- a/ocean_only/global_ALE/z/available_diags.000000
+++ b/ocean_only/global_ALE/z/available_diags.000000
@@ -144,7 +144,31 @@
     ! units: m3
     ! standard_name: ocean_volume
     ! cell_methods: z_l:sum
+"ocean_model_d2", "volcello"  [Unused]
+    ! long_name: Ocean grid-cell volume
+    ! units: m3
+    ! standard_name: ocean_volume
+    ! cell_methods: xh:sum yh:sum zl:sum area:sum
+"ocean_model_d2", "volcello_xyave"  [Unused]
+    ! long_name: Ocean grid-cell volume
+    ! units: m3
+    ! standard_name: ocean_volume
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "volcello"  [Unused]
+    ! long_name: Ocean grid-cell volume
+    ! units: m3
+    ! standard_name: ocean_volume
+    ! cell_methods: xh:sum yh:sum z_l:sum area:sum
+"ocean_model_z_d2", "volcello_xyave"  [Unused]
+    ! long_name: Ocean grid-cell volume
+    ! units: m3
+    ! standard_name: ocean_volume
+    ! cell_methods: z_l:sum
 "ocean_model", "MEKE"  [Used]
+    ! long_name: Mesoscale Eddy Kinetic Energy
+    ! units: m2 s-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "MEKE"  [Unused]
     ! long_name: Mesoscale Eddy Kinetic Energy
     ! units: m2 s-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -152,7 +176,15 @@
     ! long_name: MEKE derived diffusivity
     ! units: m2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "MEKE_KH"  [Unused]
+    ! long_name: MEKE derived diffusivity
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "MEKE_KU"  [Unused]
+    ! long_name: MEKE derived lateral viscosity
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "MEKE_KU"  [Unused]
     ! long_name: MEKE derived lateral viscosity
     ! units: m2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
@@ -160,7 +192,15 @@
     ! long_name: MEKE derived eddy-velocity scale
     ! units: m s-1
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "MEKE_Ue"  [Unused]
+    ! long_name: MEKE derived eddy-velocity scale
+    ! units: m s-1
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "MEKE_Ub"  [Unused]
+    ! long_name: MEKE derived bottom eddy-velocity scale
+    ! units: m s-1
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "MEKE_Ub"  [Unused]
     ! long_name: MEKE derived bottom eddy-velocity scale
     ! units: m s-1
     ! cell_methods: xh:mean yh:mean area:mean
@@ -168,7 +208,15 @@
     ! long_name: MEKE derived barotropic eddy-velocity scale
     ! units: m s-1
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "MEKE_Ut"  [Unused]
+    ! long_name: MEKE derived barotropic eddy-velocity scale
+    ! units: m s-1
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "MEKE_src"  [Unused]
+    ! long_name: MEKE energy source
+    ! units: m2 s-3
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "MEKE_src"  [Unused]
     ! long_name: MEKE energy source
     ! units: m2 s-3
     ! cell_methods: xh:mean yh:mean area:mean
@@ -176,7 +224,15 @@
     ! long_name: MEKE decay rate
     ! units: s-1
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "MEKE_decay"  [Unused]
+    ! long_name: MEKE decay rate
+    ! units: s-1
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "KHMEKE_u"  [Unused]
+    ! long_name: Zonal diffusivity of MEKE
+    ! units: m2 s-1
+    ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "KHMEKE_u"  [Unused]
     ! long_name: Zonal diffusivity of MEKE
     ! units: m2 s-1
     ! cell_methods: xq:point yh:mean
@@ -184,7 +240,15 @@
     ! long_name: Meridional diffusivity of MEKE
     ! units: m2 s-1
     ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "KHMEKE_v"  [Unused]
+    ! long_name: Meridional diffusivity of MEKE
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yq:point
 "ocean_model", "MEKE_GM_src"  [Unused]
+    ! long_name: MEKE energy available from thickness mixing
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "MEKE_GM_src"  [Unused]
     ! long_name: MEKE energy available from thickness mixing
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -192,7 +256,15 @@
     ! long_name: MEKE energy available from momentum
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "MEKE_mom_src"  [Unused]
+    ! long_name: MEKE energy available from momentum
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "MEKE_Le"  [Unused]
+    ! long_name: Eddy mixing length used in the MEKE derived eddy diffusivity
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "MEKE_Le"  [Unused]
     ! long_name: Eddy mixing length used in the MEKE derived eddy diffusivity
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
@@ -200,7 +272,15 @@
     ! long_name: Rhines length scale used in the MEKE derived eddy diffusivity
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "MEKE_Lrhines"  [Unused]
+    ! long_name: Rhines length scale used in the MEKE derived eddy diffusivity
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "MEKE_Leady"  [Unused]
+    ! long_name: Eady length scale used in the MEKE derived eddy diffusivity
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "MEKE_Leady"  [Unused]
     ! long_name: Eady length scale used in the MEKE derived eddy diffusivity
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
@@ -208,7 +288,15 @@
     ! long_name: Ratio of bottom-projected eddy velocity to column-mean eddy velocity
     ! units: nondim
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "MEKE_gamma_b"  [Unused]
+    ! long_name: Ratio of bottom-projected eddy velocity to column-mean eddy velocity
+    ! units: nondim
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "MEKE_gamma_t"  [Unused]
+    ! long_name: Ratio of barotropic eddy velocity to column-mean eddy velocity
+    ! units: nondim
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "MEKE_gamma_t"  [Unused]
     ! long_name: Ratio of barotropic eddy velocity to column-mean eddy velocity
     ! units: nondim
     ! cell_methods: xh:mean yh:mean area:mean
@@ -216,7 +304,15 @@
     ! long_name: Inverse eddy time-scale, S*N, at u-points
     ! units: s-1
     ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "SN_u"  [Unused]
+    ! long_name: Inverse eddy time-scale, S*N, at u-points
+    ! units: s-1
+    ! cell_methods: xq:point yh:mean
 "ocean_model", "SN_v"  [Unused]
+    ! long_name: Inverse eddy time-scale, S*N, at v-points
+    ! units: s-1
+    ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "SN_v"  [Unused]
     ! long_name: Inverse eddy time-scale, S*N, at v-points
     ! units: s-1
     ! cell_methods: xh:mean yq:point
@@ -236,6 +332,22 @@
     ! long_name: Square of Brunt-Vaisala frequency, N^2, at u-points, as used in Visbeck et al.
     ! units: s-2
     ! cell_methods: z_i:point
+"ocean_model_d2", "N2_u"  [Unused]
+    ! long_name: Square of Brunt-Vaisala frequency, N^2, at u-points, as used in Visbeck et al.
+    ! units: s-2
+    ! cell_methods: xq:point yh:mean zi:point
+"ocean_model_d2", "N2_u_xyave"  [Unused]
+    ! long_name: Square of Brunt-Vaisala frequency, N^2, at u-points, as used in Visbeck et al.
+    ! units: s-2
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "N2_u"  [Unused]
+    ! long_name: Square of Brunt-Vaisala frequency, N^2, at u-points, as used in Visbeck et al.
+    ! units: s-2
+    ! cell_methods: xq:point yh:mean z_i:point
+"ocean_model_z_d2", "N2_u_xyave"  [Unused]
+    ! long_name: Square of Brunt-Vaisala frequency, N^2, at u-points, as used in Visbeck et al.
+    ! units: s-2
+    ! cell_methods: z_i:point
 "ocean_model", "N2_v"  [Unused]
     ! long_name: Square of Brunt-Vaisala frequency, N^2, at v-points, as used in Visbeck et al.
     ! units: s-2
@@ -252,7 +364,27 @@
     ! long_name: Square of Brunt-Vaisala frequency, N^2, at v-points, as used in Visbeck et al.
     ! units: s-2
     ! cell_methods: z_i:point
+"ocean_model_d2", "N2_v"  [Unused]
+    ! long_name: Square of Brunt-Vaisala frequency, N^2, at v-points, as used in Visbeck et al.
+    ! units: s-2
+    ! cell_methods: xh:mean yq:point zi:point
+"ocean_model_d2", "N2_v_xyave"  [Unused]
+    ! long_name: Square of Brunt-Vaisala frequency, N^2, at v-points, as used in Visbeck et al.
+    ! units: s-2
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "N2_v"  [Unused]
+    ! long_name: Square of Brunt-Vaisala frequency, N^2, at v-points, as used in Visbeck et al.
+    ! units: s-2
+    ! cell_methods: xh:mean yq:point z_i:point
+"ocean_model_z_d2", "N2_v_xyave"  [Unused]
+    ! long_name: Square of Brunt-Vaisala frequency, N^2, at v-points, as used in Visbeck et al.
+    ! units: s-2
+    ! cell_methods: z_i:point
 "ocean_model", "S2_u"  [Unused]
+    ! long_name: Depth average square of slope magnitude, S^2, at u-points, as used in Visbeck et al.
+    ! units: s-2
+    ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "S2_u"  [Unused]
     ! long_name: Depth average square of slope magnitude, S^2, at u-points, as used in Visbeck et al.
     ! units: s-2
     ! cell_methods: xq:point yh:mean
@@ -260,7 +392,15 @@
     ! long_name: Depth average square of slope magnitude, S^2, at v-points, as used in Visbeck et al.
     ! units: s-2
     ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "S2_v"  [Unused]
+    ! long_name: Depth average square of slope magnitude, S^2, at v-points, as used in Visbeck et al.
+    ! units: s-2
+    ! cell_methods: xh:mean yq:point
 "ocean_model", "Res_fn"  [Unused]
+    ! long_name: Resolution function for scaling diffusivities
+    ! units: nondim
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "Res_fn"  [Unused]
     ! long_name: Resolution function for scaling diffusivities
     ! units: nondim
     ! cell_methods: xh:mean yh:mean area:mean
@@ -268,7 +408,15 @@
     ! long_name: Ratio between deformation radius and grid spacing
     ! units: m m-1
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "Rd_dx"  [Unused]
+    ! long_name: Ratio between deformation radius and grid spacing
+    ! units: m m-1
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "bbl_thick_u"  [Unused]
+    ! long_name: BBL thickness at u points
+    ! units: m
+    ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "bbl_thick_u"  [Unused]
     ! long_name: BBL thickness at u points
     ! units: m
     ! cell_methods: xq:point yh:mean
@@ -276,11 +424,23 @@
     ! long_name: BBL viscosity at u points
     ! units: m2 s-1
     ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "kv_bbl_u"  [Unused]
+    ! long_name: BBL viscosity at u points
+    ! units: m2 s-1
+    ! cell_methods: xq:point yh:mean
 "ocean_model", "bbl_thick_v"  [Unused]
     ! long_name: BBL thickness at v points
     ! units: m
     ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "bbl_thick_v"  [Unused]
+    ! long_name: BBL thickness at v points
+    ! units: m
+    ! cell_methods: xh:mean yq:point
 "ocean_model", "kv_bbl_v"  [Unused]
+    ! long_name: BBL viscosity at v points
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "kv_bbl_v"  [Unused]
     ! long_name: BBL viscosity at v points
     ! units: m2 s-1
     ! cell_methods: xh:mean yq:point
@@ -300,6 +460,22 @@
     ! long_name: Rayleigh drag velocity at u points
     ! units: m s-1
     ! cell_methods: z_l:mean
+"ocean_model_d2", "Rayleigh_u"  [Unused]
+    ! long_name: Rayleigh drag velocity at u points
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean zl:mean
+"ocean_model_d2", "Rayleigh_u_xyave"  [Unused]
+    ! long_name: Rayleigh drag velocity at u points
+    ! units: m s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "Rayleigh_u"  [Unused]
+    ! long_name: Rayleigh drag velocity at u points
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean z_l:mean
+"ocean_model_z_d2", "Rayleigh_u_xyave"  [Unused]
+    ! long_name: Rayleigh drag velocity at u points
+    ! units: m s-1
+    ! cell_methods: z_l:mean
 "ocean_model", "Rayleigh_v"  [Unused]
     ! long_name: Rayleigh drag velocity at v points
     ! units: m s-1
@@ -316,11 +492,35 @@
     ! long_name: Rayleigh drag velocity at v points
     ! units: m s-1
     ! cell_methods: z_l:mean
+"ocean_model_d2", "Rayleigh_v"  [Unused]
+    ! long_name: Rayleigh drag velocity at v points
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point zl:mean
+"ocean_model_d2", "Rayleigh_v_xyave"  [Unused]
+    ! long_name: Rayleigh drag velocity at v points
+    ! units: m s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "Rayleigh_v"  [Unused]
+    ! long_name: Rayleigh drag velocity at v points
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point z_l:mean
+"ocean_model_z_d2", "Rayleigh_v_xyave"  [Unused]
+    ! long_name: Rayleigh drag velocity at v points
+    ! units: m s-1
+    ! cell_methods: z_l:mean
 "ocean_model", "RV"  [Unused]
     ! long_name: Relative Vorticity
     ! units: s-1
     ! cell_methods: xq:point yq:point zl:mean
+"ocean_model_d2", "RV"  [Unused]
+    ! long_name: Relative Vorticity
+    ! units: s-1
+    ! cell_methods: xq:point yq:point zl:mean
 "ocean_model", "PV"  [Unused]
+    ! long_name: Potential Vorticity
+    ! units: m-1 s-1
+    ! cell_methods: xq:point yq:point zl:mean
+"ocean_model_d2", "PV"  [Unused]
     ! long_name: Potential Vorticity
     ! units: m-1 s-1
     ! cell_methods: xq:point yq:point zl:mean
@@ -340,6 +540,22 @@
     ! long_name: Zonal Acceleration from Grad. Kinetic Energy
     ! units: m-1 s-2
     ! cell_methods: z_l:mean
+"ocean_model_d2", "gKEu"  [Unused]
+    ! long_name: Zonal Acceleration from Grad. Kinetic Energy
+    ! units: m-1 s-2
+    ! cell_methods: xq:point yh:mean zl:mean
+"ocean_model_d2", "gKEu_xyave"  [Unused]
+    ! long_name: Zonal Acceleration from Grad. Kinetic Energy
+    ! units: m-1 s-2
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "gKEu"  [Unused]
+    ! long_name: Zonal Acceleration from Grad. Kinetic Energy
+    ! units: m-1 s-2
+    ! cell_methods: xq:point yh:mean z_l:mean
+"ocean_model_z_d2", "gKEu_xyave"  [Unused]
+    ! long_name: Zonal Acceleration from Grad. Kinetic Energy
+    ! units: m-1 s-2
+    ! cell_methods: z_l:mean
 "ocean_model", "gKEv"  [Unused]
     ! long_name: Meridional Acceleration from Grad. Kinetic Energy
     ! units: m-1 s-2
@@ -353,6 +569,22 @@
     ! units: m-1 s-2
     ! cell_methods: xh:mean yq:point z_l:mean
 "ocean_model_z", "gKEv_xyave"  [Unused]
+    ! long_name: Meridional Acceleration from Grad. Kinetic Energy
+    ! units: m-1 s-2
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "gKEv"  [Unused]
+    ! long_name: Meridional Acceleration from Grad. Kinetic Energy
+    ! units: m-1 s-2
+    ! cell_methods: xh:mean yq:point zl:mean
+"ocean_model_d2", "gKEv_xyave"  [Unused]
+    ! long_name: Meridional Acceleration from Grad. Kinetic Energy
+    ! units: m-1 s-2
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "gKEv"  [Unused]
+    ! long_name: Meridional Acceleration from Grad. Kinetic Energy
+    ! units: m-1 s-2
+    ! cell_methods: xh:mean yq:point z_l:mean
+"ocean_model_z_d2", "gKEv_xyave"  [Unused]
     ! long_name: Meridional Acceleration from Grad. Kinetic Energy
     ! units: m-1 s-2
     ! cell_methods: z_l:mean
@@ -372,6 +604,22 @@
     ! long_name: Meridional Acceleration from Relative Vorticity
     ! units: m-1 s-2
     ! cell_methods: z_l:mean
+"ocean_model_d2", "rvxu"  [Unused]
+    ! long_name: Meridional Acceleration from Relative Vorticity
+    ! units: m-1 s-2
+    ! cell_methods: xh:mean yq:point zl:mean
+"ocean_model_d2", "rvxu_xyave"  [Unused]
+    ! long_name: Meridional Acceleration from Relative Vorticity
+    ! units: m-1 s-2
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "rvxu"  [Unused]
+    ! long_name: Meridional Acceleration from Relative Vorticity
+    ! units: m-1 s-2
+    ! cell_methods: xh:mean yq:point z_l:mean
+"ocean_model_z_d2", "rvxu_xyave"  [Unused]
+    ! long_name: Meridional Acceleration from Relative Vorticity
+    ! units: m-1 s-2
+    ! cell_methods: z_l:mean
 "ocean_model", "rvxv"  [Unused]
     ! long_name: Zonal Acceleration from Relative Vorticity
     ! units: m-1 s-2
@@ -388,7 +636,27 @@
     ! long_name: Zonal Acceleration from Relative Vorticity
     ! units: m-1 s-2
     ! cell_methods: z_l:mean
+"ocean_model_d2", "rvxv"  [Unused]
+    ! long_name: Zonal Acceleration from Relative Vorticity
+    ! units: m-1 s-2
+    ! cell_methods: xq:point yh:mean zl:mean
+"ocean_model_d2", "rvxv_xyave"  [Unused]
+    ! long_name: Zonal Acceleration from Relative Vorticity
+    ! units: m-1 s-2
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "rvxv"  [Unused]
+    ! long_name: Zonal Acceleration from Relative Vorticity
+    ! units: m-1 s-2
+    ! cell_methods: xq:point yh:mean z_l:mean
+"ocean_model_z_d2", "rvxv_xyave"  [Unused]
+    ! long_name: Zonal Acceleration from Relative Vorticity
+    ! units: m-1 s-2
+    ! cell_methods: z_l:mean
 "ocean_model", "e_tidal"  [Unused]
+    ! long_name: Tidal Forcing Astronomical and SAL Height Anomaly
+    ! units: meter
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "e_tidal"  [Unused]
     ! long_name: Tidal Forcing Astronomical and SAL Height Anomaly
     ! units: meter
     ! cell_methods: xh:mean yh:mean area:mean
@@ -408,6 +676,22 @@
     ! long_name: Zonal Acceleration from Horizontal Viscosity
     ! units: m s-2
     ! cell_methods: z_l:mean
+"ocean_model_d2", "diffu"  [Unused]
+    ! long_name: Zonal Acceleration from Horizontal Viscosity
+    ! units: m s-2
+    ! cell_methods: xq:point yh:mean zl:mean
+"ocean_model_d2", "diffu_xyave"  [Unused]
+    ! long_name: Zonal Acceleration from Horizontal Viscosity
+    ! units: m s-2
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "diffu"  [Unused]
+    ! long_name: Zonal Acceleration from Horizontal Viscosity
+    ! units: m s-2
+    ! cell_methods: xq:point yh:mean z_l:mean
+"ocean_model_z_d2", "diffu_xyave"  [Unused]
+    ! long_name: Zonal Acceleration from Horizontal Viscosity
+    ! units: m s-2
+    ! cell_methods: z_l:mean
 "ocean_model", "diffv"  [Unused]
     ! long_name: Meridional Acceleration from Horizontal Viscosity
     ! units: m s-2
@@ -421,6 +705,22 @@
     ! units: m s-2
     ! cell_methods: xh:mean yq:point z_l:mean
 "ocean_model_z", "diffv_xyave"  [Unused]
+    ! long_name: Meridional Acceleration from Horizontal Viscosity
+    ! units: m s-2
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "diffv"  [Unused]
+    ! long_name: Meridional Acceleration from Horizontal Viscosity
+    ! units: m s-2
+    ! cell_methods: xh:mean yq:point zl:mean
+"ocean_model_d2", "diffv_xyave"  [Unused]
+    ! long_name: Meridional Acceleration from Horizontal Viscosity
+    ! units: m s-2
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "diffv"  [Unused]
+    ! long_name: Meridional Acceleration from Horizontal Viscosity
+    ! units: m s-2
+    ! cell_methods: xh:mean yq:point z_l:mean
+"ocean_model_z_d2", "diffv_xyave"  [Unused]
     ! long_name: Meridional Acceleration from Horizontal Viscosity
     ! units: m s-2
     ! cell_methods: z_l:mean
@@ -460,7 +760,47 @@
     ! units: m4 s-1
     ! standard_name: ocean_momentum_xy_biharmonic_diffusivity
     ! cell_methods: z_l:mean
+"ocean_model_d2", "Ahh"  [Unused] (CMOR equivalent is "difmxybo")
+    ! long_name: Biharmonic Horizontal Viscosity at h Points
+    ! units: m4 s-1
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "Ahh_xyave"  [Unused] (CMOR equivalent is "difmxybo_xyave")
+    ! long_name: Biharmonic Horizontal Viscosity at h Points
+    ! units: m4 s-1
+    ! cell_methods: zl:mean
+"ocean_model_d2", "difmxybo"  [Unused] (native name is "Ahh")
+    ! long_name: Ocean lateral biharmonic viscosity
+    ! units: m4 s-1
+    ! standard_name: ocean_momentum_xy_biharmonic_diffusivity
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "difmxybo_xyave"  [Unused] (native name is "Ahh_xyave")
+    ! long_name: Ocean lateral biharmonic viscosity
+    ! units: m4 s-1
+    ! standard_name: ocean_momentum_xy_biharmonic_diffusivity
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "Ahh"  [Unused] (CMOR equivalent is "difmxybo")
+    ! long_name: Biharmonic Horizontal Viscosity at h Points
+    ! units: m4 s-1
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "Ahh_xyave"  [Unused] (CMOR equivalent is "difmxybo_xyave")
+    ! long_name: Biharmonic Horizontal Viscosity at h Points
+    ! units: m4 s-1
+    ! cell_methods: z_l:mean
+"ocean_model_z_d2", "difmxybo"  [Unused] (native name is "Ahh")
+    ! long_name: Ocean lateral biharmonic viscosity
+    ! units: m4 s-1
+    ! standard_name: ocean_momentum_xy_biharmonic_diffusivity
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "difmxybo_xyave"  [Unused] (native name is "Ahh_xyave")
+    ! long_name: Ocean lateral biharmonic viscosity
+    ! units: m4 s-1
+    ! standard_name: ocean_momentum_xy_biharmonic_diffusivity
+    ! cell_methods: z_l:mean
 "ocean_model", "Ahq"  [Unused]
+    ! long_name: Biharmonic Horizontal Viscosity at q Points
+    ! units: m4 s-1
+    ! cell_methods: xq:point yq:point zl:mean
+"ocean_model_d2", "Ahq"  [Unused]
     ! long_name: Biharmonic Horizontal Viscosity at q Points
     ! units: m4 s-1
     ! cell_methods: xq:point yq:point zl:mean
@@ -500,7 +840,47 @@
     ! units: m2 s-1
     ! standard_name: ocean_momentum_xy_laplacian_diffusivity
     ! cell_methods: z_l:mean
+"ocean_model_d2", "Khh"  [Unused] (CMOR equivalent is "difmxylo")
+    ! long_name: Laplacian Horizontal Viscosity at h Points
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "Khh_xyave"  [Unused] (CMOR equivalent is "difmxylo_xyave")
+    ! long_name: Laplacian Horizontal Viscosity at h Points
+    ! units: m2 s-1
+    ! cell_methods: zl:mean
+"ocean_model_d2", "difmxylo"  [Unused] (native name is "Khh")
+    ! long_name: Ocean lateral Laplacian viscosity
+    ! units: m2 s-1
+    ! standard_name: ocean_momentum_xy_laplacian_diffusivity
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "difmxylo_xyave"  [Unused] (native name is "Khh_xyave")
+    ! long_name: Ocean lateral Laplacian viscosity
+    ! units: m2 s-1
+    ! standard_name: ocean_momentum_xy_laplacian_diffusivity
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "Khh"  [Unused] (CMOR equivalent is "difmxylo")
+    ! long_name: Laplacian Horizontal Viscosity at h Points
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "Khh_xyave"  [Unused] (CMOR equivalent is "difmxylo_xyave")
+    ! long_name: Laplacian Horizontal Viscosity at h Points
+    ! units: m2 s-1
+    ! cell_methods: z_l:mean
+"ocean_model_z_d2", "difmxylo"  [Unused] (native name is "Khh")
+    ! long_name: Ocean lateral Laplacian viscosity
+    ! units: m2 s-1
+    ! standard_name: ocean_momentum_xy_laplacian_diffusivity
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "difmxylo_xyave"  [Unused] (native name is "Khh_xyave")
+    ! long_name: Ocean lateral Laplacian viscosity
+    ! units: m2 s-1
+    ! standard_name: ocean_momentum_xy_laplacian_diffusivity
+    ! cell_methods: z_l:mean
 "ocean_model", "Khq"  [Unused]
+    ! long_name: Laplacian Horizontal Viscosity at q Points
+    ! units: m2 s-1
+    ! cell_methods: xq:point yq:point zl:mean
+"ocean_model_d2", "Khq"  [Unused]
     ! long_name: Laplacian Horizontal Viscosity at q Points
     ! units: m2 s-1
     ! cell_methods: xq:point yq:point zl:mean
@@ -520,11 +900,36 @@
     ! long_name: Integral work done by lateral friction terms
     ! units: W m-2
     ! cell_methods: z_l:mean
+"ocean_model_d2", "FrictWork"  [Unused]
+    ! long_name: Integral work done by lateral friction terms
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "FrictWork_xyave"  [Unused]
+    ! long_name: Integral work done by lateral friction terms
+    ! units: W m-2
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "FrictWork"  [Unused]
+    ! long_name: Integral work done by lateral friction terms
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "FrictWork_xyave"  [Unused]
+    ! long_name: Integral work done by lateral friction terms
+    ! units: W m-2
+    ! cell_methods: z_l:mean
 "ocean_model", "FrictWorkIntz"  [Unused] (CMOR equivalent is "dispkexyfo")
     ! long_name: Depth integrated work done by lateral friction
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "dispkexyfo"  [Used] (native name is "FrictWorkIntz")
+    ! long_name: Depth integrated ocean kinetic energy dissipation due to lateral friction
+    ! units: W m-2
+    ! standard_name: ocean_kinetic_energy_dissipation_per_unit_area_due_to_xy_friction
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "FrictWorkIntz"  [Unused] (CMOR equivalent is "dispkexyfo")
+    ! long_name: Depth integrated work done by lateral friction
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "dispkexyfo"  [Unused] (native name is "FrictWorkIntz")
     ! long_name: Depth integrated ocean kinetic energy dissipation due to lateral friction
     ! units: W m-2
     ! standard_name: ocean_kinetic_energy_dissipation_per_unit_area_due_to_xy_friction
@@ -545,6 +950,22 @@
     ! long_name: Slow varying vertical viscosity
     ! units: m2 s-1
     ! cell_methods: z_i:point
+"ocean_model_d2", "Kv_slow"  [Unused]
+    ! long_name: Slow varying vertical viscosity
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "Kv_slow_xyave"  [Unused]
+    ! long_name: Slow varying vertical viscosity
+    ! units: m2 s-1
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "Kv_slow"  [Unused]
+    ! long_name: Slow varying vertical viscosity
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "Kv_slow_xyave"  [Unused]
+    ! long_name: Slow varying vertical viscosity
+    ! units: m2 s-1
+    ! cell_methods: z_i:point
 "ocean_model", "Kv_u"  [Unused]
     ! long_name: Total vertical viscosity at u-points
     ! units: m2 s-1
@@ -558,6 +979,22 @@
     ! units: m2 s-1
     ! cell_methods: xq:point yh:mean z_l:mean
 "ocean_model_z", "Kv_u_xyave"  [Unused]
+    ! long_name: Total vertical viscosity at u-points
+    ! units: m2 s-1
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "Kv_u"  [Unused]
+    ! long_name: Total vertical viscosity at u-points
+    ! units: m2 s-1
+    ! cell_methods: xq:point yh:mean zl:mean
+"ocean_model_d2", "Kv_u_xyave"  [Unused]
+    ! long_name: Total vertical viscosity at u-points
+    ! units: m2 s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "Kv_u"  [Unused]
+    ! long_name: Total vertical viscosity at u-points
+    ! units: m2 s-1
+    ! cell_methods: xq:point yh:mean z_l:mean
+"ocean_model_z_d2", "Kv_u_xyave"  [Unused]
     ! long_name: Total vertical viscosity at u-points
     ! units: m2 s-1
     ! cell_methods: z_l:mean
@@ -577,6 +1014,22 @@
     ! long_name: Total vertical viscosity at v-points
     ! units: m2 s-1
     ! cell_methods: z_l:mean
+"ocean_model_d2", "Kv_v"  [Unused]
+    ! long_name: Total vertical viscosity at v-points
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yq:point zl:mean
+"ocean_model_d2", "Kv_v_xyave"  [Unused]
+    ! long_name: Total vertical viscosity at v-points
+    ! units: m2 s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "Kv_v"  [Unused]
+    ! long_name: Total vertical viscosity at v-points
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yq:point z_l:mean
+"ocean_model_z_d2", "Kv_v_xyave"  [Unused]
+    ! long_name: Total vertical viscosity at v-points
+    ! units: m2 s-1
+    ! cell_methods: z_l:mean
 "ocean_model", "au_visc"  [Unused]
     ! long_name: Zonal Viscous Vertical Coupling Coefficient
     ! units: m s-1
@@ -590,6 +1043,22 @@
     ! units: m s-1
     ! cell_methods: xq:point yh:mean z_i:point
 "ocean_model_z", "au_visc_xyave"  [Unused]
+    ! long_name: Zonal Viscous Vertical Coupling Coefficient
+    ! units: m s-1
+    ! cell_methods: z_i:point
+"ocean_model_d2", "au_visc"  [Unused]
+    ! long_name: Zonal Viscous Vertical Coupling Coefficient
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean zi:point
+"ocean_model_d2", "au_visc_xyave"  [Unused]
+    ! long_name: Zonal Viscous Vertical Coupling Coefficient
+    ! units: m s-1
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "au_visc"  [Unused]
+    ! long_name: Zonal Viscous Vertical Coupling Coefficient
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean z_i:point
+"ocean_model_z_d2", "au_visc_xyave"  [Unused]
     ! long_name: Zonal Viscous Vertical Coupling Coefficient
     ! units: m s-1
     ! cell_methods: z_i:point
@@ -609,6 +1078,22 @@
     ! long_name: Meridional Viscous Vertical Coupling Coefficient
     ! units: m s-1
     ! cell_methods: z_i:point
+"ocean_model_d2", "av_visc"  [Unused]
+    ! long_name: Meridional Viscous Vertical Coupling Coefficient
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point zi:point
+"ocean_model_d2", "av_visc_xyave"  [Unused]
+    ! long_name: Meridional Viscous Vertical Coupling Coefficient
+    ! units: m s-1
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "av_visc"  [Unused]
+    ! long_name: Meridional Viscous Vertical Coupling Coefficient
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point z_i:point
+"ocean_model_z_d2", "av_visc_xyave"  [Unused]
+    ! long_name: Meridional Viscous Vertical Coupling Coefficient
+    ! units: m s-1
+    ! cell_methods: z_i:point
 "ocean_model", "Hu_visc"  [Unused]
     ! long_name: Thickness at Zonal Velocity Points for Viscosity
     ! units: m
@@ -622,6 +1107,22 @@
     ! units: m
     ! cell_methods: xq:point yh:mean z_l:mean
 "ocean_model_z", "Hu_visc_xyave"  [Unused]
+    ! long_name: Thickness at Zonal Velocity Points for Viscosity
+    ! units: m
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "Hu_visc"  [Unused]
+    ! long_name: Thickness at Zonal Velocity Points for Viscosity
+    ! units: m
+    ! cell_methods: xq:point yh:mean zl:mean
+"ocean_model_d2", "Hu_visc_xyave"  [Unused]
+    ! long_name: Thickness at Zonal Velocity Points for Viscosity
+    ! units: m
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "Hu_visc"  [Unused]
+    ! long_name: Thickness at Zonal Velocity Points for Viscosity
+    ! units: m
+    ! cell_methods: xq:point yh:mean z_l:mean
+"ocean_model_z_d2", "Hu_visc_xyave"  [Unused]
     ! long_name: Thickness at Zonal Velocity Points for Viscosity
     ! units: m
     ! cell_methods: z_l:mean
@@ -641,11 +1142,35 @@
     ! long_name: Thickness at Meridional Velocity Points for Viscosity
     ! units: m
     ! cell_methods: z_l:mean
+"ocean_model_d2", "Hv_visc"  [Unused]
+    ! long_name: Thickness at Meridional Velocity Points for Viscosity
+    ! units: m
+    ! cell_methods: xh:mean yq:point zl:mean
+"ocean_model_d2", "Hv_visc_xyave"  [Unused]
+    ! long_name: Thickness at Meridional Velocity Points for Viscosity
+    ! units: m
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "Hv_visc"  [Unused]
+    ! long_name: Thickness at Meridional Velocity Points for Viscosity
+    ! units: m
+    ! cell_methods: xh:mean yq:point z_l:mean
+"ocean_model_z_d2", "Hv_visc_xyave"  [Unused]
+    ! long_name: Thickness at Meridional Velocity Points for Viscosity
+    ! units: m
+    ! cell_methods: z_l:mean
 "ocean_model", "HMLu_visc"  [Unused]
     ! long_name: Mixed Layer Thickness at Zonal Velocity Points for Viscosity
     ! units: m
     ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "HMLu_visc"  [Unused]
+    ! long_name: Mixed Layer Thickness at Zonal Velocity Points for Viscosity
+    ! units: m
+    ! cell_methods: xq:point yh:mean
 "ocean_model", "HMLv_visc"  [Unused]
+    ! long_name: Mixed Layer Thickness at Meridional Velocity Points for Viscosity
+    ! units: m
+    ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "HMLv_visc"  [Unused]
     ! long_name: Mixed Layer Thickness at Meridional Velocity Points for Viscosity
     ! units: m
     ! cell_methods: xh:mean yq:point
@@ -665,6 +1190,22 @@
     ! long_name: Zonal Acceleration from Vertical Viscosity
     ! units: m s-2
     ! cell_methods: z_l:mean
+"ocean_model_d2", "du_dt_visc"  [Unused]
+    ! long_name: Zonal Acceleration from Vertical Viscosity
+    ! units: m s-2
+    ! cell_methods: xq:point yh:mean zl:mean
+"ocean_model_d2", "du_dt_visc_xyave"  [Unused]
+    ! long_name: Zonal Acceleration from Vertical Viscosity
+    ! units: m s-2
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "du_dt_visc"  [Unused]
+    ! long_name: Zonal Acceleration from Vertical Viscosity
+    ! units: m s-2
+    ! cell_methods: xq:point yh:mean z_l:mean
+"ocean_model_z_d2", "du_dt_visc_xyave"  [Unused]
+    ! long_name: Zonal Acceleration from Vertical Viscosity
+    ! units: m s-2
+    ! cell_methods: z_l:mean
 "ocean_model", "dv_dt_visc"  [Unused]
     ! long_name: Meridional Acceleration from Vertical Viscosity
     ! units: m s-2
@@ -681,7 +1222,27 @@
     ! long_name: Meridional Acceleration from Vertical Viscosity
     ! units: m s-2
     ! cell_methods: z_l:mean
+"ocean_model_d2", "dv_dt_visc"  [Unused]
+    ! long_name: Meridional Acceleration from Vertical Viscosity
+    ! units: m s-2
+    ! cell_methods: xh:mean yq:point zl:mean
+"ocean_model_d2", "dv_dt_visc_xyave"  [Unused]
+    ! long_name: Meridional Acceleration from Vertical Viscosity
+    ! units: m s-2
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "dv_dt_visc"  [Unused]
+    ! long_name: Meridional Acceleration from Vertical Viscosity
+    ! units: m s-2
+    ! cell_methods: xh:mean yq:point z_l:mean
+"ocean_model_z_d2", "dv_dt_visc_xyave"  [Unused]
+    ! long_name: Meridional Acceleration from Vertical Viscosity
+    ! units: m s-2
+    ! cell_methods: z_l:mean
 "ocean_model", "taux_bot"  [Unused]
+    ! long_name: Zonal Bottom Stress from Ocean to Earth
+    ! units: Pa
+    ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "taux_bot"  [Unused]
     ! long_name: Zonal Bottom Stress from Ocean to Earth
     ! units: Pa
     ! cell_methods: xq:point yh:mean
@@ -689,7 +1250,15 @@
     ! long_name: Meridional Bottom Stress from Ocean to Earth
     ! units: Pa
     ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "tauy_bot"  [Unused]
+    ! long_name: Meridional Bottom Stress from Ocean to Earth
+    ! units: Pa
+    ! cell_methods: xh:mean yq:point
 "ocean_model", "PFuBT"  [Unused]
+    ! long_name: Zonal Anomalous Barotropic Pressure Force Force Acceleration
+    ! units: m s-2
+    ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "PFuBT"  [Unused]
     ! long_name: Zonal Anomalous Barotropic Pressure Force Force Acceleration
     ! units: m s-2
     ! cell_methods: xq:point yh:mean
@@ -697,7 +1266,15 @@
     ! long_name: Meridional Anomalous Barotropic Pressure Force Acceleration
     ! units: m s-2
     ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "PFvBT"  [Unused]
+    ! long_name: Meridional Anomalous Barotropic Pressure Force Acceleration
+    ! units: m s-2
+    ! cell_methods: xh:mean yq:point
 "ocean_model", "CoruBT"  [Unused]
+    ! long_name: Zonal Barotropic Coriolis Acceleration
+    ! units: m s-2
+    ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "CoruBT"  [Unused]
     ! long_name: Zonal Barotropic Coriolis Acceleration
     ! units: m s-2
     ! cell_methods: xq:point yh:mean
@@ -705,7 +1282,15 @@
     ! long_name: Meridional Barotropic Coriolis Acceleration
     ! units: m s-2
     ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "CorvBT"  [Unused]
+    ! long_name: Meridional Barotropic Coriolis Acceleration
+    ! units: m s-2
+    ! cell_methods: xh:mean yq:point
 "ocean_model", "u_accel_bt"  [Unused]
+    ! long_name: Barotropic zonal acceleration
+    ! units: m s-2
+    ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "u_accel_bt"  [Unused]
     ! long_name: Barotropic zonal acceleration
     ! units: m s-2
     ! cell_methods: xq:point yh:mean
@@ -713,7 +1298,15 @@
     ! long_name: Barotropic meridional acceleration
     ! units: m s-2
     ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "v_accel_bt"  [Unused]
+    ! long_name: Barotropic meridional acceleration
+    ! units: m s-2
+    ! cell_methods: xh:mean yq:point
 "ocean_model", "ubtforce"  [Unused]
+    ! long_name: Barotropic zonal acceleration from baroclinic terms
+    ! units: m s-2
+    ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "ubtforce"  [Unused]
     ! long_name: Barotropic zonal acceleration from baroclinic terms
     ! units: m s-2
     ! cell_methods: xq:point yh:mean
@@ -721,7 +1314,15 @@
     ! long_name: Barotropic meridional acceleration from baroclinic terms
     ! units: m s-2
     ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "vbtforce"  [Unused]
+    ! long_name: Barotropic meridional acceleration from baroclinic terms
+    ! units: m s-2
+    ! cell_methods: xh:mean yq:point
 "ocean_model", "eta_bt"  [Unused]
+    ! long_name: Barotropic end SSH
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "eta_bt"  [Unused]
     ! long_name: Barotropic end SSH
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
@@ -729,7 +1330,15 @@
     ! long_name: Barotropic end zonal velocity
     ! units: m s-1
     ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "ubt"  [Unused]
+    ! long_name: Barotropic end zonal velocity
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean
 "ocean_model", "vbt"  [Unused]
+    ! long_name: Barotropic end meridional velocity
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "vbt"  [Unused]
     ! long_name: Barotropic end meridional velocity
     ! units: m s-1
     ! cell_methods: xh:mean yq:point
@@ -737,7 +1346,15 @@
     ! long_name: Barotropic start SSH
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "eta_st"  [Unused]
+    ! long_name: Barotropic start SSH
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "ubt_st"  [Unused]
+    ! long_name: Barotropic start zonal velocity
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "ubt_st"  [Unused]
     ! long_name: Barotropic start zonal velocity
     ! units: m s-1
     ! cell_methods: xq:point yh:mean
@@ -745,7 +1362,15 @@
     ! long_name: Barotropic start meridional velocity
     ! units: m s-1
     ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "vbt_st"  [Unused]
+    ! long_name: Barotropic start meridional velocity
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point
 "ocean_model", "ubtav"  [Unused]
+    ! long_name: Barotropic time-average zonal velocity
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "ubtav"  [Unused]
     ! long_name: Barotropic time-average zonal velocity
     ! units: m s-1
     ! cell_methods: xq:point yh:mean
@@ -753,7 +1378,15 @@
     ! long_name: Barotropic time-average meridional velocity
     ! units: m s-1
     ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "vbtav"  [Unused]
+    ! long_name: Barotropic time-average meridional velocity
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point
 "ocean_model", "eta_cor"  [Unused]
+    ! long_name: Corrective mass flux
+    ! units: m s-1
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "eta_cor"  [Unused]
     ! long_name: Corrective mass flux
     ! units: m s-1
     ! cell_methods: xh:mean yh:mean area:mean
@@ -773,6 +1406,22 @@
     ! long_name: Viscous remnant at u
     ! units: nondim
     ! cell_methods: z_l:mean
+"ocean_model_d2", "visc_rem_u"  [Unused]
+    ! long_name: Viscous remnant at u
+    ! units: nondim
+    ! cell_methods: xq:point yh:mean zl:mean
+"ocean_model_d2", "visc_rem_u_xyave"  [Unused]
+    ! long_name: Viscous remnant at u
+    ! units: nondim
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "visc_rem_u"  [Unused]
+    ! long_name: Viscous remnant at u
+    ! units: nondim
+    ! cell_methods: xq:point yh:mean z_l:mean
+"ocean_model_z_d2", "visc_rem_u_xyave"  [Unused]
+    ! long_name: Viscous remnant at u
+    ! units: nondim
+    ! cell_methods: z_l:mean
 "ocean_model", "visc_rem_v"  [Unused]
     ! long_name: Viscous remnant at v
     ! units: nondim
@@ -789,7 +1438,27 @@
     ! long_name: Viscous remnant at v
     ! units: nondim
     ! cell_methods: z_l:mean
+"ocean_model_d2", "visc_rem_v"  [Unused]
+    ! long_name: Viscous remnant at v
+    ! units: nondim
+    ! cell_methods: xh:mean yq:point zl:mean
+"ocean_model_d2", "visc_rem_v_xyave"  [Unused]
+    ! long_name: Viscous remnant at v
+    ! units: nondim
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "visc_rem_v"  [Unused]
+    ! long_name: Viscous remnant at v
+    ! units: nondim
+    ! cell_methods: xh:mean yq:point z_l:mean
+"ocean_model_z_d2", "visc_rem_v_xyave"  [Unused]
+    ! long_name: Viscous remnant at v
+    ! units: nondim
+    ! cell_methods: z_l:mean
 "ocean_model", "gtot_n"  [Unused]
+    ! long_name: gtot to North
+    ! units: m s-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "gtot_n"  [Unused]
     ! long_name: gtot to North
     ! units: m s-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -797,7 +1466,15 @@
     ! long_name: gtot to South
     ! units: m s-2
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "gtot_s"  [Unused]
+    ! long_name: gtot to South
+    ! units: m s-2
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "gtot_e"  [Unused]
+    ! long_name: gtot to East
+    ! units: m s-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "gtot_e"  [Unused]
     ! long_name: gtot to East
     ! units: m s-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -805,7 +1482,15 @@
     ! long_name: gtot to West
     ! units: m s-2
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "gtot_w"  [Unused]
+    ! long_name: gtot to West
+    ! units: m s-2
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "eta_hifreq"  [Unused]
+    ! long_name: High Frequency Barotropic SSH
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "eta_hifreq"  [Unused]
     ! long_name: High Frequency Barotropic SSH
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
@@ -813,7 +1498,15 @@
     ! long_name: High Frequency Barotropic zonal velocity
     ! units: m s-1
     ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "ubt_hifreq"  [Unused]
+    ! long_name: High Frequency Barotropic zonal velocity
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean
 "ocean_model", "vbt_hifreq"  [Unused]
+    ! long_name: High Frequency Barotropic meridional velocity
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "vbt_hifreq"  [Unused]
     ! long_name: High Frequency Barotropic meridional velocity
     ! units: m s-1
     ! cell_methods: xh:mean yq:point
@@ -821,11 +1514,23 @@
     ! long_name: High Frequency Predictor Barotropic SSH
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "eta_pred_hifreq"  [Unused]
+    ! long_name: High Frequency Predictor Barotropic SSH
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "uhbt_hifreq"  [Unused]
     ! long_name: High Frequency Barotropic zonal transport
     ! units: m3 s-1
     ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "uhbt_hifreq"  [Unused]
+    ! long_name: High Frequency Barotropic zonal transport
+    ! units: m3 s-1
+    ! cell_methods: xq:point yh:mean
 "ocean_model", "vhbt_hifreq"  [Unused]
+    ! long_name: High Frequency Barotropic meridional transport
+    ! units: m3 s-1
+    ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "vhbt_hifreq"  [Unused]
     ! long_name: High Frequency Barotropic meridional transport
     ! units: m3 s-1
     ! cell_methods: xh:mean yq:point
@@ -845,6 +1550,22 @@
     ! long_name: Fractional thickness of layers in u-columns
     ! units: nondim
     ! cell_methods: z_l:mean
+"ocean_model_d2", "frhatu"  [Unused]
+    ! long_name: Fractional thickness of layers in u-columns
+    ! units: nondim
+    ! cell_methods: xq:point yh:mean zl:mean
+"ocean_model_d2", "frhatu_xyave"  [Unused]
+    ! long_name: Fractional thickness of layers in u-columns
+    ! units: nondim
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "frhatu"  [Unused]
+    ! long_name: Fractional thickness of layers in u-columns
+    ! units: nondim
+    ! cell_methods: xq:point yh:mean z_l:mean
+"ocean_model_z_d2", "frhatu_xyave"  [Unused]
+    ! long_name: Fractional thickness of layers in u-columns
+    ! units: nondim
+    ! cell_methods: z_l:mean
 "ocean_model", "frhatv"  [Unused]
     ! long_name: Fractional thickness of layers in v-columns
     ! units: nondim
@@ -858,6 +1579,22 @@
     ! units: nondim
     ! cell_methods: xh:mean yq:point z_l:mean
 "ocean_model_z", "frhatv_xyave"  [Unused]
+    ! long_name: Fractional thickness of layers in v-columns
+    ! units: nondim
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "frhatv"  [Unused]
+    ! long_name: Fractional thickness of layers in v-columns
+    ! units: nondim
+    ! cell_methods: xh:mean yq:point zl:mean
+"ocean_model_d2", "frhatv_xyave"  [Unused]
+    ! long_name: Fractional thickness of layers in v-columns
+    ! units: nondim
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "frhatv"  [Unused]
+    ! long_name: Fractional thickness of layers in v-columns
+    ! units: nondim
+    ! cell_methods: xh:mean yq:point z_l:mean
+"ocean_model_z_d2", "frhatv_xyave"  [Unused]
     ! long_name: Fractional thickness of layers in v-columns
     ! units: nondim
     ! cell_methods: z_l:mean
@@ -877,6 +1614,22 @@
     ! long_name: Predictor Fractional thickness of layers in u-columns
     ! units: nondim
     ! cell_methods: z_l:mean
+"ocean_model_d2", "frhatu1"  [Unused]
+    ! long_name: Predictor Fractional thickness of layers in u-columns
+    ! units: nondim
+    ! cell_methods: xq:point yh:mean zl:mean
+"ocean_model_d2", "frhatu1_xyave"  [Unused]
+    ! long_name: Predictor Fractional thickness of layers in u-columns
+    ! units: nondim
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "frhatu1"  [Unused]
+    ! long_name: Predictor Fractional thickness of layers in u-columns
+    ! units: nondim
+    ! cell_methods: xq:point yh:mean z_l:mean
+"ocean_model_z_d2", "frhatu1_xyave"  [Unused]
+    ! long_name: Predictor Fractional thickness of layers in u-columns
+    ! units: nondim
+    ! cell_methods: z_l:mean
 "ocean_model", "frhatv1"  [Unused]
     ! long_name: Predictor Fractional thickness of layers in v-columns
     ! units: nondim
@@ -893,7 +1646,27 @@
     ! long_name: Predictor Fractional thickness of layers in v-columns
     ! units: nondim
     ! cell_methods: z_l:mean
+"ocean_model_d2", "frhatv1"  [Unused]
+    ! long_name: Predictor Fractional thickness of layers in v-columns
+    ! units: nondim
+    ! cell_methods: xh:mean yq:point zl:mean
+"ocean_model_d2", "frhatv1_xyave"  [Unused]
+    ! long_name: Predictor Fractional thickness of layers in v-columns
+    ! units: nondim
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "frhatv1"  [Unused]
+    ! long_name: Predictor Fractional thickness of layers in v-columns
+    ! units: nondim
+    ! cell_methods: xh:mean yq:point z_l:mean
+"ocean_model_z_d2", "frhatv1_xyave"  [Unused]
+    ! long_name: Predictor Fractional thickness of layers in v-columns
+    ! units: nondim
+    ! cell_methods: z_l:mean
 "ocean_model", "uhbt"  [Unused]
+    ! long_name: Barotropic zonal transport averaged over a baroclinic step
+    ! units: m3 s-1
+    ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "uhbt"  [Unused]
     ! long_name: Barotropic zonal transport averaged over a baroclinic step
     ! units: m3 s-1
     ! cell_methods: xq:point yh:mean
@@ -901,7 +1674,15 @@
     ! long_name: Barotropic meridional transport averaged over a baroclinic step
     ! units: m3 s-1
     ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "vhbt"  [Unused]
+    ! long_name: Barotropic meridional transport averaged over a baroclinic step
+    ! units: m3 s-1
+    ! cell_methods: xh:mean yq:point
 "ocean_model", "BTC_FA_u_EE"  [Unused]
+    ! long_name: BTCont type far east face area
+    ! units: m2
+    ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "BTC_FA_u_EE"  [Unused]
     ! long_name: BTCont type far east face area
     ! units: m2
     ! cell_methods: xq:point yh:mean
@@ -909,7 +1690,15 @@
     ! long_name: BTCont type near east face area
     ! units: m2
     ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "BTC_FA_u_E0"  [Unused]
+    ! long_name: BTCont type near east face area
+    ! units: m2
+    ! cell_methods: xq:point yh:mean
 "ocean_model", "BTC_FA_u_WW"  [Unused]
+    ! long_name: BTCont type far west face area
+    ! units: m2
+    ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "BTC_FA_u_WW"  [Unused]
     ! long_name: BTCont type far west face area
     ! units: m2
     ! cell_methods: xq:point yh:mean
@@ -917,7 +1706,15 @@
     ! long_name: BTCont type near west face area
     ! units: m2
     ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "BTC_FA_u_W0"  [Unused]
+    ! long_name: BTCont type near west face area
+    ! units: m2
+    ! cell_methods: xq:point yh:mean
 "ocean_model", "BTC_ubt_EE"  [Unused]
+    ! long_name: BTCont type far east velocity
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "BTC_ubt_EE"  [Unused]
     ! long_name: BTCont type far east velocity
     ! units: m s-1
     ! cell_methods: xq:point yh:mean
@@ -925,7 +1722,15 @@
     ! long_name: BTCont type far west velocity
     ! units: m s-1
     ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "BTC_ubt_WW"  [Unused]
+    ! long_name: BTCont type far west velocity
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean
 "ocean_model", "BTC_FA_v_NN"  [Unused]
+    ! long_name: BTCont type far north face area
+    ! units: m2
+    ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "BTC_FA_v_NN"  [Unused]
     ! long_name: BTCont type far north face area
     ! units: m2
     ! cell_methods: xh:mean yq:point
@@ -933,7 +1738,15 @@
     ! long_name: BTCont type near north face area
     ! units: m2
     ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "BTC_FA_v_N0"  [Unused]
+    ! long_name: BTCont type near north face area
+    ! units: m2
+    ! cell_methods: xh:mean yq:point
 "ocean_model", "BTC_FA_v_SS"  [Unused]
+    ! long_name: BTCont type far south face area
+    ! units: m2
+    ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "BTC_FA_v_SS"  [Unused]
     ! long_name: BTCont type far south face area
     ! units: m2
     ! cell_methods: xh:mean yq:point
@@ -941,7 +1754,15 @@
     ! long_name: BTCont type near south face area
     ! units: m2
     ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "BTC_FA_v_S0"  [Unused]
+    ! long_name: BTCont type near south face area
+    ! units: m2
+    ! cell_methods: xh:mean yq:point
 "ocean_model", "BTC_vbt_NN"  [Unused]
+    ! long_name: BTCont type far north velocity
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "BTC_vbt_NN"  [Unused]
     ! long_name: BTCont type far north velocity
     ! units: m s-1
     ! cell_methods: xh:mean yq:point
@@ -949,11 +1770,23 @@
     ! long_name: BTCont type far south velocity
     ! units: m s-1
     ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "BTC_vbt_SS"  [Unused]
+    ! long_name: BTCont type far south velocity
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point
 "ocean_model", "uhbt0"  [Unused]
     ! long_name: Barotropic zonal transport difference
     ! units: m3 s-1
     ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "uhbt0"  [Unused]
+    ! long_name: Barotropic zonal transport difference
+    ! units: m3 s-1
+    ! cell_methods: xq:point yh:mean
 "ocean_model", "vhbt0"  [Unused]
+    ! long_name: Barotropic meridional transport difference
+    ! units: m3 s-1
+    ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "vhbt0"  [Unused]
     ! long_name: Barotropic meridional transport difference
     ! units: m3 s-1
     ! cell_methods: xh:mean yq:point
@@ -973,6 +1806,22 @@
     ! long_name: Zonal Thickness Flux
     ! units: m3 s-1
     ! cell_methods: z_l:sum
+"ocean_model_d2", "uh"  [Unused]
+    ! long_name: Zonal Thickness Flux
+    ! units: m3 s-1
+    ! cell_methods: xq:point yh:sum zl:sum
+"ocean_model_d2", "uh_xyave"  [Unused]
+    ! long_name: Zonal Thickness Flux
+    ! units: m3 s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "uh"  [Unused]
+    ! long_name: Zonal Thickness Flux
+    ! units: m3 s-1
+    ! cell_methods: xq:point yh:sum z_l:sum
+"ocean_model_z_d2", "uh_xyave"  [Unused]
+    ! long_name: Zonal Thickness Flux
+    ! units: m3 s-1
+    ! cell_methods: z_l:sum
 "ocean_model", "vh"  [Used]
     ! long_name: Meridional Thickness Flux
     ! units: m3 s-1
@@ -986,6 +1835,22 @@
     ! units: m3 s-1
     ! cell_methods: xh:sum yq:point z_l:sum
 "ocean_model_z", "vh_xyave"  [Unused]
+    ! long_name: Meridional Thickness Flux
+    ! units: m3 s-1
+    ! cell_methods: z_l:sum
+"ocean_model_d2", "vh"  [Unused]
+    ! long_name: Meridional Thickness Flux
+    ! units: m3 s-1
+    ! cell_methods: xh:sum yq:point zl:sum
+"ocean_model_d2", "vh_xyave"  [Unused]
+    ! long_name: Meridional Thickness Flux
+    ! units: m3 s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "vh"  [Unused]
+    ! long_name: Meridional Thickness Flux
+    ! units: m3 s-1
+    ! cell_methods: xh:sum yq:point z_l:sum
+"ocean_model_z_d2", "vh_xyave"  [Unused]
     ! long_name: Meridional Thickness Flux
     ! units: m3 s-1
     ! cell_methods: z_l:sum
@@ -1005,6 +1870,22 @@
     ! long_name: Zonal Coriolis and Advective Acceleration
     ! units: m s-2
     ! cell_methods: z_l:mean
+"ocean_model_d2", "CAu"  [Unused]
+    ! long_name: Zonal Coriolis and Advective Acceleration
+    ! units: m s-2
+    ! cell_methods: xq:point yh:mean zl:mean
+"ocean_model_d2", "CAu_xyave"  [Unused]
+    ! long_name: Zonal Coriolis and Advective Acceleration
+    ! units: m s-2
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "CAu"  [Unused]
+    ! long_name: Zonal Coriolis and Advective Acceleration
+    ! units: m s-2
+    ! cell_methods: xq:point yh:mean z_l:mean
+"ocean_model_z_d2", "CAu_xyave"  [Unused]
+    ! long_name: Zonal Coriolis and Advective Acceleration
+    ! units: m s-2
+    ! cell_methods: z_l:mean
 "ocean_model", "CAv"  [Unused]
     ! long_name: Meridional Coriolis and Advective Acceleration
     ! units: m s-2
@@ -1018,6 +1899,22 @@
     ! units: m s-2
     ! cell_methods: xh:mean yq:point z_l:mean
 "ocean_model_z", "CAv_xyave"  [Unused]
+    ! long_name: Meridional Coriolis and Advective Acceleration
+    ! units: m s-2
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "CAv"  [Unused]
+    ! long_name: Meridional Coriolis and Advective Acceleration
+    ! units: m s-2
+    ! cell_methods: xh:mean yq:point zl:mean
+"ocean_model_d2", "CAv_xyave"  [Unused]
+    ! long_name: Meridional Coriolis and Advective Acceleration
+    ! units: m s-2
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "CAv"  [Unused]
+    ! long_name: Meridional Coriolis and Advective Acceleration
+    ! units: m s-2
+    ! cell_methods: xh:mean yq:point z_l:mean
+"ocean_model_z_d2", "CAv_xyave"  [Unused]
     ! long_name: Meridional Coriolis and Advective Acceleration
     ! units: m s-2
     ! cell_methods: z_l:mean
@@ -1037,6 +1934,22 @@
     ! long_name: Zonal Pressure Force Acceleration
     ! units: m s-2
     ! cell_methods: z_l:mean
+"ocean_model_d2", "PFu"  [Unused]
+    ! long_name: Zonal Pressure Force Acceleration
+    ! units: m s-2
+    ! cell_methods: xq:point yh:mean zl:mean
+"ocean_model_d2", "PFu_xyave"  [Unused]
+    ! long_name: Zonal Pressure Force Acceleration
+    ! units: m s-2
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "PFu"  [Unused]
+    ! long_name: Zonal Pressure Force Acceleration
+    ! units: m s-2
+    ! cell_methods: xq:point yh:mean z_l:mean
+"ocean_model_z_d2", "PFu_xyave"  [Unused]
+    ! long_name: Zonal Pressure Force Acceleration
+    ! units: m s-2
+    ! cell_methods: z_l:mean
 "ocean_model", "PFv"  [Unused]
     ! long_name: Meridional Pressure Force Acceleration
     ! units: m s-2
@@ -1050,6 +1963,22 @@
     ! units: m s-2
     ! cell_methods: xh:mean yq:point z_l:mean
 "ocean_model_z", "PFv_xyave"  [Unused]
+    ! long_name: Meridional Pressure Force Acceleration
+    ! units: m s-2
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "PFv"  [Unused]
+    ! long_name: Meridional Pressure Force Acceleration
+    ! units: m s-2
+    ! cell_methods: xh:mean yq:point zl:mean
+"ocean_model_d2", "PFv_xyave"  [Unused]
+    ! long_name: Meridional Pressure Force Acceleration
+    ! units: m s-2
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "PFv"  [Unused]
+    ! long_name: Meridional Pressure Force Acceleration
+    ! units: m s-2
+    ! cell_methods: xh:mean yq:point z_l:mean
+"ocean_model_z_d2", "PFv_xyave"  [Unused]
     ! long_name: Meridional Pressure Force Acceleration
     ! units: m s-2
     ! cell_methods: z_l:mean
@@ -1069,6 +1998,22 @@
     ! long_name: Barotropic-step Averaged Zonal Velocity
     ! units: m s-1
     ! cell_methods: z_l:mean
+"ocean_model_d2", "uav"  [Unused]
+    ! long_name: Barotropic-step Averaged Zonal Velocity
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean zl:mean
+"ocean_model_d2", "uav_xyave"  [Unused]
+    ! long_name: Barotropic-step Averaged Zonal Velocity
+    ! units: m s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "uav"  [Unused]
+    ! long_name: Barotropic-step Averaged Zonal Velocity
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean z_l:mean
+"ocean_model_z_d2", "uav_xyave"  [Unused]
+    ! long_name: Barotropic-step Averaged Zonal Velocity
+    ! units: m s-1
+    ! cell_methods: z_l:mean
 "ocean_model", "vav"  [Unused]
     ! long_name: Barotropic-step Averaged Meridional Velocity
     ! units: m s-1
@@ -1082,6 +2027,22 @@
     ! units: m s-1
     ! cell_methods: xh:mean yq:point z_l:mean
 "ocean_model_z", "vav_xyave"  [Unused]
+    ! long_name: Barotropic-step Averaged Meridional Velocity
+    ! units: m s-1
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "vav"  [Unused]
+    ! long_name: Barotropic-step Averaged Meridional Velocity
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point zl:mean
+"ocean_model_d2", "vav_xyave"  [Unused]
+    ! long_name: Barotropic-step Averaged Meridional Velocity
+    ! units: m s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "vav"  [Unused]
+    ! long_name: Barotropic-step Averaged Meridional Velocity
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point z_l:mean
+"ocean_model_z_d2", "vav_xyave"  [Unused]
     ! long_name: Barotropic-step Averaged Meridional Velocity
     ! units: m s-1
     ! cell_methods: z_l:mean
@@ -1101,6 +2062,22 @@
     ! long_name: Barotropic Anomaly Zonal Acceleration
     ! units: m s-1
     ! cell_methods: z_l:mean
+"ocean_model_d2", "u_BT_accel"  [Unused]
+    ! long_name: Barotropic Anomaly Zonal Acceleration
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean zl:mean
+"ocean_model_d2", "u_BT_accel_xyave"  [Unused]
+    ! long_name: Barotropic Anomaly Zonal Acceleration
+    ! units: m s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "u_BT_accel"  [Unused]
+    ! long_name: Barotropic Anomaly Zonal Acceleration
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean z_l:mean
+"ocean_model_z_d2", "u_BT_accel_xyave"  [Unused]
+    ! long_name: Barotropic Anomaly Zonal Acceleration
+    ! units: m s-1
+    ! cell_methods: z_l:mean
 "ocean_model", "v_BT_accel"  [Unused]
     ! long_name: Barotropic Anomaly Meridional Acceleration
     ! units: m s-1
@@ -1114,6 +2091,22 @@
     ! units: m s-1
     ! cell_methods: xh:mean yq:point z_l:mean
 "ocean_model_z", "v_BT_accel_xyave"  [Unused]
+    ! long_name: Barotropic Anomaly Meridional Acceleration
+    ! units: m s-1
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "v_BT_accel"  [Unused]
+    ! long_name: Barotropic Anomaly Meridional Acceleration
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point zl:mean
+"ocean_model_d2", "v_BT_accel_xyave"  [Unused]
+    ! long_name: Barotropic Anomaly Meridional Acceleration
+    ! units: m s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "v_BT_accel"  [Unused]
+    ! long_name: Barotropic Anomaly Meridional Acceleration
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point z_l:mean
+"ocean_model_z_d2", "v_BT_accel_xyave"  [Unused]
     ! long_name: Barotropic Anomaly Meridional Acceleration
     ! units: m s-1
     ! cell_methods: z_l:mean
@@ -1133,6 +2126,22 @@
     ! long_name: Time Mean Diffusive Zonal Thickness Flux
     ! units: kg s-1
     ! cell_methods: z_l:sum
+"ocean_model_d2", "uhGM"  [Unused]
+    ! long_name: Time Mean Diffusive Zonal Thickness Flux
+    ! units: kg s-1
+    ! cell_methods: xq:point yh:sum zl:sum
+"ocean_model_d2", "uhGM_xyave"  [Unused]
+    ! long_name: Time Mean Diffusive Zonal Thickness Flux
+    ! units: kg s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "uhGM"  [Unused]
+    ! long_name: Time Mean Diffusive Zonal Thickness Flux
+    ! units: kg s-1
+    ! cell_methods: xq:point yh:sum z_l:sum
+"ocean_model_z_d2", "uhGM_xyave"  [Unused]
+    ! long_name: Time Mean Diffusive Zonal Thickness Flux
+    ! units: kg s-1
+    ! cell_methods: z_l:sum
 "ocean_model", "vhGM"  [Unused]
     ! long_name: Time Mean Diffusive Meridional Thickness Flux
     ! units: kg s-1
@@ -1149,11 +2158,36 @@
     ! long_name: Time Mean Diffusive Meridional Thickness Flux
     ! units: kg s-1
     ! cell_methods: z_l:sum
+"ocean_model_d2", "vhGM"  [Unused]
+    ! long_name: Time Mean Diffusive Meridional Thickness Flux
+    ! units: kg s-1
+    ! cell_methods: xh:sum yq:point zl:sum
+"ocean_model_d2", "vhGM_xyave"  [Unused]
+    ! long_name: Time Mean Diffusive Meridional Thickness Flux
+    ! units: kg s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "vhGM"  [Unused]
+    ! long_name: Time Mean Diffusive Meridional Thickness Flux
+    ! units: kg s-1
+    ! cell_methods: xh:sum yq:point z_l:sum
+"ocean_model_z_d2", "vhGM_xyave"  [Unused]
+    ! long_name: Time Mean Diffusive Meridional Thickness Flux
+    ! units: kg s-1
+    ! cell_methods: z_l:sum
 "ocean_model", "GMwork"  [Used] (CMOR equivalent is "tnkebto")
     ! long_name: Integrated Tendency of Ocean Mesoscale Eddy KE from Parameterized Eddy Advection
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "tnkebto"  [Unused] (native name is "GMwork")
+    ! long_name: Integrated Tendency of Ocean Mesoscale Eddy KE from Parameterized Eddy Advection
+    ! units: W m-2
+    ! standard_name: tendency_of_ocean_eddy_kinetic_energy_content_due_to_parameterized_eddy_advection
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "GMwork"  [Unused] (CMOR equivalent is "tnkebto")
+    ! long_name: Integrated Tendency of Ocean Mesoscale Eddy KE from Parameterized Eddy Advection
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "tnkebto"  [Unused] (native name is "GMwork")
     ! long_name: Integrated Tendency of Ocean Mesoscale Eddy KE from Parameterized Eddy Advection
     ! units: W m-2
     ! standard_name: tendency_of_ocean_eddy_kinetic_energy_content_due_to_parameterized_eddy_advection
@@ -1174,6 +2208,22 @@
     ! long_name: Parameterized mesoscale eddy advection diffusivity at U-point
     ! units: m2 s-1
     ! cell_methods: z_i:point
+"ocean_model_d2", "KHTH_u"  [Unused]
+    ! long_name: Parameterized mesoscale eddy advection diffusivity at U-point
+    ! units: m2 s-1
+    ! cell_methods: xq:point yh:mean zi:point
+"ocean_model_d2", "KHTH_u_xyave"  [Unused]
+    ! long_name: Parameterized mesoscale eddy advection diffusivity at U-point
+    ! units: m2 s-1
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "KHTH_u"  [Unused]
+    ! long_name: Parameterized mesoscale eddy advection diffusivity at U-point
+    ! units: m2 s-1
+    ! cell_methods: xq:point yh:mean z_i:point
+"ocean_model_z_d2", "KHTH_u_xyave"  [Unused]
+    ! long_name: Parameterized mesoscale eddy advection diffusivity at U-point
+    ! units: m2 s-1
+    ! cell_methods: z_i:point
 "ocean_model", "KHTH_v"  [Used]
     ! long_name: Parameterized mesoscale eddy advection diffusivity at V-point
     ! units: m2 s-1
@@ -1187,6 +2237,22 @@
     ! units: m2 s-1
     ! cell_methods: xh:mean yq:point z_i:point
 "ocean_model_z", "KHTH_v_xyave"  [Unused]
+    ! long_name: Parameterized mesoscale eddy advection diffusivity at V-point
+    ! units: m2 s-1
+    ! cell_methods: z_i:point
+"ocean_model_d2", "KHTH_v"  [Unused]
+    ! long_name: Parameterized mesoscale eddy advection diffusivity at V-point
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yq:point zi:point
+"ocean_model_d2", "KHTH_v_xyave"  [Unused]
+    ! long_name: Parameterized mesoscale eddy advection diffusivity at V-point
+    ! units: m2 s-1
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "KHTH_v"  [Unused]
+    ! long_name: Parameterized mesoscale eddy advection diffusivity at V-point
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yq:point z_i:point
+"ocean_model_z_d2", "KHTH_v_xyave"  [Unused]
     ! long_name: Parameterized mesoscale eddy advection diffusivity at V-point
     ! units: m2 s-1
     ! cell_methods: z_i:point
@@ -1226,7 +2292,47 @@
     ! units: m2 s-1
     ! standard_name: ocean_tracer_diffusivity_due_to_parameterized_mesoscale_advection
     ! cell_methods: z_l:mean
+"ocean_model_d2", "KHTH_t"  [Unused] (CMOR equivalent is "diftrblo")
+    ! long_name: Ocean Tracer Diffusivity due to Parameterized Mesoscale Advection
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "KHTH_t_xyave"  [Unused] (CMOR equivalent is "diftrblo_xyave")
+    ! long_name: Ocean Tracer Diffusivity due to Parameterized Mesoscale Advection
+    ! units: m2 s-1
+    ! cell_methods: zl:mean
+"ocean_model_d2", "diftrblo"  [Unused] (native name is "KHTH_t")
+    ! long_name: Ocean Tracer Diffusivity due to Parameterized Mesoscale Advection
+    ! units: m2 s-1
+    ! standard_name: ocean_tracer_diffusivity_due_to_parameterized_mesoscale_advection
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "diftrblo_xyave"  [Unused] (native name is "KHTH_t_xyave")
+    ! long_name: Ocean Tracer Diffusivity due to Parameterized Mesoscale Advection
+    ! units: m2 s-1
+    ! standard_name: ocean_tracer_diffusivity_due_to_parameterized_mesoscale_advection
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "KHTH_t"  [Unused] (CMOR equivalent is "diftrblo")
+    ! long_name: Ocean Tracer Diffusivity due to Parameterized Mesoscale Advection
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "KHTH_t_xyave"  [Unused] (CMOR equivalent is "diftrblo_xyave")
+    ! long_name: Ocean Tracer Diffusivity due to Parameterized Mesoscale Advection
+    ! units: m2 s-1
+    ! cell_methods: z_l:mean
+"ocean_model_z_d2", "diftrblo"  [Unused] (native name is "KHTH_t")
+    ! long_name: Ocean Tracer Diffusivity due to Parameterized Mesoscale Advection
+    ! units: m2 s-1
+    ! standard_name: ocean_tracer_diffusivity_due_to_parameterized_mesoscale_advection
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "diftrblo_xyave"  [Unused] (native name is "KHTH_t_xyave")
+    ! long_name: Ocean Tracer Diffusivity due to Parameterized Mesoscale Advection
+    ! units: m2 s-1
+    ! standard_name: ocean_tracer_diffusivity_due_to_parameterized_mesoscale_advection
+    ! cell_methods: z_l:mean
 "ocean_model", "KHTH_u1"  [Unused]
+    ! long_name: Parameterized mesoscale eddy advection diffusivity at U-points (2-D)
+    ! units: m2 s-1
+    ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "KHTH_u1"  [Unused]
     ! long_name: Parameterized mesoscale eddy advection diffusivity at U-points (2-D)
     ! units: m2 s-1
     ! cell_methods: xq:point yh:mean
@@ -1234,7 +2340,15 @@
     ! long_name: Parameterized mesoscale eddy advection diffusivity at V-points (2-D)
     ! units: m2 s-1
     ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "KHTH_v1"  [Unused]
+    ! long_name: Parameterized mesoscale eddy advection diffusivity at V-points (2-D)
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yq:point
 "ocean_model", "KHTH_t1"  [Unused]
+    ! long_name: Parameterized mesoscale eddy advection diffusivity at T-points (2-D)
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "KHTH_t1"  [Unused]
     ! long_name: Parameterized mesoscale eddy advection diffusivity at T-points (2-D)
     ! units: m2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
@@ -1254,6 +2368,22 @@
     ! long_name: Zonal slope of neutral surface
     ! units: nondim
     ! cell_methods: z_i:point
+"ocean_model_d2", "neutral_slope_x"  [Unused]
+    ! long_name: Zonal slope of neutral surface
+    ! units: nondim
+    ! cell_methods: xq:point yh:mean zi:point
+"ocean_model_d2", "neutral_slope_x_xyave"  [Unused]
+    ! long_name: Zonal slope of neutral surface
+    ! units: nondim
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "neutral_slope_x"  [Unused]
+    ! long_name: Zonal slope of neutral surface
+    ! units: nondim
+    ! cell_methods: xq:point yh:mean z_i:point
+"ocean_model_z_d2", "neutral_slope_x_xyave"  [Unused]
+    ! long_name: Zonal slope of neutral surface
+    ! units: nondim
+    ! cell_methods: z_i:point
 "ocean_model", "neutral_slope_y"  [Unused]
     ! long_name: Meridional slope of neutral surface
     ! units: nondim
@@ -1267,6 +2397,22 @@
     ! units: nondim
     ! cell_methods: xh:mean yq:point z_i:point
 "ocean_model_z", "neutral_slope_y_xyave"  [Unused]
+    ! long_name: Meridional slope of neutral surface
+    ! units: nondim
+    ! cell_methods: z_i:point
+"ocean_model_d2", "neutral_slope_y"  [Unused]
+    ! long_name: Meridional slope of neutral surface
+    ! units: nondim
+    ! cell_methods: xh:mean yq:point zi:point
+"ocean_model_d2", "neutral_slope_y_xyave"  [Unused]
+    ! long_name: Meridional slope of neutral surface
+    ! units: nondim
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "neutral_slope_y"  [Unused]
+    ! long_name: Meridional slope of neutral surface
+    ! units: nondim
+    ! cell_methods: xh:mean yq:point z_i:point
+"ocean_model_z_d2", "neutral_slope_y_xyave"  [Unused]
     ! long_name: Meridional slope of neutral surface
     ! units: nondim
     ! cell_methods: z_i:point
@@ -1286,6 +2432,22 @@
     ! long_name: Parameterized Zonal Overturning Streamfunction
     ! units: m3 s-1
     ! cell_methods: z_i:point
+"ocean_model_d2", "GM_sfn_x"  [Unused]
+    ! long_name: Parameterized Zonal Overturning Streamfunction
+    ! units: m3 s-1
+    ! cell_methods: xq:point yh:mean zi:point
+"ocean_model_d2", "GM_sfn_x_xyave"  [Unused]
+    ! long_name: Parameterized Zonal Overturning Streamfunction
+    ! units: m3 s-1
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "GM_sfn_x"  [Unused]
+    ! long_name: Parameterized Zonal Overturning Streamfunction
+    ! units: m3 s-1
+    ! cell_methods: xq:point yh:mean z_i:point
+"ocean_model_z_d2", "GM_sfn_x_xyave"  [Unused]
+    ! long_name: Parameterized Zonal Overturning Streamfunction
+    ! units: m3 s-1
+    ! cell_methods: z_i:point
 "ocean_model", "GM_sfn_y"  [Unused]
     ! long_name: Parameterized Meridional Overturning Streamfunction
     ! units: m3 s-1
@@ -1299,6 +2461,22 @@
     ! units: m3 s-1
     ! cell_methods: xh:mean yq:point z_i:point
 "ocean_model_z", "GM_sfn_y_xyave"  [Unused]
+    ! long_name: Parameterized Meridional Overturning Streamfunction
+    ! units: m3 s-1
+    ! cell_methods: z_i:point
+"ocean_model_d2", "GM_sfn_y"  [Unused]
+    ! long_name: Parameterized Meridional Overturning Streamfunction
+    ! units: m3 s-1
+    ! cell_methods: xh:mean yq:point zi:point
+"ocean_model_d2", "GM_sfn_y_xyave"  [Unused]
+    ! long_name: Parameterized Meridional Overturning Streamfunction
+    ! units: m3 s-1
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "GM_sfn_y"  [Unused]
+    ! long_name: Parameterized Meridional Overturning Streamfunction
+    ! units: m3 s-1
+    ! cell_methods: xh:mean yq:point z_i:point
+"ocean_model_z_d2", "GM_sfn_y_xyave"  [Unused]
     ! long_name: Parameterized Meridional Overturning Streamfunction
     ! units: m3 s-1
     ! cell_methods: z_i:point
@@ -1318,6 +2496,22 @@
     ! long_name: Parameterized Zonal Overturning Streamfunction before limiting/smoothing
     ! units: m3 s-1
     ! cell_methods: z_i:point
+"ocean_model_d2", "GM_sfn_unlim_x"  [Unused]
+    ! long_name: Parameterized Zonal Overturning Streamfunction before limiting/smoothing
+    ! units: m3 s-1
+    ! cell_methods: xq:point yh:mean zi:point
+"ocean_model_d2", "GM_sfn_unlim_x_xyave"  [Unused]
+    ! long_name: Parameterized Zonal Overturning Streamfunction before limiting/smoothing
+    ! units: m3 s-1
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "GM_sfn_unlim_x"  [Unused]
+    ! long_name: Parameterized Zonal Overturning Streamfunction before limiting/smoothing
+    ! units: m3 s-1
+    ! cell_methods: xq:point yh:mean z_i:point
+"ocean_model_z_d2", "GM_sfn_unlim_x_xyave"  [Unused]
+    ! long_name: Parameterized Zonal Overturning Streamfunction before limiting/smoothing
+    ! units: m3 s-1
+    ! cell_methods: z_i:point
 "ocean_model", "GM_sfn_unlim_y"  [Unused]
     ! long_name: Parameterized Meridional Overturning Streamfunction before limiting/smoothing
     ! units: m3 s-1
@@ -1331,6 +2525,22 @@
     ! units: m3 s-1
     ! cell_methods: xh:mean yq:point z_i:point
 "ocean_model_z", "GM_sfn_unlim_y_xyave"  [Unused]
+    ! long_name: Parameterized Meridional Overturning Streamfunction before limiting/smoothing
+    ! units: m3 s-1
+    ! cell_methods: z_i:point
+"ocean_model_d2", "GM_sfn_unlim_y"  [Unused]
+    ! long_name: Parameterized Meridional Overturning Streamfunction before limiting/smoothing
+    ! units: m3 s-1
+    ! cell_methods: xh:mean yq:point zi:point
+"ocean_model_d2", "GM_sfn_unlim_y_xyave"  [Unused]
+    ! long_name: Parameterized Meridional Overturning Streamfunction before limiting/smoothing
+    ! units: m3 s-1
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "GM_sfn_unlim_y"  [Unused]
+    ! long_name: Parameterized Meridional Overturning Streamfunction before limiting/smoothing
+    ! units: m3 s-1
+    ! cell_methods: xh:mean yq:point z_i:point
+"ocean_model_z_d2", "GM_sfn_unlim_y_xyave"  [Unused]
     ! long_name: Parameterized Meridional Overturning Streamfunction before limiting/smoothing
     ! units: m3 s-1
     ! cell_methods: z_i:point
@@ -1350,6 +2560,22 @@
     ! long_name: Zonal Thickness Flux to Restratify Mixed Layer
     ! units: kg s-1
     ! cell_methods: z_l:sum
+"ocean_model_d2", "uhml"  [Unused]
+    ! long_name: Zonal Thickness Flux to Restratify Mixed Layer
+    ! units: kg s-1
+    ! cell_methods: xq:point yh:sum zl:sum
+"ocean_model_d2", "uhml_xyave"  [Unused]
+    ! long_name: Zonal Thickness Flux to Restratify Mixed Layer
+    ! units: kg s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "uhml"  [Unused]
+    ! long_name: Zonal Thickness Flux to Restratify Mixed Layer
+    ! units: kg s-1
+    ! cell_methods: xq:point yh:sum z_l:sum
+"ocean_model_z_d2", "uhml_xyave"  [Unused]
+    ! long_name: Zonal Thickness Flux to Restratify Mixed Layer
+    ! units: kg s-1
+    ! cell_methods: z_l:sum
 "ocean_model", "vhml"  [Unused]
     ! long_name: Meridional Thickness Flux to Restratify Mixed Layer
     ! units: kg s-1
@@ -1366,7 +2592,27 @@
     ! long_name: Meridional Thickness Flux to Restratify Mixed Layer
     ! units: kg s-1
     ! cell_methods: z_l:sum
+"ocean_model_d2", "vhml"  [Unused]
+    ! long_name: Meridional Thickness Flux to Restratify Mixed Layer
+    ! units: kg s-1
+    ! cell_methods: xh:sum yq:point zl:sum
+"ocean_model_d2", "vhml_xyave"  [Unused]
+    ! long_name: Meridional Thickness Flux to Restratify Mixed Layer
+    ! units: kg s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "vhml"  [Unused]
+    ! long_name: Meridional Thickness Flux to Restratify Mixed Layer
+    ! units: kg s-1
+    ! cell_methods: xh:sum yq:point z_l:sum
+"ocean_model_z_d2", "vhml_xyave"  [Unused]
+    ! long_name: Meridional Thickness Flux to Restratify Mixed Layer
+    ! units: kg s-1
+    ! cell_methods: z_l:sum
 "ocean_model", "MLu_restrat_time"  [Unused]
+    ! long_name: Mixed Layer Zonal Restratification Timescale
+    ! units: s
+    ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "MLu_restrat_time"  [Unused]
     ! long_name: Mixed Layer Zonal Restratification Timescale
     ! units: s
     ! cell_methods: xq:point yh:mean
@@ -1374,7 +2620,15 @@
     ! long_name: Mixed Layer Meridional Restratification Timescale
     ! units: s
     ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "MLv_restrat_time"  [Unused]
+    ! long_name: Mixed Layer Meridional Restratification Timescale
+    ! units: s
+    ! cell_methods: xh:mean yq:point
 "ocean_model", "MLD_restrat"  [Unused]
+    ! long_name: Mixed Layer Depth as used in the mixed-layer restratification parameterization
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "MLD_restrat"  [Unused]
     ! long_name: Mixed Layer Depth as used in the mixed-layer restratification parameterization
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
@@ -1382,7 +2636,15 @@
     ! long_name: Mixed Layer Buoyancy as used in the mixed-layer restratification parameterization
     ! units: m s2
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "ML_buoy_restrat"  [Unused]
+    ! long_name: Mixed Layer Buoyancy as used in the mixed-layer restratification parameterization
+    ! units: m s2
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "udml_restrat"  [Unused]
+    ! long_name: Transport stream function amplitude for zonal restratification of mixed layer
+    ! units: m3 s-1
+    ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "udml_restrat"  [Unused]
     ! long_name: Transport stream function amplitude for zonal restratification of mixed layer
     ! units: m3 s-1
     ! cell_methods: xq:point yh:mean
@@ -1390,11 +2652,23 @@
     ! long_name: Transport stream function amplitude for meridional restratification of mixed layer
     ! units: m3 s-1
     ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "vdml_restrat"  [Unused]
+    ! long_name: Transport stream function amplitude for meridional restratification of mixed layer
+    ! units: m3 s-1
+    ! cell_methods: xh:mean yq:point
 "ocean_model", "uml_restrat"  [Unused]
     ! long_name: Surface zonal velocity component of mixed layer restratification
     ! units: m s-1
     ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "uml_restrat"  [Unused]
+    ! long_name: Surface zonal velocity component of mixed layer restratification
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean
 "ocean_model", "vml_restrat"  [Unused]
+    ! long_name: Surface meridional velocity component of mixed layer restratification
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "vml_restrat"  [Unused]
     ! long_name: Surface meridional velocity component of mixed layer restratification
     ! units: m s-1
     ! cell_methods: xh:mean yq:point
@@ -1414,6 +2688,26 @@
     ! standard_name: sea_water_mass_per_unit_area
     ! cell_methods: xh:mean yh:mean z_l:sum area:mean
 "ocean_model_z", "masscello_xyave"  [Unused]
+    ! long_name: Mass per unit area of liquid ocean grid cell
+    ! units: kg m-2
+    ! standard_name: sea_water_mass_per_unit_area
+    ! cell_methods: z_l:sum
+"ocean_model_d2", "masscello"  [Unused]
+    ! long_name: Mass per unit area of liquid ocean grid cell
+    ! units: kg m-2
+    ! standard_name: sea_water_mass_per_unit_area
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "masscello_xyave"  [Unused]
+    ! long_name: Mass per unit area of liquid ocean grid cell
+    ! units: kg m-2
+    ! standard_name: sea_water_mass_per_unit_area
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "masscello"  [Unused]
+    ! long_name: Mass per unit area of liquid ocean grid cell
+    ! units: kg m-2
+    ! standard_name: sea_water_mass_per_unit_area
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "masscello_xyave"  [Unused]
     ! long_name: Mass per unit area of liquid ocean grid cell
     ! units: kg m-2
     ! standard_name: sea_water_mass_per_unit_area
@@ -1442,6 +2736,26 @@
     ! units: m
     ! standard_name: cell_thickness
     ! cell_methods: z_l:sum
+"ocean_model_d2", "thkcello"  [Unused]
+    ! long_name: Cell Thickness
+    ! units: m
+    ! standard_name: cell_thickness
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "thkcello_xyave"  [Unused]
+    ! long_name: Cell Thickness
+    ! units: m
+    ! standard_name: cell_thickness
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "thkcello"  [Unused]
+    ! long_name: Cell Thickness
+    ! units: m
+    ! standard_name: cell_thickness
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "thkcello_xyave"  [Unused]
+    ! long_name: Cell Thickness
+    ! units: m
+    ! standard_name: cell_thickness
+    ! cell_methods: z_l:sum
 "ocean_model", "h_pre_sync"  [Unused]
     ! long_name: Cell thickness from the previous timestep
     ! units: m
@@ -1458,7 +2772,28 @@
     ! long_name: Cell thickness from the previous timestep
     ! units: m
     ! cell_methods: z_l:sum
+"ocean_model_d2", "h_pre_sync"  [Unused]
+    ! long_name: Cell thickness from the previous timestep
+    ! units: m
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "h_pre_sync_xyave"  [Unused]
+    ! long_name: Cell thickness from the previous timestep
+    ! units: m
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "h_pre_sync"  [Unused]
+    ! long_name: Cell thickness from the previous timestep
+    ! units: m
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "h_pre_sync_xyave"  [Unused]
+    ! long_name: Cell thickness from the previous timestep
+    ! units: m
+    ! cell_methods: z_l:sum
 "ocean_model", "tob"  [Unused]
+    ! long_name: Sea Water Potential Temperature at Sea Floor
+    ! units: degC
+    ! standard_name: sea_water_potential_temperature_at_sea_floor
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "tob"  [Unused]
     ! long_name: Sea Water Potential Temperature at Sea Floor
     ! units: degC
     ! standard_name: sea_water_potential_temperature_at_sea_floor
@@ -1468,11 +2803,24 @@
     ! units: psu
     ! standard_name: sea_water_salinity_at_sea_floor
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "sob"  [Unused]
+    ! long_name: Sea Water Salinity at Sea Floor
+    ! units: psu
+    ! standard_name: sea_water_salinity_at_sea_floor
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "temp_layer_ave"  [Used]
     ! long_name: Layer Average Ocean Temperature
     ! units: degC
     ! cell_methods: zl:mean
+"ocean_model_d2", "temp_layer_ave"  [Unused]
+    ! long_name: Layer Average Ocean Temperature
+    ! units: degC
+    ! cell_methods: zl:mean
 "ocean_model", "salt_layer_ave"  [Used]
+    ! long_name: Layer Average Ocean Salinity
+    ! units: psu
+    ! cell_methods: zl:mean
+"ocean_model_d2", "salt_layer_ave"  [Unused]
     ! long_name: Layer Average Ocean Salinity
     ! units: psu
     ! cell_methods: zl:mean
@@ -1536,6 +2884,42 @@
     ! units: m s-1
     ! standard_name: sea_water_x_velocity
     ! cell_methods: z_l:mean
+"ocean_model_d2", "u"  [Unused] (CMOR equivalent is "uo")
+    ! long_name: Zonal velocity
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean zl:mean
+"ocean_model_d2", "u_xyave"  [Unused] (CMOR equivalent is "uo_xyave")
+    ! long_name: Zonal velocity
+    ! units: m s-1
+    ! cell_methods: zl:mean
+"ocean_model_d2", "uo"  [Unused] (native name is "u")
+    ! long_name: Sea Water X Velocity
+    ! units: m s-1
+    ! standard_name: sea_water_x_velocity
+    ! cell_methods: xq:point yh:mean zl:mean
+"ocean_model_d2", "uo_xyave"  [Unused] (native name is "u_xyave")
+    ! long_name: Sea Water X Velocity
+    ! units: m s-1
+    ! standard_name: sea_water_x_velocity
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "u"  [Unused] (CMOR equivalent is "uo")
+    ! long_name: Zonal velocity
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean z_l:mean
+"ocean_model_z_d2", "u_xyave"  [Unused] (CMOR equivalent is "uo_xyave")
+    ! long_name: Zonal velocity
+    ! units: m s-1
+    ! cell_methods: z_l:mean
+"ocean_model_z_d2", "uo"  [Unused] (native name is "u")
+    ! long_name: Sea Water X Velocity
+    ! units: m s-1
+    ! standard_name: sea_water_x_velocity
+    ! cell_methods: xq:point yh:mean z_l:mean
+"ocean_model_z_d2", "uo_xyave"  [Unused] (native name is "u_xyave")
+    ! long_name: Sea Water X Velocity
+    ! units: m s-1
+    ! standard_name: sea_water_x_velocity
+    ! cell_methods: z_l:mean
 "ocean_model", "v"  [Used] (CMOR equivalent is "vo")
     ! long_name: Meridional velocity
     ! units: m s-1
@@ -1572,6 +2956,42 @@
     ! units: m s-1
     ! standard_name: sea_water_y_velocity
     ! cell_methods: z_l:mean
+"ocean_model_d2", "v"  [Unused] (CMOR equivalent is "vo")
+    ! long_name: Meridional velocity
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point zl:mean
+"ocean_model_d2", "v_xyave"  [Unused] (CMOR equivalent is "vo_xyave")
+    ! long_name: Meridional velocity
+    ! units: m s-1
+    ! cell_methods: zl:mean
+"ocean_model_d2", "vo"  [Unused] (native name is "v")
+    ! long_name: Sea Water Y Velocity
+    ! units: m s-1
+    ! standard_name: sea_water_y_velocity
+    ! cell_methods: xh:mean yq:point zl:mean
+"ocean_model_d2", "vo_xyave"  [Unused] (native name is "v_xyave")
+    ! long_name: Sea Water Y Velocity
+    ! units: m s-1
+    ! standard_name: sea_water_y_velocity
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "v"  [Unused] (CMOR equivalent is "vo")
+    ! long_name: Meridional velocity
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point z_l:mean
+"ocean_model_z_d2", "v_xyave"  [Unused] (CMOR equivalent is "vo_xyave")
+    ! long_name: Meridional velocity
+    ! units: m s-1
+    ! cell_methods: z_l:mean
+"ocean_model_z_d2", "vo"  [Unused] (native name is "v")
+    ! long_name: Sea Water Y Velocity
+    ! units: m s-1
+    ! standard_name: sea_water_y_velocity
+    ! cell_methods: xh:mean yq:point z_l:mean
+"ocean_model_z_d2", "vo_xyave"  [Unused] (native name is "v_xyave")
+    ! long_name: Sea Water Y Velocity
+    ! units: m s-1
+    ! standard_name: sea_water_y_velocity
+    ! cell_methods: z_l:mean
 "ocean_model", "h"  [Used]
     ! long_name: Layer Thickness
     ! units: m
@@ -1585,6 +3005,22 @@
     ! units: m
     ! cell_methods: xh:mean yh:mean z_l:sum area:mean
 "ocean_model_z", "h_xyave"  [Unused]
+    ! long_name: Layer Thickness
+    ! units: m
+    ! cell_methods: z_l:sum
+"ocean_model_d2", "h"  [Unused]
+    ! long_name: Layer Thickness
+    ! units: m
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "h_xyave"  [Unused]
+    ! long_name: Layer Thickness
+    ! units: m
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "h"  [Unused]
+    ! long_name: Layer Thickness
+    ! units: m
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "h_xyave"  [Unused]
     ! long_name: Layer Thickness
     ! units: m
     ! cell_methods: z_l:sum
@@ -1604,6 +3040,22 @@
     ! long_name: Interface Height Relative to Mean Sea Level
     ! units: m
     ! cell_methods: z_i:point
+"ocean_model_d2", "e"  [Unused]
+    ! long_name: Interface Height Relative to Mean Sea Level
+    ! units: m
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "e_xyave"  [Unused]
+    ! long_name: Interface Height Relative to Mean Sea Level
+    ! units: m
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "e"  [Unused]
+    ! long_name: Interface Height Relative to Mean Sea Level
+    ! units: m
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "e_xyave"  [Unused]
+    ! long_name: Interface Height Relative to Mean Sea Level
+    ! units: m
+    ! cell_methods: z_i:point
 "ocean_model", "e_D"  [Unused]
     ! long_name: Interface Height above the Seafloor
     ! units: m
@@ -1617,6 +3069,22 @@
     ! units: m
     ! cell_methods: xh:mean yh:mean z_i:point area:mean
 "ocean_model_z", "e_D_xyave"  [Unused]
+    ! long_name: Interface Height above the Seafloor
+    ! units: m
+    ! cell_methods: z_i:point
+"ocean_model_d2", "e_D"  [Unused]
+    ! long_name: Interface Height above the Seafloor
+    ! units: m
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "e_D_xyave"  [Unused]
+    ! long_name: Interface Height above the Seafloor
+    ! units: m
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "e_D"  [Unused]
+    ! long_name: Interface Height above the Seafloor
+    ! units: m
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "e_D_xyave"  [Unused]
     ! long_name: Interface Height above the Seafloor
     ! units: m
     ! cell_methods: z_i:point
@@ -1636,6 +3104,22 @@
     ! long_name: Mixed Layer Coordinate Potential Density
     ! units: kg m-3
     ! cell_methods: z_l:mean
+"ocean_model_d2", "Rml"  [Unused]
+    ! long_name: Mixed Layer Coordinate Potential Density
+    ! units: kg m-3
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "Rml_xyave"  [Unused]
+    ! long_name: Mixed Layer Coordinate Potential Density
+    ! units: kg m-3
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "Rml"  [Unused]
+    ! long_name: Mixed Layer Coordinate Potential Density
+    ! units: kg m-3
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "Rml_xyave"  [Unused]
+    ! long_name: Mixed Layer Coordinate Potential Density
+    ! units: kg m-3
+    ! cell_methods: z_l:mean
 "ocean_model", "Rho_cv"  [Unused]
     ! long_name: Coordinate Potential Density
     ! units: kg m-3
@@ -1649,6 +3133,22 @@
     ! units: kg m-3
     ! cell_methods: xh:mean yh:mean z_l:mean area:mean
 "ocean_model_z", "Rho_cv_xyave"  [Unused]
+    ! long_name: Coordinate Potential Density
+    ! units: kg m-3
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "Rho_cv"  [Unused]
+    ! long_name: Coordinate Potential Density
+    ! units: kg m-3
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "Rho_cv_xyave"  [Unused]
+    ! long_name: Coordinate Potential Density
+    ! units: kg m-3
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "Rho_cv"  [Unused]
+    ! long_name: Coordinate Potential Density
+    ! units: kg m-3
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "Rho_cv_xyave"  [Unused]
     ! long_name: Coordinate Potential Density
     ! units: kg m-3
     ! cell_methods: z_l:mean
@@ -1668,6 +3168,22 @@
     ! long_name: Potential density referenced to surface
     ! units: kg m-3
     ! cell_methods: z_l:mean
+"ocean_model_d2", "rhopot0"  [Unused]
+    ! long_name: Potential density referenced to surface
+    ! units: kg m-3
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "rhopot0_xyave"  [Unused]
+    ! long_name: Potential density referenced to surface
+    ! units: kg m-3
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "rhopot0"  [Unused]
+    ! long_name: Potential density referenced to surface
+    ! units: kg m-3
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "rhopot0_xyave"  [Unused]
+    ! long_name: Potential density referenced to surface
+    ! units: kg m-3
+    ! cell_methods: z_l:mean
 "ocean_model", "rhopot2"  [Unused]
     ! long_name: Potential density referenced to 2000 dbar
     ! units: kg m-3
@@ -1681,6 +3197,22 @@
     ! units: kg m-3
     ! cell_methods: xh:mean yh:mean z_l:mean area:mean
 "ocean_model_z", "rhopot2_xyave"  [Unused]
+    ! long_name: Potential density referenced to 2000 dbar
+    ! units: kg m-3
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "rhopot2"  [Unused]
+    ! long_name: Potential density referenced to 2000 dbar
+    ! units: kg m-3
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "rhopot2_xyave"  [Unused]
+    ! long_name: Potential density referenced to 2000 dbar
+    ! units: kg m-3
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "rhopot2"  [Unused]
+    ! long_name: Potential density referenced to 2000 dbar
+    ! units: kg m-3
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "rhopot2_xyave"  [Unused]
     ! long_name: Potential density referenced to 2000 dbar
     ! units: kg m-3
     ! cell_methods: z_l:mean
@@ -1700,6 +3232,22 @@
     ! long_name: In situ density
     ! units: kg m-3
     ! cell_methods: z_l:mean
+"ocean_model_d2", "rhoinsitu"  [Unused]
+    ! long_name: In situ density
+    ! units: kg m-3
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "rhoinsitu_xyave"  [Unused]
+    ! long_name: In situ density
+    ! units: kg m-3
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "rhoinsitu"  [Unused]
+    ! long_name: In situ density
+    ! units: kg m-3
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "rhoinsitu_xyave"  [Unused]
+    ! long_name: In situ density
+    ! units: kg m-3
+    ! cell_methods: z_l:mean
 "ocean_model", "dudt"  [Unused]
     ! long_name: Zonal Acceleration
     ! units: m s-2
@@ -1713,6 +3261,22 @@
     ! units: m s-2
     ! cell_methods: xq:point yh:mean z_l:mean
 "ocean_model_z", "dudt_xyave"  [Unused]
+    ! long_name: Zonal Acceleration
+    ! units: m s-2
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "dudt"  [Unused]
+    ! long_name: Zonal Acceleration
+    ! units: m s-2
+    ! cell_methods: xq:point yh:mean zl:mean
+"ocean_model_d2", "dudt_xyave"  [Unused]
+    ! long_name: Zonal Acceleration
+    ! units: m s-2
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "dudt"  [Unused]
+    ! long_name: Zonal Acceleration
+    ! units: m s-2
+    ! cell_methods: xq:point yh:mean z_l:mean
+"ocean_model_z_d2", "dudt_xyave"  [Unused]
     ! long_name: Zonal Acceleration
     ! units: m s-2
     ! cell_methods: z_l:mean
@@ -1732,6 +3296,22 @@
     ! long_name: Meridional Acceleration
     ! units: m s-2
     ! cell_methods: z_l:mean
+"ocean_model_d2", "dvdt"  [Unused]
+    ! long_name: Meridional Acceleration
+    ! units: m s-2
+    ! cell_methods: xh:mean yq:point zl:mean
+"ocean_model_d2", "dvdt_xyave"  [Unused]
+    ! long_name: Meridional Acceleration
+    ! units: m s-2
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "dvdt"  [Unused]
+    ! long_name: Meridional Acceleration
+    ! units: m s-2
+    ! cell_methods: xh:mean yq:point z_l:mean
+"ocean_model_z_d2", "dvdt_xyave"  [Unused]
+    ! long_name: Meridional Acceleration
+    ! units: m s-2
+    ! cell_methods: z_l:mean
 "ocean_model", "dhdt"  [Unused]
     ! long_name: Thickness tendency
     ! units: m s-1
@@ -1745,6 +3325,22 @@
     ! units: m s-1
     ! cell_methods: xh:mean yh:mean z_l:sum area:mean
 "ocean_model_z", "dhdt_xyave"  [Unused]
+    ! long_name: Thickness tendency
+    ! units: m s-1
+    ! cell_methods: z_l:sum
+"ocean_model_d2", "dhdt"  [Unused]
+    ! long_name: Thickness tendency
+    ! units: m s-1
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "dhdt_xyave"  [Unused]
+    ! long_name: Thickness tendency
+    ! units: m s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "dhdt"  [Unused]
+    ! long_name: Thickness tendency
+    ! units: m s-1
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "dhdt_xyave"  [Unused]
     ! long_name: Thickness tendency
     ! units: m s-1
     ! cell_methods: z_l:sum
@@ -1764,6 +3360,22 @@
     ! long_name: Layer thicknesses in pure potential density coordinates
     ! units: m
     ! cell_methods: z_l:mean
+"ocean_model_d2", "h_rho"  [Unused]
+    ! long_name: Layer thicknesses in pure potential density coordinates
+    ! units: m
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "h_rho_xyave"  [Unused]
+    ! long_name: Layer thicknesses in pure potential density coordinates
+    ! units: m
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "h_rho"  [Unused]
+    ! long_name: Layer thicknesses in pure potential density coordinates
+    ! units: m
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "h_rho_xyave"  [Unused]
+    ! long_name: Layer thicknesses in pure potential density coordinates
+    ! units: m
+    ! cell_methods: z_l:mean
 "ocean_model", "uh_rho"  [Used]
     ! long_name: Zonal volume transport in pure potential density coordinates
     ! units: m3 s-1
@@ -1777,6 +3389,22 @@
     ! units: m3 s-1
     ! cell_methods: xq:point yh:mean z_l:mean
 "ocean_model_z", "uh_rho_xyave"  [Unused]
+    ! long_name: Zonal volume transport in pure potential density coordinates
+    ! units: m3 s-1
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "uh_rho"  [Unused]
+    ! long_name: Zonal volume transport in pure potential density coordinates
+    ! units: m3 s-1
+    ! cell_methods: xq:point yh:mean zl:mean
+"ocean_model_d2", "uh_rho_xyave"  [Unused]
+    ! long_name: Zonal volume transport in pure potential density coordinates
+    ! units: m3 s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "uh_rho"  [Unused]
+    ! long_name: Zonal volume transport in pure potential density coordinates
+    ! units: m3 s-1
+    ! cell_methods: xq:point yh:mean z_l:mean
+"ocean_model_z_d2", "uh_rho_xyave"  [Unused]
     ! long_name: Zonal volume transport in pure potential density coordinates
     ! units: m3 s-1
     ! cell_methods: z_l:mean
@@ -1796,6 +3424,22 @@
     ! long_name: Meridional volume transport in pure potential density coordinates
     ! units: m3 s-1
     ! cell_methods: z_l:mean
+"ocean_model_d2", "vh_rho"  [Unused]
+    ! long_name: Meridional volume transport in pure potential density coordinates
+    ! units: m3 s-1
+    ! cell_methods: xh:mean yq:point zl:mean
+"ocean_model_d2", "vh_rho_xyave"  [Unused]
+    ! long_name: Meridional volume transport in pure potential density coordinates
+    ! units: m3 s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "vh_rho"  [Unused]
+    ! long_name: Meridional volume transport in pure potential density coordinates
+    ! units: m3 s-1
+    ! cell_methods: xh:mean yq:point z_l:mean
+"ocean_model_z_d2", "vh_rho_xyave"  [Unused]
+    ! long_name: Meridional volume transport in pure potential density coordinates
+    ! units: m3 s-1
+    ! cell_methods: z_l:mean
 "ocean_model", "uhGM_rho"  [Used]
     ! long_name: Zonal volume transport due to interface height diffusion in pure potential density coordinates
     ! units: m3 s-1
@@ -1809,6 +3453,22 @@
     ! units: m3 s-1
     ! cell_methods: xq:point yh:mean z_l:mean
 "ocean_model_z", "uhGM_rho_xyave"  [Unused]
+    ! long_name: Zonal volume transport due to interface height diffusion in pure potential density coordinates
+    ! units: m3 s-1
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "uhGM_rho"  [Unused]
+    ! long_name: Zonal volume transport due to interface height diffusion in pure potential density coordinates
+    ! units: m3 s-1
+    ! cell_methods: xq:point yh:mean zl:mean
+"ocean_model_d2", "uhGM_rho_xyave"  [Unused]
+    ! long_name: Zonal volume transport due to interface height diffusion in pure potential density coordinates
+    ! units: m3 s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "uhGM_rho"  [Unused]
+    ! long_name: Zonal volume transport due to interface height diffusion in pure potential density coordinates
+    ! units: m3 s-1
+    ! cell_methods: xq:point yh:mean z_l:mean
+"ocean_model_z_d2", "uhGM_rho_xyave"  [Unused]
     ! long_name: Zonal volume transport due to interface height diffusion in pure potential density coordinates
     ! units: m3 s-1
     ! cell_methods: z_l:mean
@@ -1828,6 +3488,22 @@
     ! long_name: Meridional volume transport due to interface height diffusion in pure potential density coordinates
     ! units: m3 s-1
     ! cell_methods: z_l:mean
+"ocean_model_d2", "vhGM_rho"  [Unused]
+    ! long_name: Meridional volume transport due to interface height diffusion in pure potential density coordinates
+    ! units: m3 s-1
+    ! cell_methods: xh:mean yq:point zl:mean
+"ocean_model_d2", "vhGM_rho_xyave"  [Unused]
+    ! long_name: Meridional volume transport due to interface height diffusion in pure potential density coordinates
+    ! units: m3 s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "vhGM_rho"  [Unused]
+    ! long_name: Meridional volume transport due to interface height diffusion in pure potential density coordinates
+    ! units: m3 s-1
+    ! cell_methods: xh:mean yq:point z_l:mean
+"ocean_model_z_d2", "vhGM_rho_xyave"  [Unused]
+    ! long_name: Meridional volume transport due to interface height diffusion in pure potential density coordinates
+    ! units: m3 s-1
+    ! cell_methods: z_l:mean
 "ocean_model", "KE"  [Unused]
     ! long_name: Layer kinetic energy per unit mass
     ! units: m2 s-2
@@ -1841,6 +3517,22 @@
     ! units: m2 s-2
     ! cell_methods: xh:mean yh:mean z_l:mean area:mean
 "ocean_model_z", "KE_xyave"  [Unused]
+    ! long_name: Layer kinetic energy per unit mass
+    ! units: m2 s-2
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "KE"  [Unused]
+    ! long_name: Layer kinetic energy per unit mass
+    ! units: m2 s-2
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "KE_xyave"  [Unused]
+    ! long_name: Layer kinetic energy per unit mass
+    ! units: m2 s-2
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "KE"  [Unused]
+    ! long_name: Layer kinetic energy per unit mass
+    ! units: m2 s-2
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "KE_xyave"  [Unused]
     ! long_name: Layer kinetic energy per unit mass
     ! units: m2 s-2
     ! cell_methods: z_l:mean
@@ -1860,6 +3552,22 @@
     ! long_name: Kinetic Energy Tendency of Layer
     ! units: m3 s-3
     ! cell_methods: z_l:mean
+"ocean_model_d2", "dKE_dt"  [Unused]
+    ! long_name: Kinetic Energy Tendency of Layer
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "dKE_dt_xyave"  [Unused]
+    ! long_name: Kinetic Energy Tendency of Layer
+    ! units: m3 s-3
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "dKE_dt"  [Unused]
+    ! long_name: Kinetic Energy Tendency of Layer
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "dKE_dt_xyave"  [Unused]
+    ! long_name: Kinetic Energy Tendency of Layer
+    ! units: m3 s-3
+    ! cell_methods: z_l:mean
 "ocean_model", "PE_to_KE"  [Unused]
     ! long_name: Potential to Kinetic Energy Conversion of Layer
     ! units: m3 s-3
@@ -1873,6 +3581,22 @@
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean z_l:mean area:mean
 "ocean_model_z", "PE_to_KE_xyave"  [Unused]
+    ! long_name: Potential to Kinetic Energy Conversion of Layer
+    ! units: m3 s-3
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "PE_to_KE"  [Unused]
+    ! long_name: Potential to Kinetic Energy Conversion of Layer
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "PE_to_KE_xyave"  [Unused]
+    ! long_name: Potential to Kinetic Energy Conversion of Layer
+    ! units: m3 s-3
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "PE_to_KE"  [Unused]
+    ! long_name: Potential to Kinetic Energy Conversion of Layer
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "PE_to_KE_xyave"  [Unused]
     ! long_name: Potential to Kinetic Energy Conversion of Layer
     ! units: m3 s-3
     ! cell_methods: z_l:mean
@@ -1892,6 +3616,22 @@
     ! long_name: Kinetic Energy Source from Coriolis and Advection
     ! units: m3 s-3
     ! cell_methods: z_l:mean
+"ocean_model_d2", "KE_Coradv"  [Unused]
+    ! long_name: Kinetic Energy Source from Coriolis and Advection
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "KE_Coradv_xyave"  [Unused]
+    ! long_name: Kinetic Energy Source from Coriolis and Advection
+    ! units: m3 s-3
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "KE_Coradv"  [Unused]
+    ! long_name: Kinetic Energy Source from Coriolis and Advection
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "KE_Coradv_xyave"  [Unused]
+    ! long_name: Kinetic Energy Source from Coriolis and Advection
+    ! units: m3 s-3
+    ! cell_methods: z_l:mean
 "ocean_model", "KE_adv"  [Unused]
     ! long_name: Kinetic Energy Source from Advection
     ! units: m3 s-3
@@ -1905,6 +3645,22 @@
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean z_l:mean area:mean
 "ocean_model_z", "KE_adv_xyave"  [Unused]
+    ! long_name: Kinetic Energy Source from Advection
+    ! units: m3 s-3
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "KE_adv"  [Unused]
+    ! long_name: Kinetic Energy Source from Advection
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "KE_adv_xyave"  [Unused]
+    ! long_name: Kinetic Energy Source from Advection
+    ! units: m3 s-3
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "KE_adv"  [Unused]
+    ! long_name: Kinetic Energy Source from Advection
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "KE_adv_xyave"  [Unused]
     ! long_name: Kinetic Energy Source from Advection
     ! units: m3 s-3
     ! cell_methods: z_l:mean
@@ -1924,6 +3680,22 @@
     ! long_name: Kinetic Energy Source from Vertical Viscosity and Stresses
     ! units: m3 s-3
     ! cell_methods: z_l:mean
+"ocean_model_d2", "KE_visc"  [Unused]
+    ! long_name: Kinetic Energy Source from Vertical Viscosity and Stresses
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "KE_visc_xyave"  [Unused]
+    ! long_name: Kinetic Energy Source from Vertical Viscosity and Stresses
+    ! units: m3 s-3
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "KE_visc"  [Unused]
+    ! long_name: Kinetic Energy Source from Vertical Viscosity and Stresses
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "KE_visc_xyave"  [Unused]
+    ! long_name: Kinetic Energy Source from Vertical Viscosity and Stresses
+    ! units: m3 s-3
+    ! cell_methods: z_l:mean
 "ocean_model", "KE_horvisc"  [Unused]
     ! long_name: Kinetic Energy Source from Horizontal Viscosity
     ! units: m3 s-3
@@ -1937,6 +3709,22 @@
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean z_l:mean area:mean
 "ocean_model_z", "KE_horvisc_xyave"  [Unused]
+    ! long_name: Kinetic Energy Source from Horizontal Viscosity
+    ! units: m3 s-3
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "KE_horvisc"  [Unused]
+    ! long_name: Kinetic Energy Source from Horizontal Viscosity
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "KE_horvisc_xyave"  [Unused]
+    ! long_name: Kinetic Energy Source from Horizontal Viscosity
+    ! units: m3 s-3
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "KE_horvisc"  [Unused]
+    ! long_name: Kinetic Energy Source from Horizontal Viscosity
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "KE_horvisc_xyave"  [Unused]
     ! long_name: Kinetic Energy Source from Horizontal Viscosity
     ! units: m3 s-3
     ! cell_methods: z_l:mean
@@ -1956,7 +3744,27 @@
     ! long_name: Kinetic Energy Source from Diapycnal Diffusion
     ! units: m3 s-3
     ! cell_methods: z_l:mean
+"ocean_model_d2", "KE_dia"  [Unused]
+    ! long_name: Kinetic Energy Source from Diapycnal Diffusion
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "KE_dia_xyave"  [Unused]
+    ! long_name: Kinetic Energy Source from Diapycnal Diffusion
+    ! units: m3 s-3
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "KE_dia"  [Unused]
+    ! long_name: Kinetic Energy Source from Diapycnal Diffusion
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "KE_dia_xyave"  [Unused]
+    ! long_name: Kinetic Energy Source from Diapycnal Diffusion
+    ! units: m3 s-3
+    ! cell_methods: z_l:mean
 "ocean_model", "cg1"  [Unused]
+    ! long_name: First baroclinic gravity wave speed
+    ! units: m s-1
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "cg1"  [Unused]
     ! long_name: First baroclinic gravity wave speed
     ! units: m s-1
     ! cell_methods: xh:mean yh:mean area:mean
@@ -1964,7 +3772,15 @@
     ! long_name: First baroclinic deformation radius
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "Rd1"  [Unused]
+    ! long_name: First baroclinic deformation radius
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "CFL_cg1"  [Unused]
+    ! long_name: CFL of first baroclinic gravity wave = dt*cg1*(1/dx+1/dy)
+    ! units: nondim
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "CFL_cg1"  [Unused]
     ! long_name: CFL of first baroclinic gravity wave = dt*cg1*(1/dx+1/dy)
     ! units: nondim
     ! cell_methods: xh:mean yh:mean area:mean
@@ -1972,7 +3788,15 @@
     ! long_name: i-component of CFL of first baroclinic gravity wave = dt*cg1*/dx
     ! units: nondim
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "CFL_cg1_x"  [Unused]
+    ! long_name: i-component of CFL of first baroclinic gravity wave = dt*cg1*/dx
+    ! units: nondim
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "CFL_cg1_y"  [Unused]
+    ! long_name: j-component of CFL of first baroclinic gravity wave = dt*cg1*/dy
+    ! units: nondim
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "CFL_cg1_y"  [Unused]
     ! long_name: j-component of CFL of first baroclinic gravity wave = dt*cg1*/dy
     ! units: nondim
     ! cell_methods: xh:mean yh:mean area:mean
@@ -1980,7 +3804,15 @@
     ! long_name: Equivalent barotropic gravity wave speed
     ! units: m s-1
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "cg_ebt"  [Unused]
+    ! long_name: Equivalent barotropic gravity wave speed
+    ! units: m s-1
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "Rd_ebt"  [Unused]
+    ! long_name: Equivalent barotropic deformation radius
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "Rd_ebt"  [Unused]
     ! long_name: Equivalent barotropic deformation radius
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
@@ -2000,7 +3832,27 @@
     ! long_name: Equivalent barotropic modal strcuture
     ! units: nondim
     ! cell_methods: z_l:mean
-"ocean_model", "mass_wt"  [Used]
+"ocean_model_d2", "p_ebt"  [Unused]
+    ! long_name: Equivalent barotropic modal strcuture
+    ! units: nondim
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "p_ebt_xyave"  [Unused]
+    ! long_name: Equivalent barotropic modal strcuture
+    ! units: nondim
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "p_ebt"  [Unused]
+    ! long_name: Equivalent barotropic modal strcuture
+    ! units: nondim
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "p_ebt_xyave"  [Unused]
+    ! long_name: Equivalent barotropic modal strcuture
+    ! units: nondim
+    ! cell_methods: z_l:mean
+"ocean_model", "mass_wt"  [Unused]
+    ! long_name: The column mass for calculating mass-weighted average properties
+    ! units: kg m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "mass_wt"  [Unused]
     ! long_name: The column mass for calculating mass-weighted average properties
     ! units: kg m-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -2009,6 +3861,15 @@
     ! units: degC kg m-2
     ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "opottempmint"  [Used] (native name is "temp_int")
+    ! long_name: integral_wrt_depth_of_product_of_sea_water_density_and_potential_temperature
+    ! units: degC kg m-2
+    ! standard_name: Depth integrated density times potential temperature
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "temp_int"  [Unused] (CMOR equivalent is "opottempmint")
+    ! long_name: Density weighted column integrated potential temperature
+    ! units: degC kg m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "opottempmint"  [Unused] (native name is "temp_int")
     ! long_name: integral_wrt_depth_of_product_of_sea_water_density_and_potential_temperature
     ! units: degC kg m-2
     ! standard_name: Depth integrated density times potential temperature
@@ -2022,7 +3883,20 @@
     ! units: psu kg m-2
     ! standard_name: Depth integrated density times salinity
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "salt_int"  [Unused] (CMOR equivalent is "somint")
+    ! long_name: Density weighted column integrated salinity
+    ! units: psu kg m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "somint"  [Unused] (native name is "salt_int")
+    ! long_name: integral_wrt_depth_of_product_of_sea_water_density_and_salinity
+    ! units: psu kg m-2
+    ! standard_name: Depth integrated density times salinity
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "col_mass"  [Unused]
+    ! long_name: The column integrated in situ density
+    ! units: kg m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "col_mass"  [Unused]
     ! long_name: The column integrated in situ density
     ! units: kg m-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -2030,7 +3904,16 @@
     ! long_name: The height of the water column
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "col_height"  [Unused]
+    ! long_name: The height of the water column
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "pbo"  [Used]
+    ! long_name: Sea Water Pressure at Sea Floor
+    ! units: Pa
+    ! standard_name: sea_water_pressure_at_sea_floor
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "pbo"  [Unused]
     ! long_name: Sea Water Pressure at Sea Floor
     ! units: Pa
     ! standard_name: sea_water_pressure_at_sea_floor
@@ -2071,6 +3954,22 @@
     ! long_name: Layer (heat) entrainment from above per timestep
     ! units: m
     ! cell_methods: z_l:mean
+"ocean_model_d2", "ea_t"  [Unused]
+    ! long_name: Layer (heat) entrainment from above per timestep
+    ! units: m
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "ea_t_xyave"  [Unused]
+    ! long_name: Layer (heat) entrainment from above per timestep
+    ! units: m
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "ea_t"  [Unused]
+    ! long_name: Layer (heat) entrainment from above per timestep
+    ! units: m
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "ea_t_xyave"  [Unused]
+    ! long_name: Layer (heat) entrainment from above per timestep
+    ! units: m
+    ! cell_methods: z_l:mean
 "ocean_model", "eb_t"  [Unused]
     ! long_name: Layer (heat) entrainment from below per timestep
     ! units: m
@@ -2084,6 +3983,22 @@
     ! units: m
     ! cell_methods: xh:mean yh:mean z_l:mean area:mean
 "ocean_model_z", "eb_t_xyave"  [Unused]
+    ! long_name: Layer (heat) entrainment from below per timestep
+    ! units: m
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "eb_t"  [Unused]
+    ! long_name: Layer (heat) entrainment from below per timestep
+    ! units: m
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "eb_t_xyave"  [Unused]
+    ! long_name: Layer (heat) entrainment from below per timestep
+    ! units: m
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "eb_t"  [Unused]
+    ! long_name: Layer (heat) entrainment from below per timestep
+    ! units: m
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "eb_t_xyave"  [Unused]
     ! long_name: Layer (heat) entrainment from below per timestep
     ! units: m
     ! cell_methods: z_l:mean
@@ -2103,6 +4018,22 @@
     ! long_name: Layer (salt) entrainment from above per timestep
     ! units: m
     ! cell_methods: z_l:mean
+"ocean_model_d2", "ea_s"  [Unused]
+    ! long_name: Layer (salt) entrainment from above per timestep
+    ! units: m
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "ea_s_xyave"  [Unused]
+    ! long_name: Layer (salt) entrainment from above per timestep
+    ! units: m
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "ea_s"  [Unused]
+    ! long_name: Layer (salt) entrainment from above per timestep
+    ! units: m
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "ea_s_xyave"  [Unused]
+    ! long_name: Layer (salt) entrainment from above per timestep
+    ! units: m
+    ! cell_methods: z_l:mean
 "ocean_model", "eb_s"  [Unused]
     ! long_name: Layer (salt) entrainment from below per timestep
     ! units: m
@@ -2116,6 +4047,22 @@
     ! units: m
     ! cell_methods: xh:mean yh:mean z_l:mean area:mean
 "ocean_model_z", "eb_s_xyave"  [Unused]
+    ! long_name: Layer (salt) entrainment from below per timestep
+    ! units: m
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "eb_s"  [Unused]
+    ! long_name: Layer (salt) entrainment from below per timestep
+    ! units: m
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "eb_s_xyave"  [Unused]
+    ! long_name: Layer (salt) entrainment from below per timestep
+    ! units: m
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "eb_s"  [Unused]
+    ! long_name: Layer (salt) entrainment from below per timestep
+    ! units: m
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "eb_s_xyave"  [Unused]
     ! long_name: Layer (salt) entrainment from below per timestep
     ! units: m
     ! cell_methods: z_l:mean
@@ -2135,6 +4082,22 @@
     ! long_name: Layer entrainment from above per timestep
     ! units: m
     ! cell_methods: z_l:mean
+"ocean_model_d2", "ea"  [Unused]
+    ! long_name: Layer entrainment from above per timestep
+    ! units: m
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "ea_xyave"  [Unused]
+    ! long_name: Layer entrainment from above per timestep
+    ! units: m
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "ea"  [Unused]
+    ! long_name: Layer entrainment from above per timestep
+    ! units: m
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "ea_xyave"  [Unused]
+    ! long_name: Layer entrainment from above per timestep
+    ! units: m
+    ! cell_methods: z_l:mean
 "ocean_model", "eb"  [Unused]
     ! long_name: Layer entrainment from below per timestep
     ! units: m
@@ -2148,6 +4111,22 @@
     ! units: m
     ! cell_methods: xh:mean yh:mean z_l:mean area:mean
 "ocean_model_z", "eb_xyave"  [Unused]
+    ! long_name: Layer entrainment from below per timestep
+    ! units: m
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "eb"  [Unused]
+    ! long_name: Layer entrainment from below per timestep
+    ! units: m
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "eb_xyave"  [Unused]
+    ! long_name: Layer entrainment from below per timestep
+    ! units: m
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "eb"  [Unused]
+    ! long_name: Layer entrainment from below per timestep
+    ! units: m
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "eb_xyave"  [Unused]
     ! long_name: Layer entrainment from below per timestep
     ! units: m
     ! cell_methods: z_l:mean
@@ -2167,6 +4146,22 @@
     ! long_name: Diapycnal velocity
     ! units: m s-1
     ! cell_methods: z_i:point
+"ocean_model_d2", "wd"  [Unused]
+    ! long_name: Diapycnal velocity
+    ! units: m s-1
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "wd_xyave"  [Unused]
+    ! long_name: Diapycnal velocity
+    ! units: m s-1
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "wd"  [Unused]
+    ! long_name: Diapycnal velocity
+    ! units: m s-1
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "wd_xyave"  [Unused]
+    ! long_name: Diapycnal velocity
+    ! units: m s-1
+    ! cell_methods: z_i:point
 "ocean_model", "dudt_dia"  [Unused]
     ! long_name: Zonal Acceleration from Diapycnal Mixing
     ! units: m s-2
@@ -2180,6 +4175,22 @@
     ! units: m s-2
     ! cell_methods: xq:point yh:mean z_l:mean
 "ocean_model_z", "dudt_dia_xyave"  [Unused]
+    ! long_name: Zonal Acceleration from Diapycnal Mixing
+    ! units: m s-2
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "dudt_dia"  [Unused]
+    ! long_name: Zonal Acceleration from Diapycnal Mixing
+    ! units: m s-2
+    ! cell_methods: xq:point yh:mean zl:mean
+"ocean_model_d2", "dudt_dia_xyave"  [Unused]
+    ! long_name: Zonal Acceleration from Diapycnal Mixing
+    ! units: m s-2
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "dudt_dia"  [Unused]
+    ! long_name: Zonal Acceleration from Diapycnal Mixing
+    ! units: m s-2
+    ! cell_methods: xq:point yh:mean z_l:mean
+"ocean_model_z_d2", "dudt_dia_xyave"  [Unused]
     ! long_name: Zonal Acceleration from Diapycnal Mixing
     ! units: m s-2
     ! cell_methods: z_l:mean
@@ -2199,6 +4210,22 @@
     ! long_name: Meridional Acceleration from Diapycnal Mixing
     ! units: m s-2
     ! cell_methods: z_l:mean
+"ocean_model_d2", "dvdt_dia"  [Unused]
+    ! long_name: Meridional Acceleration from Diapycnal Mixing
+    ! units: m s-2
+    ! cell_methods: xh:mean yq:point zl:mean
+"ocean_model_d2", "dvdt_dia_xyave"  [Unused]
+    ! long_name: Meridional Acceleration from Diapycnal Mixing
+    ! units: m s-2
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "dvdt_dia"  [Unused]
+    ! long_name: Meridional Acceleration from Diapycnal Mixing
+    ! units: m s-2
+    ! cell_methods: xh:mean yq:point z_l:mean
+"ocean_model_z_d2", "dvdt_dia_xyave"  [Unused]
+    ! long_name: Meridional Acceleration from Diapycnal Mixing
+    ! units: m s-2
+    ! cell_methods: z_l:mean
 "ocean_model", "Tflx_dia_diff"  [Unused]
     ! long_name: Diffusive diapycnal temperature flux across interfaces
     ! units: degC m s-1
@@ -2212,6 +4239,22 @@
     ! units: degC m s-1
     ! cell_methods: xh:mean yh:mean z_i:point area:mean
 "ocean_model_z", "Tflx_dia_diff_xyave"  [Unused]
+    ! long_name: Diffusive diapycnal temperature flux across interfaces
+    ! units: degC m s-1
+    ! cell_methods: z_i:point
+"ocean_model_d2", "Tflx_dia_diff"  [Unused]
+    ! long_name: Diffusive diapycnal temperature flux across interfaces
+    ! units: degC m s-1
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "Tflx_dia_diff_xyave"  [Unused]
+    ! long_name: Diffusive diapycnal temperature flux across interfaces
+    ! units: degC m s-1
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "Tflx_dia_diff"  [Unused]
+    ! long_name: Diffusive diapycnal temperature flux across interfaces
+    ! units: degC m s-1
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "Tflx_dia_diff_xyave"  [Unused]
     ! long_name: Diffusive diapycnal temperature flux across interfaces
     ! units: degC m s-1
     ! cell_methods: z_i:point
@@ -2231,6 +4274,22 @@
     ! long_name: Advective diapycnal temperature flux across interfaces
     ! units: degC m s-1
     ! cell_methods: z_i:point
+"ocean_model_d2", "Tflx_dia_adv"  [Unused]
+    ! long_name: Advective diapycnal temperature flux across interfaces
+    ! units: degC m s-1
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "Tflx_dia_adv_xyave"  [Unused]
+    ! long_name: Advective diapycnal temperature flux across interfaces
+    ! units: degC m s-1
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "Tflx_dia_adv"  [Unused]
+    ! long_name: Advective diapycnal temperature flux across interfaces
+    ! units: degC m s-1
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "Tflx_dia_adv_xyave"  [Unused]
+    ! long_name: Advective diapycnal temperature flux across interfaces
+    ! units: degC m s-1
+    ! cell_methods: z_i:point
 "ocean_model", "Sflx_dia_diff"  [Unused]
     ! long_name: Diffusive diapycnal salnity flux across interfaces
     ! units: psu m s-1
@@ -2244,6 +4303,22 @@
     ! units: psu m s-1
     ! cell_methods: xh:mean yh:mean z_i:point area:mean
 "ocean_model_z", "Sflx_dia_diff_xyave"  [Unused]
+    ! long_name: Diffusive diapycnal salnity flux across interfaces
+    ! units: psu m s-1
+    ! cell_methods: z_i:point
+"ocean_model_d2", "Sflx_dia_diff"  [Unused]
+    ! long_name: Diffusive diapycnal salnity flux across interfaces
+    ! units: psu m s-1
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "Sflx_dia_diff_xyave"  [Unused]
+    ! long_name: Diffusive diapycnal salnity flux across interfaces
+    ! units: psu m s-1
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "Sflx_dia_diff"  [Unused]
+    ! long_name: Diffusive diapycnal salnity flux across interfaces
+    ! units: psu m s-1
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "Sflx_dia_diff_xyave"  [Unused]
     ! long_name: Diffusive diapycnal salnity flux across interfaces
     ! units: psu m s-1
     ! cell_methods: z_i:point
@@ -2263,6 +4338,22 @@
     ! long_name: Advective diapycnal salnity flux across interfaces
     ! units: psu m s-1
     ! cell_methods: z_i:point
+"ocean_model_d2", "Sflx_dia_adv"  [Unused]
+    ! long_name: Advective diapycnal salnity flux across interfaces
+    ! units: psu m s-1
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "Sflx_dia_adv_xyave"  [Unused]
+    ! long_name: Advective diapycnal salnity flux across interfaces
+    ! units: psu m s-1
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "Sflx_dia_adv"  [Unused]
+    ! long_name: Advective diapycnal salnity flux across interfaces
+    ! units: psu m s-1
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "Sflx_dia_adv_xyave"  [Unused]
+    ! long_name: Advective diapycnal salnity flux across interfaces
+    ! units: psu m s-1
+    ! cell_methods: z_i:point
 "ocean_model", "MLD_003"  [Used] (CMOR equivalent is "mlotst")
     ! long_name: Mixed layer depth (delta rho = 0.03)
     ! units: m
@@ -2272,7 +4363,21 @@
     ! units: m
     ! standard_name: ocean_mixed_layer_thickness_defined_by_sigma_t
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "MLD_003"  [Unused] (CMOR equivalent is "mlotst")
+    ! long_name: Mixed layer depth (delta rho = 0.03)
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "mlotst"  [Unused] (native name is "MLD_003")
+    ! long_name: Ocean Mixed Layer Thickness Defined by Sigma T
+    ! units: m
+    ! standard_name: ocean_mixed_layer_thickness_defined_by_sigma_t
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "mlotstsq"  [Used]
+    ! long_name: Square of Ocean Mixed Layer Thickness Defined by Sigma T
+    ! units: m2
+    ! standard_name: square_of_ocean_mixed_layer_thickness_defined_by_sigma_t
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "mlotstsq"  [Unused]
     ! long_name: Square of Ocean Mixed Layer Thickness Defined by Sigma T
     ! units: m2
     ! standard_name: square_of_ocean_mixed_layer_thickness_defined_by_sigma_t
@@ -2281,11 +4386,23 @@
     ! long_name: Mixed layer depth (delta rho = 0.125)
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "MLD_0125"  [Unused]
+    ! long_name: Mixed layer depth (delta rho = 0.125)
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "subML_N2"  [Used]
     ! long_name: Squared buoyancy frequency below mixed layer
     ! units: s-2
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "subML_N2"  [Unused]
+    ! long_name: Squared buoyancy frequency below mixed layer
+    ! units: s-2
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "MLD_user"  [Unused]
+    ! long_name: Mixed layer depth (used defined)
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "MLD_user"  [Unused]
     ! long_name: Mixed layer depth (used defined)
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
@@ -2320,6 +4437,22 @@
     ! long_name: Zonal velocity before diabatic forcing
     ! units: m s-1
     ! cell_methods: z_l:mean
+"ocean_model_d2", "u_predia"  [Unused]
+    ! long_name: Zonal velocity before diabatic forcing
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean zl:mean
+"ocean_model_d2", "u_predia_xyave"  [Unused]
+    ! long_name: Zonal velocity before diabatic forcing
+    ! units: m s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "u_predia"  [Unused]
+    ! long_name: Zonal velocity before diabatic forcing
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean z_l:mean
+"ocean_model_z_d2", "u_predia_xyave"  [Unused]
+    ! long_name: Zonal velocity before diabatic forcing
+    ! units: m s-1
+    ! cell_methods: z_l:mean
 "ocean_model", "v_predia"  [Unused]
     ! long_name: Meridional velocity before diabatic forcing
     ! units: m s-1
@@ -2333,6 +4466,22 @@
     ! units: m s-1
     ! cell_methods: xh:mean yq:point z_l:mean
 "ocean_model_z", "v_predia_xyave"  [Unused]
+    ! long_name: Meridional velocity before diabatic forcing
+    ! units: m s-1
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "v_predia"  [Unused]
+    ! long_name: Meridional velocity before diabatic forcing
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point zl:mean
+"ocean_model_d2", "v_predia_xyave"  [Unused]
+    ! long_name: Meridional velocity before diabatic forcing
+    ! units: m s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "v_predia"  [Unused]
+    ! long_name: Meridional velocity before diabatic forcing
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point z_l:mean
+"ocean_model_z_d2", "v_predia_xyave"  [Unused]
     ! long_name: Meridional velocity before diabatic forcing
     ! units: m s-1
     ! cell_methods: z_l:mean
@@ -2352,6 +4501,22 @@
     ! long_name: Layer Thickness before diabatic forcing
     ! units: m
     ! cell_methods: z_l:sum
+"ocean_model_d2", "h_predia"  [Unused]
+    ! long_name: Layer Thickness before diabatic forcing
+    ! units: m
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "h_predia_xyave"  [Unused]
+    ! long_name: Layer Thickness before diabatic forcing
+    ! units: m
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "h_predia"  [Unused]
+    ! long_name: Layer Thickness before diabatic forcing
+    ! units: m
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "h_predia_xyave"  [Unused]
+    ! long_name: Layer Thickness before diabatic forcing
+    ! units: m
+    ! cell_methods: z_l:sum
 "ocean_model", "e_predia"  [Unused]
     ! long_name: Interface Heights before diabatic forcing
     ! units: m
@@ -2365,6 +4530,22 @@
     ! units: m
     ! cell_methods: xh:mean yh:mean z_i:point area:mean
 "ocean_model_z", "e_predia_xyave"  [Unused]
+    ! long_name: Interface Heights before diabatic forcing
+    ! units: m
+    ! cell_methods: z_i:point
+"ocean_model_d2", "e_predia"  [Unused]
+    ! long_name: Interface Heights before diabatic forcing
+    ! units: m
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "e_predia_xyave"  [Unused]
+    ! long_name: Interface Heights before diabatic forcing
+    ! units: m
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "e_predia"  [Unused]
+    ! long_name: Interface Heights before diabatic forcing
+    ! units: m
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "e_predia_xyave"  [Unused]
     ! long_name: Interface Heights before diabatic forcing
     ! units: m
     ! cell_methods: z_i:point
@@ -2384,6 +4565,22 @@
     ! long_name: Potential Temperature
     ! units: degC
     ! cell_methods: z_l:mean
+"ocean_model_d2", "temp_predia"  [Unused]
+    ! long_name: Potential Temperature
+    ! units: degC
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "temp_predia_xyave"  [Unused]
+    ! long_name: Potential Temperature
+    ! units: degC
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "temp_predia"  [Unused]
+    ! long_name: Potential Temperature
+    ! units: degC
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "temp_predia_xyave"  [Unused]
+    ! long_name: Potential Temperature
+    ! units: degC
+    ! cell_methods: z_l:mean
 "ocean_model", "salt_predia"  [Unused]
     ! long_name: Salinity
     ! units: PSU
@@ -2397,6 +4594,22 @@
     ! units: PSU
     ! cell_methods: xh:mean yh:mean z_l:mean area:mean
 "ocean_model_z", "salt_predia_xyave"  [Unused]
+    ! long_name: Salinity
+    ! units: PSU
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "salt_predia"  [Unused]
+    ! long_name: Salinity
+    ! units: PSU
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "salt_predia_xyave"  [Unused]
+    ! long_name: Salinity
+    ! units: PSU
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "salt_predia"  [Unused]
+    ! long_name: Salinity
+    ! units: PSU
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "salt_predia_xyave"  [Unused]
     ! long_name: Salinity
     ! units: PSU
     ! cell_methods: z_l:mean
@@ -2416,6 +4629,22 @@
     ! long_name: Total diapycnal diffusivity at interfaces
     ! units: m2 s-1
     ! cell_methods: z_i:point
+"ocean_model_d2", "Kd_interface"  [Unused]
+    ! long_name: Total diapycnal diffusivity at interfaces
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "Kd_interface_xyave"  [Unused]
+    ! long_name: Total diapycnal diffusivity at interfaces
+    ! units: m2 s-1
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "Kd_interface"  [Unused]
+    ! long_name: Total diapycnal diffusivity at interfaces
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "Kd_interface_xyave"  [Unused]
+    ! long_name: Total diapycnal diffusivity at interfaces
+    ! units: m2 s-1
+    ! cell_methods: z_i:point
 "ocean_model", "Kd_ePBL"  [Unused]
     ! long_name: ePBL diapycnal diffusivity at interfaces
     ! units: m2 s-1
@@ -2429,6 +4658,22 @@
     ! units: m2 s-1
     ! cell_methods: xh:mean yh:mean z_i:point area:mean
 "ocean_model_z", "Kd_ePBL_xyave"  [Unused]
+    ! long_name: ePBL diapycnal diffusivity at interfaces
+    ! units: m2 s-1
+    ! cell_methods: z_i:point
+"ocean_model_d2", "Kd_ePBL"  [Unused]
+    ! long_name: ePBL diapycnal diffusivity at interfaces
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "Kd_ePBL_xyave"  [Unused]
+    ! long_name: ePBL diapycnal diffusivity at interfaces
+    ! units: m2 s-1
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "Kd_ePBL"  [Unused]
+    ! long_name: ePBL diapycnal diffusivity at interfaces
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "Kd_ePBL_xyave"  [Unused]
     ! long_name: ePBL diapycnal diffusivity at interfaces
     ! units: m2 s-1
     ! cell_methods: z_i:point
@@ -2464,6 +4709,42 @@
     ! standard_name: ocean_vertical_heat_diffusivity
     ! cell_methods: xh:mean yh:mean z_i:point area:mean
 "ocean_model_z", "difvho_xyave"  [Unused] (native name is "Kd_heat_xyave")
+    ! long_name: Ocean vertical heat diffusivity
+    ! units: m2 s-1
+    ! standard_name: ocean_vertical_heat_diffusivity
+    ! cell_methods: z_i:point
+"ocean_model_d2", "Kd_heat"  [Unused] (CMOR equivalent is "difvho")
+    ! long_name: Total diapycnal diffusivity for heat at interfaces
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "Kd_heat_xyave"  [Unused] (CMOR equivalent is "difvho_xyave")
+    ! long_name: Total diapycnal diffusivity for heat at interfaces
+    ! units: m2 s-1
+    ! cell_methods: zi:point
+"ocean_model_d2", "difvho"  [Unused] (native name is "Kd_heat")
+    ! long_name: Ocean vertical heat diffusivity
+    ! units: m2 s-1
+    ! standard_name: ocean_vertical_heat_diffusivity
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "difvho_xyave"  [Unused] (native name is "Kd_heat_xyave")
+    ! long_name: Ocean vertical heat diffusivity
+    ! units: m2 s-1
+    ! standard_name: ocean_vertical_heat_diffusivity
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "Kd_heat"  [Unused] (CMOR equivalent is "difvho")
+    ! long_name: Total diapycnal diffusivity for heat at interfaces
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "Kd_heat_xyave"  [Unused] (CMOR equivalent is "difvho_xyave")
+    ! long_name: Total diapycnal diffusivity for heat at interfaces
+    ! units: m2 s-1
+    ! cell_methods: z_i:point
+"ocean_model_z_d2", "difvho"  [Unused] (native name is "Kd_heat")
+    ! long_name: Ocean vertical heat diffusivity
+    ! units: m2 s-1
+    ! standard_name: ocean_vertical_heat_diffusivity
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "difvho_xyave"  [Unused] (native name is "Kd_heat_xyave")
     ! long_name: Ocean vertical heat diffusivity
     ! units: m2 s-1
     ! standard_name: ocean_vertical_heat_diffusivity
@@ -2504,6 +4785,42 @@
     ! units: m2 s-1
     ! standard_name: ocean_vertical_salt_diffusivity
     ! cell_methods: z_i:point
+"ocean_model_d2", "Kd_salt"  [Unused] (CMOR equivalent is "difvso")
+    ! long_name: Total diapycnal diffusivity for salt at interfaces
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "Kd_salt_xyave"  [Unused] (CMOR equivalent is "difvso_xyave")
+    ! long_name: Total diapycnal diffusivity for salt at interfaces
+    ! units: m2 s-1
+    ! cell_methods: zi:point
+"ocean_model_d2", "difvso"  [Unused] (native name is "Kd_salt")
+    ! long_name: Ocean vertical salt diffusivity
+    ! units: m2 s-1
+    ! standard_name: ocean_vertical_salt_diffusivity
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "difvso_xyave"  [Unused] (native name is "Kd_salt_xyave")
+    ! long_name: Ocean vertical salt diffusivity
+    ! units: m2 s-1
+    ! standard_name: ocean_vertical_salt_diffusivity
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "Kd_salt"  [Unused] (CMOR equivalent is "difvso")
+    ! long_name: Total diapycnal diffusivity for salt at interfaces
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "Kd_salt_xyave"  [Unused] (CMOR equivalent is "difvso_xyave")
+    ! long_name: Total diapycnal diffusivity for salt at interfaces
+    ! units: m2 s-1
+    ! cell_methods: z_i:point
+"ocean_model_z_d2", "difvso"  [Unused] (native name is "Kd_salt")
+    ! long_name: Ocean vertical salt diffusivity
+    ! units: m2 s-1
+    ! standard_name: ocean_vertical_salt_diffusivity
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "difvso_xyave"  [Unused] (native name is "Kd_salt_xyave")
+    ! long_name: Ocean vertical salt diffusivity
+    ! units: m2 s-1
+    ! standard_name: ocean_vertical_salt_diffusivity
+    ! cell_methods: z_i:point
 "ocean_model", "diabatic_diff_h"  [Unused]
     ! long_name: Cell thickness used during diabatic diffusion
     ! units: m
@@ -2517,6 +4834,22 @@
     ! units: m
     ! cell_methods: xh:mean yh:mean z_l:sum area:mean
 "ocean_model_z", "diabatic_diff_h_xyave"  [Unused]
+    ! long_name: Cell thickness used during diabatic diffusion
+    ! units: m
+    ! cell_methods: z_l:sum
+"ocean_model_d2", "diabatic_diff_h"  [Unused]
+    ! long_name: Cell thickness used during diabatic diffusion
+    ! units: m
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "diabatic_diff_h_xyave"  [Unused]
+    ! long_name: Cell thickness used during diabatic diffusion
+    ! units: m
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "diabatic_diff_h"  [Unused]
+    ! long_name: Cell thickness used during diabatic diffusion
+    ! units: m
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "diabatic_diff_h_xyave"  [Unused]
     ! long_name: Cell thickness used during diabatic diffusion
     ! units: m
     ! cell_methods: z_l:sum
@@ -2536,6 +4869,22 @@
     ! long_name: Diabatic diffusion temperature tendency
     ! units: degC s-1
     ! cell_methods: z_l:mean
+"ocean_model_d2", "diabatic_diff_temp_tendency"  [Unused]
+    ! long_name: Diabatic diffusion temperature tendency
+    ! units: degC s-1
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "diabatic_diff_temp_tendency_xyave"  [Unused]
+    ! long_name: Diabatic diffusion temperature tendency
+    ! units: degC s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "diabatic_diff_temp_tendency"  [Unused]
+    ! long_name: Diabatic diffusion temperature tendency
+    ! units: degC s-1
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "diabatic_diff_temp_tendency_xyave"  [Unused]
+    ! long_name: Diabatic diffusion temperature tendency
+    ! units: degC s-1
+    ! cell_methods: z_l:mean
 "ocean_model", "diabatic_diff_saln_tendency"  [Unused]
     ! long_name: Diabatic diffusion salinity tendency
     ! units: psu s-1
@@ -2549,6 +4898,22 @@
     ! units: psu s-1
     ! cell_methods: xh:mean yh:mean z_l:mean area:mean
 "ocean_model_z", "diabatic_diff_saln_tendency_xyave"  [Unused]
+    ! long_name: Diabatic diffusion salinity tendency
+    ! units: psu s-1
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "diabatic_diff_saln_tendency"  [Unused]
+    ! long_name: Diabatic diffusion salinity tendency
+    ! units: psu s-1
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "diabatic_diff_saln_tendency_xyave"  [Unused]
+    ! long_name: Diabatic diffusion salinity tendency
+    ! units: psu s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "diabatic_diff_saln_tendency"  [Unused]
+    ! long_name: Diabatic diffusion salinity tendency
+    ! units: psu s-1
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "diabatic_diff_saln_tendency_xyave"  [Unused]
     ! long_name: Diabatic diffusion salinity tendency
     ! units: psu s-1
     ! cell_methods: z_l:mean
@@ -2584,6 +4949,42 @@
     ! standard_name: tendency_of_sea_water_potential_temperature_expressed_as_heat_content_due_to_parameterized_dianeutral_mixing
     ! cell_methods: xh:mean yh:mean z_l:sum area:mean
 "ocean_model_z", "opottempdiff_xyave"  [Unused] (native name is "diabatic_heat_tendency_xyave")
+    ! long_name: Tendency of sea water potential temperature expressed as heat content due to parameterized dianeutral mixing
+    ! units: W m-2
+    ! standard_name: tendency_of_sea_water_potential_temperature_expressed_as_heat_content_due_to_parameterized_dianeutral_mixing
+    ! cell_methods: z_l:sum
+"ocean_model_d2", "diabatic_heat_tendency"  [Unused] (CMOR equivalent is "opottempdiff")
+    ! long_name: Diabatic diffusion heat tendency
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "diabatic_heat_tendency_xyave"  [Unused] (CMOR equivalent is "opottempdiff_xyave")
+    ! long_name: Diabatic diffusion heat tendency
+    ! units: W m-2
+    ! cell_methods: zl:sum
+"ocean_model_d2", "opottempdiff"  [Unused] (native name is "diabatic_heat_tendency")
+    ! long_name: Tendency of sea water potential temperature expressed as heat content due to parameterized dianeutral mixing
+    ! units: W m-2
+    ! standard_name: tendency_of_sea_water_potential_temperature_expressed_as_heat_content_due_to_parameterized_dianeutral_mixing
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "opottempdiff_xyave"  [Unused] (native name is "diabatic_heat_tendency_xyave")
+    ! long_name: Tendency of sea water potential temperature expressed as heat content due to parameterized dianeutral mixing
+    ! units: W m-2
+    ! standard_name: tendency_of_sea_water_potential_temperature_expressed_as_heat_content_due_to_parameterized_dianeutral_mixing
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "diabatic_heat_tendency"  [Unused] (CMOR equivalent is "opottempdiff")
+    ! long_name: Diabatic diffusion heat tendency
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "diabatic_heat_tendency_xyave"  [Unused] (CMOR equivalent is "opottempdiff_xyave")
+    ! long_name: Diabatic diffusion heat tendency
+    ! units: W m-2
+    ! cell_methods: z_l:sum
+"ocean_model_z_d2", "opottempdiff"  [Unused] (native name is "diabatic_heat_tendency")
+    ! long_name: Tendency of sea water potential temperature expressed as heat content due to parameterized dianeutral mixing
+    ! units: W m-2
+    ! standard_name: tendency_of_sea_water_potential_temperature_expressed_as_heat_content_due_to_parameterized_dianeutral_mixing
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "opottempdiff_xyave"  [Unused] (native name is "diabatic_heat_tendency_xyave")
     ! long_name: Tendency of sea water potential temperature expressed as heat content due to parameterized dianeutral mixing
     ! units: W m-2
     ! standard_name: tendency_of_sea_water_potential_temperature_expressed_as_heat_content_due_to_parameterized_dianeutral_mixing
@@ -2624,6 +5025,42 @@
     ! units: kg m-2 s-1
     ! standard_name: tendency_of_sea_water_salinity_expressed_as_salt_content_due_to_parameterized_dianeutral_mixing
     ! cell_methods: z_l:sum
+"ocean_model_d2", "diabatic_salt_tendency"  [Unused] (CMOR equivalent is "osaltdiff")
+    ! long_name: Diabatic diffusion of salt tendency
+    ! units: kg m-2 s-1
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "diabatic_salt_tendency_xyave"  [Unused] (CMOR equivalent is "osaltdiff_xyave")
+    ! long_name: Diabatic diffusion of salt tendency
+    ! units: kg m-2 s-1
+    ! cell_methods: zl:sum
+"ocean_model_d2", "osaltdiff"  [Unused] (native name is "diabatic_salt_tendency")
+    ! long_name: Tendency of sea water salinity expressed as salt content due to parameterized dianeutral mixing
+    ! units: kg m-2 s-1
+    ! standard_name: tendency_of_sea_water_salinity_expressed_as_salt_content_due_to_parameterized_dianeutral_mixing
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "osaltdiff_xyave"  [Unused] (native name is "diabatic_salt_tendency_xyave")
+    ! long_name: Tendency of sea water salinity expressed as salt content due to parameterized dianeutral mixing
+    ! units: kg m-2 s-1
+    ! standard_name: tendency_of_sea_water_salinity_expressed_as_salt_content_due_to_parameterized_dianeutral_mixing
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "diabatic_salt_tendency"  [Unused] (CMOR equivalent is "osaltdiff")
+    ! long_name: Diabatic diffusion of salt tendency
+    ! units: kg m-2 s-1
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "diabatic_salt_tendency_xyave"  [Unused] (CMOR equivalent is "osaltdiff_xyave")
+    ! long_name: Diabatic diffusion of salt tendency
+    ! units: kg m-2 s-1
+    ! cell_methods: z_l:sum
+"ocean_model_z_d2", "osaltdiff"  [Unused] (native name is "diabatic_salt_tendency")
+    ! long_name: Tendency of sea water salinity expressed as salt content due to parameterized dianeutral mixing
+    ! units: kg m-2 s-1
+    ! standard_name: tendency_of_sea_water_salinity_expressed_as_salt_content_due_to_parameterized_dianeutral_mixing
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "osaltdiff_xyave"  [Unused] (native name is "diabatic_salt_tendency_xyave")
+    ! long_name: Tendency of sea water salinity expressed as salt content due to parameterized dianeutral mixing
+    ! units: kg m-2 s-1
+    ! standard_name: tendency_of_sea_water_salinity_expressed_as_salt_content_due_to_parameterized_dianeutral_mixing
+    ! cell_methods: z_l:sum
 "ocean_model", "diabatic_heat_tendency_2d"  [Unused] (CMOR equivalent is "opottempdiff_2d")
     ! long_name: Depth integrated diabatic diffusion heat tendency
     ! units: W m-2
@@ -2633,11 +5070,29 @@
     ! units: W m-2
     ! standard_name: tendency_of_sea_water_potential_temperature_expressed_as_heat_content_due_to_parameterized_dianeutral_mixing_depth_integrated
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "diabatic_heat_tendency_2d"  [Unused] (CMOR equivalent is "opottempdiff_2d")
+    ! long_name: Depth integrated diabatic diffusion heat tendency
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "opottempdiff_2d"  [Unused] (native name is "diabatic_heat_tendency_2d")
+    ! long_name: Tendency of sea water potential temperature expressed as heat content due to parameterized dianeutral mixing depth integrated
+    ! units: W m-2
+    ! standard_name: tendency_of_sea_water_potential_temperature_expressed_as_heat_content_due_to_parameterized_dianeutral_mixing_depth_integrated
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "diabatic_salt_tendency_2d"  [Unused] (CMOR equivalent is "osaltdiff_2d")
     ! long_name: Depth integrated diabatic diffusion salt tendency
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "osaltdiff_2d"  [Unused] (native name is "diabatic_salt_tendency_2d")
+    ! long_name: Tendency of sea water salinity expressed as salt content due to parameterized dianeutral mixing depth integrated
+    ! units: kg m-2 s-1
+    ! standard_name: tendency_of_sea_water_salinity_expressed_as_salt_content_due_to_parameterized_dianeutral_mixing_depth_integrated
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "diabatic_salt_tendency_2d"  [Unused] (CMOR equivalent is "osaltdiff_2d")
+    ! long_name: Depth integrated diabatic diffusion salt tendency
+    ! units: kg m-2 s-1
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "osaltdiff_2d"  [Unused] (native name is "diabatic_salt_tendency_2d")
     ! long_name: Tendency of sea water salinity expressed as salt content due to parameterized dianeutral mixing depth integrated
     ! units: kg m-2 s-1
     ! standard_name: tendency_of_sea_water_salinity_expressed_as_salt_content_due_to_parameterized_dianeutral_mixing_depth_integrated
@@ -2658,6 +5113,22 @@
     ! long_name: Cell thickness after applying boundary forcing
     ! units: m
     ! cell_methods: z_l:sum
+"ocean_model_d2", "boundary_forcing_h"  [Unused]
+    ! long_name: Cell thickness after applying boundary forcing
+    ! units: m
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "boundary_forcing_h_xyave"  [Unused]
+    ! long_name: Cell thickness after applying boundary forcing
+    ! units: m
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "boundary_forcing_h"  [Unused]
+    ! long_name: Cell thickness after applying boundary forcing
+    ! units: m
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "boundary_forcing_h_xyave"  [Unused]
+    ! long_name: Cell thickness after applying boundary forcing
+    ! units: m
+    ! cell_methods: z_l:sum
 "ocean_model", "boundary_forcing_h_tendency"  [Unused]
     ! long_name: Cell thickness tendency due to boundary forcing
     ! units: m s-1
@@ -2671,6 +5142,22 @@
     ! units: m s-1
     ! cell_methods: xh:mean yh:mean z_l:sum area:mean
 "ocean_model_z", "boundary_forcing_h_tendency_xyave"  [Unused]
+    ! long_name: Cell thickness tendency due to boundary forcing
+    ! units: m s-1
+    ! cell_methods: z_l:sum
+"ocean_model_d2", "boundary_forcing_h_tendency"  [Unused]
+    ! long_name: Cell thickness tendency due to boundary forcing
+    ! units: m s-1
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "boundary_forcing_h_tendency_xyave"  [Unused]
+    ! long_name: Cell thickness tendency due to boundary forcing
+    ! units: m s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "boundary_forcing_h_tendency"  [Unused]
+    ! long_name: Cell thickness tendency due to boundary forcing
+    ! units: m s-1
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "boundary_forcing_h_tendency_xyave"  [Unused]
     ! long_name: Cell thickness tendency due to boundary forcing
     ! units: m s-1
     ! cell_methods: z_l:sum
@@ -2690,6 +5177,22 @@
     ! long_name: Boundary forcing temperature tendency
     ! units: degC s-1
     ! cell_methods: z_l:mean
+"ocean_model_d2", "boundary_forcing_temp_tendency"  [Unused]
+    ! long_name: Boundary forcing temperature tendency
+    ! units: degC s-1
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "boundary_forcing_temp_tendency_xyave"  [Unused]
+    ! long_name: Boundary forcing temperature tendency
+    ! units: degC s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "boundary_forcing_temp_tendency"  [Unused]
+    ! long_name: Boundary forcing temperature tendency
+    ! units: degC s-1
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "boundary_forcing_temp_tendency_xyave"  [Unused]
+    ! long_name: Boundary forcing temperature tendency
+    ! units: degC s-1
+    ! cell_methods: z_l:mean
 "ocean_model", "boundary_forcing_saln_tendency"  [Unused]
     ! long_name: Boundary forcing saln tendency
     ! units: psu s-1
@@ -2703,6 +5206,22 @@
     ! units: psu s-1
     ! cell_methods: xh:mean yh:mean z_l:mean area:mean
 "ocean_model_z", "boundary_forcing_saln_tendency_xyave"  [Unused]
+    ! long_name: Boundary forcing saln tendency
+    ! units: psu s-1
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "boundary_forcing_saln_tendency"  [Unused]
+    ! long_name: Boundary forcing saln tendency
+    ! units: psu s-1
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "boundary_forcing_saln_tendency_xyave"  [Unused]
+    ! long_name: Boundary forcing saln tendency
+    ! units: psu s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "boundary_forcing_saln_tendency"  [Unused]
+    ! long_name: Boundary forcing saln tendency
+    ! units: psu s-1
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "boundary_forcing_saln_tendency_xyave"  [Unused]
     ! long_name: Boundary forcing saln tendency
     ! units: psu s-1
     ! cell_methods: z_l:mean
@@ -2722,6 +5241,22 @@
     ! long_name: Boundary forcing heat tendency
     ! units: W m-2
     ! cell_methods: z_l:sum
+"ocean_model_d2", "boundary_forcing_heat_tendency"  [Unused]
+    ! long_name: Boundary forcing heat tendency
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "boundary_forcing_heat_tendency_xyave"  [Unused]
+    ! long_name: Boundary forcing heat tendency
+    ! units: W m-2
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "boundary_forcing_heat_tendency"  [Unused]
+    ! long_name: Boundary forcing heat tendency
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "boundary_forcing_heat_tendency_xyave"  [Unused]
+    ! long_name: Boundary forcing heat tendency
+    ! units: W m-2
+    ! cell_methods: z_l:sum
 "ocean_model", "boundary_forcing_salt_tendency"  [Unused]
     ! long_name: Boundary forcing salt tendency
     ! units: kg m-2 s-1
@@ -2738,11 +5273,35 @@
     ! long_name: Boundary forcing salt tendency
     ! units: kg m-2 s-1
     ! cell_methods: z_l:sum
+"ocean_model_d2", "boundary_forcing_salt_tendency"  [Unused]
+    ! long_name: Boundary forcing salt tendency
+    ! units: kg m-2 s-1
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "boundary_forcing_salt_tendency_xyave"  [Unused]
+    ! long_name: Boundary forcing salt tendency
+    ! units: kg m-2 s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "boundary_forcing_salt_tendency"  [Unused]
+    ! long_name: Boundary forcing salt tendency
+    ! units: kg m-2 s-1
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "boundary_forcing_salt_tendency_xyave"  [Unused]
+    ! long_name: Boundary forcing salt tendency
+    ! units: kg m-2 s-1
+    ! cell_methods: z_l:sum
 "ocean_model", "boundary_forcing_heat_tendency_2d"  [Unused]
     ! long_name: Depth integrated boundary forcing of ocean heat
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "boundary_forcing_heat_tendency_2d"  [Unused]
+    ! long_name: Depth integrated boundary forcing of ocean heat
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "boundary_forcing_salt_tendency_2d"  [Unused]
+    ! long_name: Depth integrated boundary forcing of ocean salt
+    ! units: kg m-2 s-1
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "boundary_forcing_salt_tendency_2d"  [Unused]
     ! long_name: Depth integrated boundary forcing of ocean salt
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
@@ -2766,6 +5325,26 @@
     ! units: m
     ! standard_name: cell_thickness
     ! cell_methods: z_l:sum
+"ocean_model_d2", "frazil_h"  [Unused]
+    ! long_name: Cell Thickness
+    ! units: m
+    ! standard_name: cell_thickness
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "frazil_h_xyave"  [Unused]
+    ! long_name: Cell Thickness
+    ! units: m
+    ! standard_name: cell_thickness
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "frazil_h"  [Unused]
+    ! long_name: Cell Thickness
+    ! units: m
+    ! standard_name: cell_thickness
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "frazil_h_xyave"  [Unused]
+    ! long_name: Cell Thickness
+    ! units: m
+    ! standard_name: cell_thickness
+    ! cell_methods: z_l:sum
 "ocean_model", "frazil_temp_tendency"  [Used]
     ! long_name: Temperature tendency due to frazil formation
     ! units: degC s-1
@@ -2779,6 +5358,22 @@
     ! units: degC s-1
     ! cell_methods: xh:mean yh:mean z_l:mean area:mean
 "ocean_model_z", "frazil_temp_tendency_xyave"  [Unused]
+    ! long_name: Temperature tendency due to frazil formation
+    ! units: degC s-1
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "frazil_temp_tendency"  [Unused]
+    ! long_name: Temperature tendency due to frazil formation
+    ! units: degC s-1
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "frazil_temp_tendency_xyave"  [Unused]
+    ! long_name: Temperature tendency due to frazil formation
+    ! units: degC s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "frazil_temp_tendency"  [Unused]
+    ! long_name: Temperature tendency due to frazil formation
+    ! units: degC s-1
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "frazil_temp_tendency_xyave"  [Unused]
     ! long_name: Temperature tendency due to frazil formation
     ! units: degC s-1
     ! cell_methods: z_l:mean
@@ -2798,7 +5393,27 @@
     ! long_name: Heat tendency due to frazil formation
     ! units: W m-2
     ! cell_methods: z_l:sum
+"ocean_model_d2", "frazil_heat_tendency"  [Unused]
+    ! long_name: Heat tendency due to frazil formation
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "frazil_heat_tendency_xyave"  [Unused]
+    ! long_name: Heat tendency due to frazil formation
+    ! units: W m-2
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "frazil_heat_tendency"  [Unused]
+    ! long_name: Heat tendency due to frazil formation
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "frazil_heat_tendency_xyave"  [Unused]
+    ! long_name: Heat tendency due to frazil formation
+    ! units: W m-2
+    ! cell_methods: z_l:sum
 "ocean_model", "frazil_heat_tendency_2d"  [Used]
+    ! long_name: Depth integrated heat tendency due to frazil formation
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "frazil_heat_tendency_2d"  [Unused]
     ! long_name: Depth integrated heat tendency due to frazil formation
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -2818,11 +5433,35 @@
     ! long_name: Internal Tide Driven Diffusivity
     ! units: m2 s-1
     ! cell_methods: z_i:point
+"ocean_model_d2", "Kd_itides"  [Unused]
+    ! long_name: Internal Tide Driven Diffusivity
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "Kd_itides_xyave"  [Unused]
+    ! long_name: Internal Tide Driven Diffusivity
+    ! units: m2 s-1
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "Kd_itides"  [Unused]
+    ! long_name: Internal Tide Driven Diffusivity
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "Kd_itides_xyave"  [Unused]
+    ! long_name: Internal Tide Driven Diffusivity
+    ! units: m2 s-1
+    ! cell_methods: z_i:point
 "ocean_model", "TKE_itidal"  [Unused]
     ! long_name: Internal Tide Driven Turbulent Kinetic Energy
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "TKE_itidal"  [Unused]
+    ! long_name: Internal Tide Driven Turbulent Kinetic Energy
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "Nb"  [Unused]
+    ! long_name: Bottom Buoyancy Frequency
+    ! units: s-1
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "Nb"  [Unused]
     ! long_name: Bottom Buoyancy Frequency
     ! units: s-1
     ! cell_methods: xh:mean yh:mean area:mean
@@ -2842,6 +5481,22 @@
     ! long_name: Internal Tide Driven Diffusivity (from propagating low modes)
     ! units: m2 s-1
     ! cell_methods: z_i:point
+"ocean_model_d2", "Kd_lowmode"  [Unused]
+    ! long_name: Internal Tide Driven Diffusivity (from propagating low modes)
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "Kd_lowmode_xyave"  [Unused]
+    ! long_name: Internal Tide Driven Diffusivity (from propagating low modes)
+    ! units: m2 s-1
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "Kd_lowmode"  [Unused]
+    ! long_name: Internal Tide Driven Diffusivity (from propagating low modes)
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "Kd_lowmode_xyave"  [Unused]
+    ! long_name: Internal Tide Driven Diffusivity (from propagating low modes)
+    ! units: m2 s-1
+    ! cell_methods: z_i:point
 "ocean_model", "Fl_itides"  [Unused]
     ! long_name: Vertical flux of tidal turbulent dissipation
     ! units: m3 s-3
@@ -2855,6 +5510,22 @@
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean z_i:point area:mean
 "ocean_model_z", "Fl_itides_xyave"  [Unused]
+    ! long_name: Vertical flux of tidal turbulent dissipation
+    ! units: m3 s-3
+    ! cell_methods: z_i:point
+"ocean_model_d2", "Fl_itides"  [Unused]
+    ! long_name: Vertical flux of tidal turbulent dissipation
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "Fl_itides_xyave"  [Unused]
+    ! long_name: Vertical flux of tidal turbulent dissipation
+    ! units: m3 s-3
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "Fl_itides"  [Unused]
+    ! long_name: Vertical flux of tidal turbulent dissipation
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "Fl_itides_xyave"  [Unused]
     ! long_name: Vertical flux of tidal turbulent dissipation
     ! units: m3 s-3
     ! cell_methods: z_i:point
@@ -2874,7 +5545,27 @@
     ! long_name: Vertical flux of tidal turbulent dissipation (from propagating low modes)
     ! units: m3 s-3
     ! cell_methods: z_i:point
+"ocean_model_d2", "Fl_lowmode"  [Unused]
+    ! long_name: Vertical flux of tidal turbulent dissipation (from propagating low modes)
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "Fl_lowmode_xyave"  [Unused]
+    ! long_name: Vertical flux of tidal turbulent dissipation (from propagating low modes)
+    ! units: m3 s-3
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "Fl_lowmode"  [Unused]
+    ! long_name: Vertical flux of tidal turbulent dissipation (from propagating low modes)
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "Fl_lowmode_xyave"  [Unused]
+    ! long_name: Vertical flux of tidal turbulent dissipation (from propagating low modes)
+    ! units: m3 s-3
+    ! cell_methods: z_i:point
 "ocean_model", "Polzin_decay_scale"  [Unused]
+    ! long_name: Vertical decay scale for the tidal turbulent dissipation with Polzin scheme
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "Polzin_decay_scale"  [Unused]
     ! long_name: Vertical decay scale for the tidal turbulent dissipation with Polzin scheme
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
@@ -2882,11 +5573,23 @@
     ! long_name: Vertical decay scale for the tidal turbulent dissipation with Polzin scheme, scaled by N2_bot/N2_meanz
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "Polzin_decay_scale_scaled"  [Unused]
+    ! long_name: Vertical decay scale for the tidal turbulent dissipation with Polzin scheme, scaled by N2_bot/N2_meanz
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "N2_b"  [Unused]
     ! long_name: Bottom Buoyancy frequency squared
     ! units: s-2
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "N2_b"  [Unused]
+    ! long_name: Bottom Buoyancy frequency squared
+    ! units: s-2
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "N2_meanz"  [Unused]
+    ! long_name: Buoyancy frequency squared averaged over the water column
+    ! units: s-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "N2_meanz"  [Unused]
     ! long_name: Buoyancy frequency squared averaged over the water column
     ! units: s-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -2906,6 +5609,22 @@
     ! long_name: Work done by Internal Tide Diapycnal Mixing
     ! units: W m-2
     ! cell_methods: z_l:mean
+"ocean_model_d2", "Kd_Itidal_Work"  [Unused]
+    ! long_name: Work done by Internal Tide Diapycnal Mixing
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "Kd_Itidal_Work_xyave"  [Unused]
+    ! long_name: Work done by Internal Tide Diapycnal Mixing
+    ! units: W m-2
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "Kd_Itidal_Work"  [Unused]
+    ! long_name: Work done by Internal Tide Diapycnal Mixing
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "Kd_Itidal_Work_xyave"  [Unused]
+    ! long_name: Work done by Internal Tide Diapycnal Mixing
+    ! units: W m-2
+    ! cell_methods: z_l:mean
 "ocean_model", "Kd_Nikurashin_Work"  [Unused]
     ! long_name: Work done by Nikurashin Lee Wave Drag Scheme
     ! units: W m-2
@@ -2922,6 +5641,22 @@
     ! long_name: Work done by Nikurashin Lee Wave Drag Scheme
     ! units: W m-2
     ! cell_methods: z_l:mean
+"ocean_model_d2", "Kd_Nikurashin_Work"  [Unused]
+    ! long_name: Work done by Nikurashin Lee Wave Drag Scheme
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "Kd_Nikurashin_Work_xyave"  [Unused]
+    ! long_name: Work done by Nikurashin Lee Wave Drag Scheme
+    ! units: W m-2
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "Kd_Nikurashin_Work"  [Unused]
+    ! long_name: Work done by Nikurashin Lee Wave Drag Scheme
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "Kd_Nikurashin_Work_xyave"  [Unused]
+    ! long_name: Work done by Nikurashin Lee Wave Drag Scheme
+    ! units: W m-2
+    ! cell_methods: z_l:mean
 "ocean_model", "Kd_Lowmode_Work"  [Unused]
     ! long_name: Work done by Internal Tide Diapycnal Mixing (low modes)
     ! units: W m-2
@@ -2935,6 +5670,22 @@
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean z_l:mean area:mean
 "ocean_model_z", "Kd_Lowmode_Work_xyave"  [Unused]
+    ! long_name: Work done by Internal Tide Diapycnal Mixing (low modes)
+    ! units: W m-2
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "Kd_Lowmode_Work"  [Unused]
+    ! long_name: Work done by Internal Tide Diapycnal Mixing (low modes)
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "Kd_Lowmode_Work_xyave"  [Unused]
+    ! long_name: Work done by Internal Tide Diapycnal Mixing (low modes)
+    ! units: W m-2
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "Kd_Lowmode_Work"  [Unused]
+    ! long_name: Work done by Internal Tide Diapycnal Mixing (low modes)
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "Kd_Lowmode_Work_xyave"  [Unused]
     ! long_name: Work done by Internal Tide Diapycnal Mixing (low modes)
     ! units: W m-2
     ! cell_methods: z_l:mean
@@ -2957,6 +5708,22 @@
     ! long_name: Diapycnal diffusivity as applied
     ! units: m2 s-1
     ! cell_methods: z_l:mean
+"ocean_model_d2", "Kd_effective"  [Unused]
+    ! long_name: Diapycnal diffusivity as applied
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "Kd_effective_xyave"  [Unused]
+    ! long_name: Diapycnal diffusivity as applied
+    ! units: m2 s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "Kd_effective"  [Unused]
+    ! long_name: Diapycnal diffusivity as applied
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "Kd_effective_xyave"  [Unused]
+    ! long_name: Diapycnal diffusivity as applied
+    ! units: m2 s-1
+    ! cell_methods: z_l:mean
 "ocean_model", "diff_work"  [Unused]
     ! long_name: Work actually done by diapycnal diffusion across each interface
     ! units: W m-2
@@ -2970,6 +5737,22 @@
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean z_i:point area:mean
 "ocean_model_z", "diff_work_xyave"  [Unused]
+    ! long_name: Work actually done by diapycnal diffusion across each interface
+    ! units: W m-2
+    ! cell_methods: z_i:point
+"ocean_model_d2", "diff_work"  [Unused]
+    ! long_name: Work actually done by diapycnal diffusion across each interface
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "diff_work_xyave"  [Unused]
+    ! long_name: Work actually done by diapycnal diffusion across each interface
+    ! units: W m-2
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "diff_work"  [Unused]
+    ! long_name: Work actually done by diapycnal diffusion across each interface
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "diff_work_xyave"  [Unused]
     ! long_name: Work actually done by diapycnal diffusion across each interface
     ! units: W m-2
     ! cell_methods: z_i:point
@@ -2996,6 +5779,22 @@
     ! long_name: Bottom Boundary Layer Diffusivity
     ! units: m2 s-1
     ! cell_methods: z_i:point
+"ocean_model_d2", "Kd_BBL"  [Unused]
+    ! long_name: Bottom Boundary Layer Diffusivity
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "Kd_BBL_xyave"  [Unused]
+    ! long_name: Bottom Boundary Layer Diffusivity
+    ! units: m2 s-1
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "Kd_BBL"  [Unused]
+    ! long_name: Bottom Boundary Layer Diffusivity
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "Kd_BBL_xyave"  [Unused]
+    ! long_name: Bottom Boundary Layer Diffusivity
+    ! units: m2 s-1
+    ! cell_methods: z_i:point
 "ocean_model", "Kd_bkgnd"  [Unused]
     ! long_name: Background diffusivity added by MOM_bkgnd_mixing module
     ! units: m2/s
@@ -3009,6 +5808,22 @@
     ! units: m2/s
     ! cell_methods: xh:mean yh:mean z_i:point area:mean
 "ocean_model_z", "Kd_bkgnd_xyave"  [Unused]
+    ! long_name: Background diffusivity added by MOM_bkgnd_mixing module
+    ! units: m2/s
+    ! cell_methods: z_i:point
+"ocean_model_d2", "Kd_bkgnd"  [Unused]
+    ! long_name: Background diffusivity added by MOM_bkgnd_mixing module
+    ! units: m2/s
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "Kd_bkgnd_xyave"  [Unused]
+    ! long_name: Background diffusivity added by MOM_bkgnd_mixing module
+    ! units: m2/s
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "Kd_bkgnd"  [Unused]
+    ! long_name: Background diffusivity added by MOM_bkgnd_mixing module
+    ! units: m2/s
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "Kd_bkgnd_xyave"  [Unused]
     ! long_name: Background diffusivity added by MOM_bkgnd_mixing module
     ! units: m2/s
     ! cell_methods: z_i:point
@@ -3028,6 +5843,22 @@
     ! long_name: Background viscosity added by MOM_bkgnd_mixing module
     ! units: m2/s
     ! cell_methods: z_i:point
+"ocean_model_d2", "Kv_bkgnd"  [Unused]
+    ! long_name: Background viscosity added by MOM_bkgnd_mixing module
+    ! units: m2/s
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "Kv_bkgnd_xyave"  [Unused]
+    ! long_name: Background viscosity added by MOM_bkgnd_mixing module
+    ! units: m2/s
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "Kv_bkgnd"  [Unused]
+    ! long_name: Background viscosity added by MOM_bkgnd_mixing module
+    ! units: m2/s
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "Kv_bkgnd_xyave"  [Unused]
+    ! long_name: Background viscosity added by MOM_bkgnd_mixing module
+    ! units: m2/s
+    ! cell_methods: z_i:point
 "ocean_model", "Kd_layer"  [Used]
     ! long_name: Diapycnal diffusivity of layers (as set)
     ! units: m2 s-1
@@ -3041,6 +5872,22 @@
     ! units: m2 s-1
     ! cell_methods: xh:mean yh:mean z_l:mean area:mean
 "ocean_model_z", "Kd_layer_xyave"  [Unused]
+    ! long_name: Diapycnal diffusivity of layers (as set)
+    ! units: m2 s-1
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "Kd_layer"  [Unused]
+    ! long_name: Diapycnal diffusivity of layers (as set)
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "Kd_layer_xyave"  [Unused]
+    ! long_name: Diapycnal diffusivity of layers (as set)
+    ! units: m2 s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "Kd_layer"  [Unused]
+    ! long_name: Diapycnal diffusivity of layers (as set)
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "Kd_layer_xyave"  [Unused]
     ! long_name: Diapycnal diffusivity of layers (as set)
     ! units: m2 s-1
     ! cell_methods: z_l:mean
@@ -3060,6 +5907,22 @@
     ! long_name: Work done by Diapycnal Mixing
     ! units: W m-2
     ! cell_methods: z_l:mean
+"ocean_model_d2", "Kd_Work"  [Unused]
+    ! long_name: Work done by Diapycnal Mixing
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "Kd_Work_xyave"  [Unused]
+    ! long_name: Work done by Diapycnal Mixing
+    ! units: W m-2
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "Kd_Work"  [Unused]
+    ! long_name: Work done by Diapycnal Mixing
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "Kd_Work_xyave"  [Unused]
+    ! long_name: Work done by Diapycnal Mixing
+    ! units: W m-2
+    ! cell_methods: z_l:mean
 "ocean_model", "maxTKE"  [Unused]
     ! long_name: Maximum layer TKE
     ! units: m3 s-3
@@ -3076,6 +5939,22 @@
     ! long_name: Maximum layer TKE
     ! units: m3 s-3
     ! cell_methods: z_l:mean
+"ocean_model_d2", "maxTKE"  [Unused]
+    ! long_name: Maximum layer TKE
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "maxTKE_xyave"  [Unused]
+    ! long_name: Maximum layer TKE
+    ! units: m3 s-3
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "maxTKE"  [Unused]
+    ! long_name: Maximum layer TKE
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "maxTKE_xyave"  [Unused]
+    ! long_name: Maximum layer TKE
+    ! units: m3 s-3
+    ! cell_methods: z_l:mean
 "ocean_model", "TKE_to_Kd"  [Unused]
     ! long_name: Convert TKE to Kd
     ! units: s2 m
@@ -3089,6 +5968,22 @@
     ! units: s2 m
     ! cell_methods: xh:mean yh:mean z_l:mean area:mean
 "ocean_model_z", "TKE_to_Kd_xyave"  [Unused]
+    ! long_name: Convert TKE to Kd
+    ! units: s2 m
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "TKE_to_Kd"  [Unused]
+    ! long_name: Convert TKE to Kd
+    ! units: s2 m
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "TKE_to_Kd_xyave"  [Unused]
+    ! long_name: Convert TKE to Kd
+    ! units: s2 m
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "TKE_to_Kd"  [Unused]
+    ! long_name: Convert TKE to Kd
+    ! units: s2 m
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "TKE_to_Kd_xyave"  [Unused]
     ! long_name: Convert TKE to Kd
     ! units: s2 m
     ! cell_methods: z_l:mean
@@ -3128,6 +6023,42 @@
     ! units: s-2
     ! standard_name: square_of_brunt_vaisala_frequency_in_sea_water
     ! cell_methods: z_i:point
+"ocean_model_d2", "N2"  [Unused] (CMOR equivalent is "obvfsq")
+    ! long_name: Buoyancy frequency squared
+    ! units: s-2
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "N2_xyave"  [Unused] (CMOR equivalent is "obvfsq_xyave")
+    ! long_name: Buoyancy frequency squared
+    ! units: s-2
+    ! cell_methods: zi:point
+"ocean_model_d2", "obvfsq"  [Unused] (native name is "N2")
+    ! long_name: Square of seawater buoyancy frequency
+    ! units: s-2
+    ! standard_name: square_of_brunt_vaisala_frequency_in_sea_water
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "obvfsq_xyave"  [Unused] (native name is "N2_xyave")
+    ! long_name: Square of seawater buoyancy frequency
+    ! units: s-2
+    ! standard_name: square_of_brunt_vaisala_frequency_in_sea_water
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "N2"  [Unused] (CMOR equivalent is "obvfsq")
+    ! long_name: Buoyancy frequency squared
+    ! units: s-2
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "N2_xyave"  [Unused] (CMOR equivalent is "obvfsq_xyave")
+    ! long_name: Buoyancy frequency squared
+    ! units: s-2
+    ! cell_methods: z_i:point
+"ocean_model_z_d2", "obvfsq"  [Unused] (native name is "N2")
+    ! long_name: Square of seawater buoyancy frequency
+    ! units: s-2
+    ! standard_name: square_of_brunt_vaisala_frequency_in_sea_water
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "obvfsq_xyave"  [Unused] (native name is "N2_xyave")
+    ! long_name: Square of seawater buoyancy frequency
+    ! units: s-2
+    ! standard_name: square_of_brunt_vaisala_frequency_in_sea_water
+    ! cell_methods: z_i:point
 "ocean_model_zold", "N2"  [Unused]
     ! long_name: Buoyancy frequency, interpolated to z
     ! units: s-2
@@ -3147,6 +6078,22 @@
     ! long_name: Shear-driven Diapycnal Diffusivity
     ! units: m2 s-1
     ! cell_methods: z_i:point
+"ocean_model_d2", "Kd_shear"  [Unused]
+    ! long_name: Shear-driven Diapycnal Diffusivity
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "Kd_shear_xyave"  [Unused]
+    ! long_name: Shear-driven Diapycnal Diffusivity
+    ! units: m2 s-1
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "Kd_shear"  [Unused]
+    ! long_name: Shear-driven Diapycnal Diffusivity
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "Kd_shear_xyave"  [Unused]
+    ! long_name: Shear-driven Diapycnal Diffusivity
+    ! units: m2 s-1
+    ! cell_methods: z_i:point
 "ocean_model", "TKE_shear"  [Unused]
     ! long_name: Shear-driven Turbulent Kinetic Energy
     ! units: m2 s-2
@@ -3163,7 +6110,27 @@
     ! long_name: Shear-driven Turbulent Kinetic Energy
     ! units: m2 s-2
     ! cell_methods: z_i:point
+"ocean_model_d2", "TKE_shear"  [Unused]
+    ! long_name: Shear-driven Turbulent Kinetic Energy
+    ! units: m2 s-2
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "TKE_shear_xyave"  [Unused]
+    ! long_name: Shear-driven Turbulent Kinetic Energy
+    ! units: m2 s-2
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "TKE_shear"  [Unused]
+    ! long_name: Shear-driven Turbulent Kinetic Energy
+    ! units: m2 s-2
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "TKE_shear_xyave"  [Unused]
+    ! long_name: Shear-driven Turbulent Kinetic Energy
+    ! units: m2 s-2
+    ! cell_methods: z_i:point
 "ocean_model", "created_H"  [Unused]
+    ! long_name: The volume flux added to stop the ocean from drying out and becoming negative in depth
+    ! units: m s-1
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "created_H"  [Unused]
     ! long_name: The volume flux added to stop the ocean from drying out and becoming negative in depth
     ! units: m s-1
     ! cell_methods: xh:mean yh:mean area:mean
@@ -3183,6 +6150,26 @@
     ! standard_name: net_rate_of_absorption_of_shortwave_energy_in_ocean_layer
     ! cell_methods: xh:mean yh:mean z_l:sum area:mean
 "ocean_model_z", "rsdoabsorb_xyave"  [Unused]
+    ! long_name: Convergence of Penetrative Shortwave Flux in Sea Water Layer
+    ! units: W m-2
+    ! standard_name: net_rate_of_absorption_of_shortwave_energy_in_ocean_layer
+    ! cell_methods: z_l:sum
+"ocean_model_d2", "rsdoabsorb"  [Unused]
+    ! long_name: Convergence of Penetrative Shortwave Flux in Sea Water Layer
+    ! units: W m-2
+    ! standard_name: net_rate_of_absorption_of_shortwave_energy_in_ocean_layer
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "rsdoabsorb_xyave"  [Unused]
+    ! long_name: Convergence of Penetrative Shortwave Flux in Sea Water Layer
+    ! units: W m-2
+    ! standard_name: net_rate_of_absorption_of_shortwave_energy_in_ocean_layer
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "rsdoabsorb"  [Unused]
+    ! long_name: Convergence of Penetrative Shortwave Flux in Sea Water Layer
+    ! units: W m-2
+    ! standard_name: net_rate_of_absorption_of_shortwave_energy_in_ocean_layer
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "rsdoabsorb_xyave"  [Unused]
     ! long_name: Convergence of Penetrative Shortwave Flux in Sea Water Layer
     ! units: W m-2
     ! standard_name: net_rate_of_absorption_of_shortwave_energy_in_ocean_layer
@@ -3207,7 +6194,32 @@
     ! units: W m-2
     ! standard_name: downwelling_shortwave_flux_in_sea_water
     ! cell_methods: z_i:point
+"ocean_model_d2", "rsdo"  [Unused]
+    ! long_name: Downwelling Shortwave Flux in Sea Water at Grid Cell Upper Interface
+    ! units: W m-2
+    ! standard_name: downwelling_shortwave_flux_in_sea_water
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "rsdo_xyave"  [Unused]
+    ! long_name: Downwelling Shortwave Flux in Sea Water at Grid Cell Upper Interface
+    ! units: W m-2
+    ! standard_name: downwelling_shortwave_flux_in_sea_water
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "rsdo"  [Unused]
+    ! long_name: Downwelling Shortwave Flux in Sea Water at Grid Cell Upper Interface
+    ! units: W m-2
+    ! standard_name: downwelling_shortwave_flux_in_sea_water
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "rsdo_xyave"  [Unused]
+    ! long_name: Downwelling Shortwave Flux in Sea Water at Grid Cell Upper Interface
+    ! units: W m-2
+    ! standard_name: downwelling_shortwave_flux_in_sea_water
+    ! cell_methods: z_i:point
 "ocean_model", "nonpenSW"  [Unused]
+    ! long_name: Non-downwelling SW radiation (i.e., SW absorbed in ocean surface with LW,SENS,LAT)
+    ! units: W m-2
+    ! standard_name: nondownwelling_shortwave_flux_in_sea_water
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "nonpenSW"  [Unused]
     ! long_name: Non-downwelling SW radiation (i.e., SW absorbed in ocean surface with LW,SENS,LAT)
     ! units: W m-2
     ! standard_name: nondownwelling_shortwave_flux_in_sea_water
@@ -3216,7 +6228,15 @@
     ! long_name: Surface boundary layer depth
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "ePBL_h_ML"  [Unused]
+    ! long_name: Surface boundary layer depth
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "ePBL_TKE_wind"  [Unused]
+    ! long_name: Wind-stirring source of mixed layer TKE
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "ePBL_TKE_wind"  [Unused]
     ! long_name: Wind-stirring source of mixed layer TKE
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean area:mean
@@ -3224,7 +6244,15 @@
     ! long_name: Mean kinetic energy source of mixed layer TKE
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "ePBL_TKE_MKE"  [Unused]
+    ! long_name: Mean kinetic energy source of mixed layer TKE
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "ePBL_TKE_conv"  [Unused]
+    ! long_name: Convective source of mixed layer TKE
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "ePBL_TKE_conv"  [Unused]
     ! long_name: Convective source of mixed layer TKE
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean area:mean
@@ -3232,7 +6260,15 @@
     ! long_name: TKE consumed by mixing surface forcing or penetrative shortwave radation through model layers
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "ePBL_TKE_forcing"  [Unused]
+    ! long_name: TKE consumed by mixing surface forcing or penetrative shortwave radation through model layers
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "ePBL_TKE_mixing"  [Unused]
+    ! long_name: TKE consumed by mixing that deepens the mixed layer
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "ePBL_TKE_mixing"  [Unused]
     ! long_name: TKE consumed by mixing that deepens the mixed layer
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean area:mean
@@ -3240,11 +6276,23 @@
     ! long_name: Mechanical energy decay sink of mixed layer TKE
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "ePBL_TKE_mech_decay"  [Unused]
+    ! long_name: Mechanical energy decay sink of mixed layer TKE
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "ePBL_TKE_conv_decay"  [Unused]
     ! long_name: Convective energy decay sink of mixed layer TKE
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "ePBL_TKE_conv_decay"  [Unused]
+    ! long_name: Convective energy decay sink of mixed layer TKE
+    ! units: m3 s-3
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "ePBL_Hs_used"  [Unused]
+    ! long_name: Surface region thickness that is used
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "ePBL_Hs_used"  [Unused]
     ! long_name: Surface region thickness that is used
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
@@ -3264,6 +6312,22 @@
     ! long_name: Mixing Length that is used
     ! units: m
     ! cell_methods: z_i:point
+"ocean_model_d2", "Mixing_Length"  [Unused]
+    ! long_name: Mixing Length that is used
+    ! units: m
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "Mixing_Length_xyave"  [Unused]
+    ! long_name: Mixing Length that is used
+    ! units: m
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "Mixing_Length"  [Unused]
+    ! long_name: Mixing Length that is used
+    ! units: m
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "Mixing_Length_xyave"  [Unused]
+    ! long_name: Mixing Length that is used
+    ! units: m
+    ! cell_methods: z_i:point
 "ocean_model", "Velocity_Scale"  [Unused]
     ! long_name: Velocity Scale that is used.
     ! units: m s-1
@@ -3280,7 +6344,27 @@
     ! long_name: Velocity Scale that is used.
     ! units: m s-1
     ! cell_methods: z_i:point
+"ocean_model_d2", "Velocity_Scale"  [Unused]
+    ! long_name: Velocity Scale that is used.
+    ! units: m s-1
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "Velocity_Scale_xyave"  [Unused]
+    ! long_name: Velocity Scale that is used.
+    ! units: m s-1
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "Velocity_Scale"  [Unused]
+    ! long_name: Velocity Scale that is used.
+    ! units: m s-1
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "Velocity_Scale_xyave"  [Unused]
+    ! long_name: Velocity Scale that is used.
+    ! units: m s-1
+    ! cell_methods: z_i:point
 "ocean_model", "LT_Enhancement"  [Unused]
+    ! long_name: LT enhancement that is used.
+    ! units: nondim
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "LT_Enhancement"  [Unused]
     ! long_name: LT enhancement that is used.
     ! units: nondim
     ! cell_methods: xh:mean yh:mean area:mean
@@ -3288,7 +6372,15 @@
     ! long_name: MSTAR that is used.
     ! units: nondim
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "MSTAR"  [Unused]
+    ! long_name: MSTAR that is used.
+    ! units: nondim
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "ePBL_OSBL"  [Unused]
+    ! long_name: ePBL Surface Boundary layer depth.
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "ePBL_OSBL"  [Unused]
     ! long_name: ePBL Surface Boundary layer depth.
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
@@ -3296,7 +6388,15 @@
     ! long_name: Boundary layer depth over Ekman length.
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "MLD_EKMAN"  [Unused]
+    ! long_name: Boundary layer depth over Ekman length.
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "MLD_OBUKHOV"  [Unused]
+    ! long_name: Boundary layer depth over Obukhov length.
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "MLD_OBUKHOV"  [Unused]
     ! long_name: Boundary layer depth over Obukhov length.
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
@@ -3304,7 +6404,15 @@
     ! long_name: Ekman length over Obukhov length.
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "EKMAN_OBUKHOV"  [Unused]
+    ! long_name: Ekman length over Obukhov length.
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "LA"  [Unused]
+    ! long_name: Langmuir number.
+    ! units: nondim
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "LA"  [Unused]
     ! long_name: Langmuir number.
     ! units: nondim
     ! cell_methods: xh:mean yh:mean area:mean
@@ -3312,7 +6420,15 @@
     ! long_name: Modified Langmuir number.
     ! units: nondim
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "LA_MOD"  [Unused]
+    ! long_name: Modified Langmuir number.
+    ! units: nondim
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "MSTAR_LT"  [Unused]
+    ! long_name: MSTAR applied for LT effect.
+    ! units: nondim
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "MSTAR_LT"  [Unused]
     ! long_name: MSTAR applied for LT effect.
     ! units: nondim
     ! cell_methods: xh:mean yh:mean area:mean
@@ -3320,11 +6436,23 @@
     ! long_name: Max face thickness deficit ratio
     ! units: nondim
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "deficit_ratio"  [Unused]
+    ! long_name: Max face thickness deficit ratio
+    ! units: nondim
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "SW_pen"  [Unused]
     ! long_name: Penetrating shortwave radiation flux into ocean
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "SW_pen"  [Unused]
+    ! long_name: Penetrating shortwave radiation flux into ocean
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "SW_vis_pen"  [Unused]
+    ! long_name: Visible penetrating shortwave radiation flux into ocean
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "SW_vis_pen"  [Unused]
     ! long_name: Visible penetrating shortwave radiation flux into ocean
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -3344,6 +6472,22 @@
     ! long_name: Opacity for shortwave radiation in band 1
     ! units: m-1
     ! cell_methods: z_l:mean
+"ocean_model_d2", "opac_1"  [Unused]
+    ! long_name: Opacity for shortwave radiation in band 1
+    ! units: m-1
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "opac_1_xyave"  [Unused]
+    ! long_name: Opacity for shortwave radiation in band 1
+    ! units: m-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "opac_1"  [Unused]
+    ! long_name: Opacity for shortwave radiation in band 1
+    ! units: m-1
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "opac_1_xyave"  [Unused]
+    ! long_name: Opacity for shortwave radiation in band 1
+    ! units: m-1
+    ! cell_methods: z_l:mean
 "ocean_model", "opac_2"  [Unused]
     ! long_name: Opacity for shortwave radiation in band 2
     ! units: m-1
@@ -3357,6 +6501,22 @@
     ! units: m-1
     ! cell_methods: xh:mean yh:mean z_l:mean area:mean
 "ocean_model_z", "opac_2_xyave"  [Unused]
+    ! long_name: Opacity for shortwave radiation in band 2
+    ! units: m-1
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "opac_2"  [Unused]
+    ! long_name: Opacity for shortwave radiation in band 2
+    ! units: m-1
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "opac_2_xyave"  [Unused]
+    ! long_name: Opacity for shortwave radiation in band 2
+    ! units: m-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "opac_2"  [Unused]
+    ! long_name: Opacity for shortwave radiation in band 2
+    ! units: m-1
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "opac_2_xyave"  [Unused]
     ! long_name: Opacity for shortwave radiation in band 2
     ! units: m-1
     ! cell_methods: z_l:mean
@@ -3376,7 +6536,27 @@
     ! long_name: Opacity for shortwave radiation in band 3
     ! units: m-1
     ! cell_methods: z_l:mean
+"ocean_model_d2", "opac_3"  [Unused]
+    ! long_name: Opacity for shortwave radiation in band 3
+    ! units: m-1
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "opac_3_xyave"  [Unused]
+    ! long_name: Opacity for shortwave radiation in band 3
+    ! units: m-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "opac_3"  [Unused]
+    ! long_name: Opacity for shortwave radiation in band 3
+    ! units: m-1
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "opac_3_xyave"  [Unused]
+    ! long_name: Opacity for shortwave radiation in band 3
+    ! units: m-1
+    ! cell_methods: z_l:mean
 "ocean_model", "Chl_opac"  [Unused]
+    ! long_name: Surface chlorophyll A concentration used to find opacity
+    ! units: mg m-3
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "Chl_opac"  [Unused]
     ! long_name: Surface chlorophyll A concentration used to find opacity
     ! units: mg m-3
     ! cell_methods: xh:mean yh:mean area:mean
@@ -3384,7 +6564,15 @@
     ! long_name: Epipycnal tracer diffusivity at zonal faces of tracer cell
     ! units: m2 s-1
     ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "KHTR_u"  [Unused]
+    ! long_name: Epipycnal tracer diffusivity at zonal faces of tracer cell
+    ! units: m2 s-1
+    ! cell_methods: xq:point yh:mean
 "ocean_model", "KHTR_v"  [Used]
+    ! long_name: Epipycnal tracer diffusivity at meridional faces of tracer cell
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "KHTR_v"  [Unused]
     ! long_name: Epipycnal tracer diffusivity at meridional faces of tracer cell
     ! units: m2 s-1
     ! cell_methods: xh:mean yq:point
@@ -3397,11 +6585,28 @@
     ! units: m2 s-1
     ! standard_name: ocean_tracer_epineutral_laplacian_diffusivity
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "KHTR_h"  [Unused] (CMOR equivalent is "diftrelo")
+    ! long_name: Epipycnal tracer diffusivity at tracer cell center
+    ! units: m2 s-1
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "diftrelo"  [Unused] (native name is "KHTR_h")
+    ! long_name: Ocean Tracer Epineutral Laplacian Diffusivity
+    ! units: m2 s-1
+    ! standard_name: ocean_tracer_epineutral_laplacian_diffusivity
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "KHDT_x"  [Unused]
     ! long_name: Epipycnal tracer diffusivity operator at zonal faces of tracer cell
     ! units: m2
     ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "KHDT_x"  [Unused]
+    ! long_name: Epipycnal tracer diffusivity operator at zonal faces of tracer cell
+    ! units: m2
+    ! cell_methods: xq:point yh:mean
 "ocean_model", "KHDT_y"  [Unused]
+    ! long_name: Epipycnal tracer diffusivity operator at meridional faces of tracer cell
+    ! units: m2
+    ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "KHDT_y"  [Unused]
     ! long_name: Epipycnal tracer diffusivity operator at meridional faces of tracer cell
     ! units: m2
     ! cell_methods: xh:mean yq:point
@@ -3414,12 +6619,26 @@
     ! units: m
     ! standard_name: sea_surface_height_above_geoid
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "zos"  [Unused]
+    ! long_name: Sea surface height above geoid
+    ! units: m
+    ! standard_name: sea_surface_height_above_geoid
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "zossq"  [Used]
     ! long_name: Square of sea surface height above geoid
     ! units: m2
     ! standard_name: square_of_sea_surface_height_above_geoid
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "zossq"  [Unused]
+    ! long_name: Square of sea surface height above geoid
+    ! units: m2
+    ! standard_name: square_of_sea_surface_height_above_geoid
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "SSH"  [Used]
+    ! long_name: Sea Surface Height
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "SSH"  [Unused]
     ! long_name: Sea Surface Height
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
@@ -3431,11 +6650,23 @@
     ! long_name: Sea Surface Zonal Velocity
     ! units: m s-1
     ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "SSU"  [Unused]
+    ! long_name: Sea Surface Zonal Velocity
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean
 "ocean_model", "SSV"  [Used]
     ! long_name: Sea Surface Meridional Velocity
     ! units: m s-1
     ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "SSV"  [Unused]
+    ! long_name: Sea Surface Meridional Velocity
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point
 "ocean_model", "speed"  [Used]
+    ! long_name: Sea Surface Speed
+    ! units: m s-1
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "speed"  [Unused]
     ! long_name: Sea Surface Speed
     ! units: m s-1
     ! cell_methods: xh:mean yh:mean area:mean
@@ -3444,6 +6675,15 @@
     ! units: degC
     ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "tos"  [Unused] (native name is "SST")
+    ! long_name: Sea Surface Temperature
+    ! units: degC
+    ! standard_name: sea_surface_temperature
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "SST"  [Unused] (CMOR equivalent is "tos")
+    ! long_name: Sea Surface Temperature
+    ! units: degC
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "tos"  [Unused] (native name is "SST")
     ! long_name: Sea Surface Temperature
     ! units: degC
     ! standard_name: sea_surface_temperature
@@ -3457,11 +6697,29 @@
     ! units: degC2
     ! standard_name: square_of_sea_surface_temperature
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "SST_sq"  [Unused] (CMOR equivalent is "tossq")
+    ! long_name: Sea Surface Temperature Squared
+    ! units: degC2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "tossq"  [Unused] (native name is "SST_sq")
+    ! long_name: Square of Sea Surface Temperature
+    ! units: degC2
+    ! standard_name: square_of_sea_surface_temperature
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "SSS"  [Used] (CMOR equivalent is "sos")
     ! long_name: Sea Surface Salinity
     ! units: psu
     ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "sos"  [Unused] (native name is "SSS")
+    ! long_name: Sea Surface Salinity
+    ! units: psu
+    ! standard_name: sea_surface_salinity
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "SSS"  [Unused] (CMOR equivalent is "sos")
+    ! long_name: Sea Surface Salinity
+    ! units: psu
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "sos"  [Unused] (native name is "SSS")
     ! long_name: Sea Surface Salinity
     ! units: psu
     ! standard_name: sea_surface_salinity
@@ -3475,6 +6733,15 @@
     ! units: psu
     ! standard_name: square_of_sea_surface_salinity
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "SSS_sq"  [Unused] (CMOR equivalent is "sossq")
+    ! long_name: Sea Surface Salinity Squared
+    ! units: psu
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "sossq"  [Unused] (native name is "SSS_sq")
+    ! long_name: Square of Sea Surface Salinity
+    ! units: psu
+    ! standard_name: square_of_sea_surface_salinity
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "frazil"  [Used] (CMOR equivalent is "hfsifrazil")
     ! long_name: Heat from frazil formation
     ! units: W m-2
@@ -3484,7 +6751,20 @@
     ! units: W m-2
     ! standard_name: heat_flux_into_sea_water_due_to_frazil_ice_formation
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "frazil"  [Unused] (CMOR equivalent is "hfsifrazil")
+    ! long_name: Heat from frazil formation
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "hfsifrazil"  [Unused] (native name is "frazil")
+    ! long_name: Heat Flux into Sea Water due to Frazil Ice Formation
+    ! units: W m-2
+    ! standard_name: heat_flux_into_sea_water_due_to_frazil_ice_formation
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "salt_deficit"  [Unused]
+    ! long_name: Salt sink in ocean due to ice flux
+    ! units: psu m-2 s-1
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "salt_deficit"  [Unused]
     ! long_name: Salt sink in ocean due to ice flux
     ! units: psu m-2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
@@ -3492,7 +6772,15 @@
     ! long_name: Heat flux into ocean from mass flux into ocean
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
-"ocean_model", "internal_heat"  [Used]
+"ocean_model_d2", "Heat_PmE"  [Unused]
+    ! long_name: Heat flux into ocean from mass flux into ocean
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model", "internal_heat"  [Unused]
+    ! long_name: Heat flux into ocean from geothermal or other internal sources
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "internal_heat"  [Unused]
     ! long_name: Heat flux into ocean from geothermal or other internal sources
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -3512,6 +6800,22 @@
     ! long_name: Zonal velocity after the dynamics update
     ! units: m s-1
     ! cell_methods: z_l:mean
+"ocean_model_d2", "u_dyn"  [Unused]
+    ! long_name: Zonal velocity after the dynamics update
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean zl:mean
+"ocean_model_d2", "u_dyn_xyave"  [Unused]
+    ! long_name: Zonal velocity after the dynamics update
+    ! units: m s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "u_dyn"  [Unused]
+    ! long_name: Zonal velocity after the dynamics update
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean z_l:mean
+"ocean_model_z_d2", "u_dyn_xyave"  [Unused]
+    ! long_name: Zonal velocity after the dynamics update
+    ! units: m s-1
+    ! cell_methods: z_l:mean
 "ocean_model", "v_dyn"  [Unused]
     ! long_name: Meridional velocity after the dynamics update
     ! units: m s-1
@@ -3525,6 +6829,22 @@
     ! units: m s-1
     ! cell_methods: xh:mean yq:point z_l:mean
 "ocean_model_z", "v_dyn_xyave"  [Unused]
+    ! long_name: Meridional velocity after the dynamics update
+    ! units: m s-1
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "v_dyn"  [Unused]
+    ! long_name: Meridional velocity after the dynamics update
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point zl:mean
+"ocean_model_d2", "v_dyn_xyave"  [Unused]
+    ! long_name: Meridional velocity after the dynamics update
+    ! units: m s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "v_dyn"  [Unused]
+    ! long_name: Meridional velocity after the dynamics update
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point z_l:mean
+"ocean_model_z_d2", "v_dyn_xyave"  [Unused]
     ! long_name: Meridional velocity after the dynamics update
     ! units: m s-1
     ! cell_methods: z_l:mean
@@ -3544,7 +6864,27 @@
     ! long_name: Layer Thickness after the dynamics update
     ! units: m
     ! cell_methods: z_l:sum
+"ocean_model_d2", "h_dyn"  [Unused]
+    ! long_name: Layer Thickness after the dynamics update
+    ! units: m
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "h_dyn_xyave"  [Unused]
+    ! long_name: Layer Thickness after the dynamics update
+    ! units: m
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "h_dyn"  [Unused]
+    ! long_name: Layer Thickness after the dynamics update
+    ! units: m
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "h_dyn_xyave"  [Unused]
+    ! long_name: Layer Thickness after the dynamics update
+    ! units: m
+    ! cell_methods: z_l:sum
 "ocean_model", "SSH_inst"  [Unused]
+    ! long_name: Instantaneous Sea Surface Height
+    ! units: m
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "SSH_inst"  [Unused]
     ! long_name: Instantaneous Sea Surface Height
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
@@ -3564,6 +6904,22 @@
     ! long_name: Accumulated zonal thickness fluxes to advect tracers
     ! units: kg
     ! cell_methods: z_l:sum
+"ocean_model_d2", "uhtr"  [Unused]
+    ! long_name: Accumulated zonal thickness fluxes to advect tracers
+    ! units: kg
+    ! cell_methods: xq:point yh:sum zl:sum
+"ocean_model_d2", "uhtr_xyave"  [Unused]
+    ! long_name: Accumulated zonal thickness fluxes to advect tracers
+    ! units: kg
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "uhtr"  [Unused]
+    ! long_name: Accumulated zonal thickness fluxes to advect tracers
+    ! units: kg
+    ! cell_methods: xq:point yh:sum z_l:sum
+"ocean_model_z_d2", "uhtr_xyave"  [Unused]
+    ! long_name: Accumulated zonal thickness fluxes to advect tracers
+    ! units: kg
+    ! cell_methods: z_l:sum
 "ocean_model", "vhtr"  [Unused]
     ! long_name: Accumulated meridional thickness fluxes to advect tracers
     ! units: kg
@@ -3577,6 +6933,22 @@
     ! units: kg
     ! cell_methods: xh:sum yq:point z_l:sum
 "ocean_model_z", "vhtr_xyave"  [Unused]
+    ! long_name: Accumulated meridional thickness fluxes to advect tracers
+    ! units: kg
+    ! cell_methods: z_l:sum
+"ocean_model_d2", "vhtr"  [Unused]
+    ! long_name: Accumulated meridional thickness fluxes to advect tracers
+    ! units: kg
+    ! cell_methods: xh:sum yq:point zl:sum
+"ocean_model_d2", "vhtr_xyave"  [Unused]
+    ! long_name: Accumulated meridional thickness fluxes to advect tracers
+    ! units: kg
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "vhtr"  [Unused]
+    ! long_name: Accumulated meridional thickness fluxes to advect tracers
+    ! units: kg
+    ! cell_methods: xh:sum yq:point z_l:sum
+"ocean_model_z_d2", "vhtr_xyave"  [Unused]
     ! long_name: Accumulated meridional thickness fluxes to advect tracers
     ! units: kg
     ! cell_methods: z_l:sum
@@ -3596,6 +6968,26 @@
     ! standard_name: ocean_mass_x_transport
     ! cell_methods: xq:point yh:sum z_l:sum
 "ocean_model_z", "umo_xyave"  [Unused]
+    ! long_name: Ocean Mass X Transport
+    ! units: kg s-1
+    ! standard_name: ocean_mass_x_transport
+    ! cell_methods: z_l:sum
+"ocean_model_d2", "umo"  [Unused]
+    ! long_name: Ocean Mass X Transport
+    ! units: kg s-1
+    ! standard_name: ocean_mass_x_transport
+    ! cell_methods: xq:point yh:sum zl:sum
+"ocean_model_d2", "umo_xyave"  [Unused]
+    ! long_name: Ocean Mass X Transport
+    ! units: kg s-1
+    ! standard_name: ocean_mass_x_transport
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "umo"  [Unused]
+    ! long_name: Ocean Mass X Transport
+    ! units: kg s-1
+    ! standard_name: ocean_mass_x_transport
+    ! cell_methods: xq:point yh:sum z_l:sum
+"ocean_model_z_d2", "umo_xyave"  [Unused]
     ! long_name: Ocean Mass X Transport
     ! units: kg s-1
     ! standard_name: ocean_mass_x_transport
@@ -3620,12 +7012,42 @@
     ! units: kg s-1
     ! standard_name: ocean_mass_y_transport
     ! cell_methods: z_l:sum
+"ocean_model_d2", "vmo"  [Unused]
+    ! long_name: Ocean Mass Y Transport
+    ! units: kg s-1
+    ! standard_name: ocean_mass_y_transport
+    ! cell_methods: xh:sum yq:point zl:sum
+"ocean_model_d2", "vmo_xyave"  [Unused]
+    ! long_name: Ocean Mass Y Transport
+    ! units: kg s-1
+    ! standard_name: ocean_mass_y_transport
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "vmo"  [Unused]
+    ! long_name: Ocean Mass Y Transport
+    ! units: kg s-1
+    ! standard_name: ocean_mass_y_transport
+    ! cell_methods: xh:sum yq:point z_l:sum
+"ocean_model_z_d2", "vmo_xyave"  [Unused]
+    ! long_name: Ocean Mass Y Transport
+    ! units: kg s-1
+    ! standard_name: ocean_mass_y_transport
+    ! cell_methods: z_l:sum
 "ocean_model", "umo_2d"  [Used]
     ! long_name: Ocean Mass X Transport Vertical Sum
     ! units: kg s-1
     ! standard_name: ocean_mass_x_transport_vertical_sum
     ! cell_methods: xq:point yh:sum
+"ocean_model_d2", "umo_2d"  [Unused]
+    ! long_name: Ocean Mass X Transport Vertical Sum
+    ! units: kg s-1
+    ! standard_name: ocean_mass_x_transport_vertical_sum
+    ! cell_methods: xq:point yh:sum
 "ocean_model", "vmo_2d"  [Used]
+    ! long_name: Ocean Mass Y Transport Vertical Sum
+    ! units: kg s-1
+    ! standard_name: ocean_mass_y_transport_vertical_sum
+    ! cell_methods: xh:sum yq:point
+"ocean_model_d2", "vmo_2d"  [Unused]
     ! long_name: Ocean Mass Y Transport Vertical Sum
     ! units: kg s-1
     ! standard_name: ocean_mass_y_transport_vertical_sum
@@ -3646,6 +7068,22 @@
     ! long_name: Change in layer thicknesses due to horizontal dynamics
     ! units: m s-1
     ! cell_methods: z_l:sum
+"ocean_model_d2", "dynamics_h"  [Unused]
+    ! long_name: Change in layer thicknesses due to horizontal dynamics
+    ! units: m s-1
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "dynamics_h_xyave"  [Unused]
+    ! long_name: Change in layer thicknesses due to horizontal dynamics
+    ! units: m s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "dynamics_h"  [Unused]
+    ! long_name: Change in layer thicknesses due to horizontal dynamics
+    ! units: m s-1
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "dynamics_h_xyave"  [Unused]
+    ! long_name: Change in layer thicknesses due to horizontal dynamics
+    ! units: m s-1
+    ! cell_methods: z_l:sum
 "ocean_model", "dynamics_h_tendency"  [Unused]
     ! long_name: Change in layer thicknesses due to horizontal dynamics
     ! units: m s-1
@@ -3659,6 +7097,22 @@
     ! units: m s-1
     ! cell_methods: xh:mean yh:mean z_l:sum area:mean
 "ocean_model_z", "dynamics_h_tendency_xyave"  [Unused]
+    ! long_name: Change in layer thicknesses due to horizontal dynamics
+    ! units: m s-1
+    ! cell_methods: z_l:sum
+"ocean_model_d2", "dynamics_h_tendency"  [Unused]
+    ! long_name: Change in layer thicknesses due to horizontal dynamics
+    ! units: m s-1
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "dynamics_h_tendency_xyave"  [Unused]
+    ! long_name: Change in layer thicknesses due to horizontal dynamics
+    ! units: m s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "dynamics_h_tendency"  [Unused]
+    ! long_name: Change in layer thicknesses due to horizontal dynamics
+    ! units: m s-1
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "dynamics_h_tendency_xyave"  [Unused]
     ! long_name: Change in layer thicknesses due to horizontal dynamics
     ! units: m s-1
     ! cell_methods: z_l:sum
@@ -3698,6 +7152,42 @@
     ! units: degC
     ! standard_name: sea_water_potential_temperature
     ! cell_methods: z_l:mean
+"ocean_model_d2", "temp"  [Unused] (CMOR equivalent is "thetao")
+    ! long_name: Potential Temperature
+    ! units: degC
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "temp_xyave"  [Unused] (CMOR equivalent is "thetao_xyave")
+    ! long_name: Potential Temperature
+    ! units: degC
+    ! cell_methods: zl:mean
+"ocean_model_d2", "thetao"  [Unused] (native name is "temp")
+    ! long_name: Sea Water Potential Temperature
+    ! units: degC
+    ! standard_name: sea_water_potential_temperature
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "thetao_xyave"  [Unused] (native name is "temp_xyave")
+    ! long_name: Sea Water Potential Temperature
+    ! units: degC
+    ! standard_name: sea_water_potential_temperature
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "temp"  [Unused] (CMOR equivalent is "thetao")
+    ! long_name: Potential Temperature
+    ! units: degC
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "temp_xyave"  [Unused] (CMOR equivalent is "thetao_xyave")
+    ! long_name: Potential Temperature
+    ! units: degC
+    ! cell_methods: z_l:mean
+"ocean_model_z_d2", "thetao"  [Unused] (native name is "temp")
+    ! long_name: Sea Water Potential Temperature
+    ! units: degC
+    ! standard_name: sea_water_potential_temperature
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "thetao_xyave"  [Unused] (native name is "temp_xyave")
+    ! long_name: Sea Water Potential Temperature
+    ! units: degC
+    ! standard_name: sea_water_potential_temperature
+    ! cell_methods: z_l:mean
 "ocean_model", "T_adx"  [Used]
     ! long_name: Advective (by residual mean) Zonal Flux of Heat
     ! units: W m-2
@@ -3711,6 +7201,22 @@
     ! units: W m-2
     ! cell_methods: xq:point yh:sum z_l:sum
 "ocean_model_z", "T_adx_xyave"  [Unused]
+    ! long_name: Advective (by residual mean) Zonal Flux of Heat
+    ! units: W m-2
+    ! cell_methods: z_l:sum
+"ocean_model_d2", "T_adx"  [Unused]
+    ! long_name: Advective (by residual mean) Zonal Flux of Heat
+    ! units: W m-2
+    ! cell_methods: xq:point yh:sum zl:sum
+"ocean_model_d2", "T_adx_xyave"  [Unused]
+    ! long_name: Advective (by residual mean) Zonal Flux of Heat
+    ! units: W m-2
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "T_adx"  [Unused]
+    ! long_name: Advective (by residual mean) Zonal Flux of Heat
+    ! units: W m-2
+    ! cell_methods: xq:point yh:sum z_l:sum
+"ocean_model_z_d2", "T_adx_xyave"  [Unused]
     ! long_name: Advective (by residual mean) Zonal Flux of Heat
     ! units: W m-2
     ! cell_methods: z_l:sum
@@ -3730,6 +7236,22 @@
     ! long_name: Advective (by residual mean) Meridional Flux of Heat
     ! units: W m-2
     ! cell_methods: z_l:sum
+"ocean_model_d2", "T_ady"  [Unused]
+    ! long_name: Advective (by residual mean) Meridional Flux of Heat
+    ! units: W m-2
+    ! cell_methods: xh:sum yq:point zl:sum
+"ocean_model_d2", "T_ady_xyave"  [Unused]
+    ! long_name: Advective (by residual mean) Meridional Flux of Heat
+    ! units: W m-2
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "T_ady"  [Unused]
+    ! long_name: Advective (by residual mean) Meridional Flux of Heat
+    ! units: W m-2
+    ! cell_methods: xh:sum yq:point z_l:sum
+"ocean_model_z_d2", "T_ady_xyave"  [Unused]
+    ! long_name: Advective (by residual mean) Meridional Flux of Heat
+    ! units: W m-2
+    ! cell_methods: z_l:sum
 "ocean_model", "T_diffx"  [Used]
     ! long_name: Diffusive Zonal Flux of Heat
     ! units: W m-2
@@ -3743,6 +7265,22 @@
     ! units: W m-2
     ! cell_methods: xq:point yh:sum z_l:sum
 "ocean_model_z", "T_diffx_xyave"  [Unused]
+    ! long_name: Diffusive Zonal Flux of Heat
+    ! units: W m-2
+    ! cell_methods: z_l:sum
+"ocean_model_d2", "T_diffx"  [Unused]
+    ! long_name: Diffusive Zonal Flux of Heat
+    ! units: W m-2
+    ! cell_methods: xq:point yh:sum zl:sum
+"ocean_model_d2", "T_diffx_xyave"  [Unused]
+    ! long_name: Diffusive Zonal Flux of Heat
+    ! units: W m-2
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "T_diffx"  [Unused]
+    ! long_name: Diffusive Zonal Flux of Heat
+    ! units: W m-2
+    ! cell_methods: xq:point yh:sum z_l:sum
+"ocean_model_z_d2", "T_diffx_xyave"  [Unused]
     ! long_name: Diffusive Zonal Flux of Heat
     ! units: W m-2
     ! cell_methods: z_l:sum
@@ -3762,7 +7300,27 @@
     ! long_name: Diffusive Meridional Flux of Heat
     ! units: W m-2
     ! cell_methods: z_l:sum
+"ocean_model_d2", "T_diffy"  [Unused]
+    ! long_name: Diffusive Meridional Flux of Heat
+    ! units: W m-2
+    ! cell_methods: xh:sum yq:point zl:sum
+"ocean_model_d2", "T_diffy_xyave"  [Unused]
+    ! long_name: Diffusive Meridional Flux of Heat
+    ! units: W m-2
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "T_diffy"  [Unused]
+    ! long_name: Diffusive Meridional Flux of Heat
+    ! units: W m-2
+    ! cell_methods: xh:sum yq:point z_l:sum
+"ocean_model_z_d2", "T_diffy_xyave"  [Unused]
+    ! long_name: Diffusive Meridional Flux of Heat
+    ! units: W m-2
+    ! cell_methods: z_l:sum
 "ocean_model", "T_adx_2d"  [Unused]
+    ! long_name: Vertically Integrated Advective Zonal Flux of Heat
+    ! units: W m-2
+    ! cell_methods: xq:point yh:sum
+"ocean_model_d2", "T_adx_2d"  [Unused]
     ! long_name: Vertically Integrated Advective Zonal Flux of Heat
     ! units: W m-2
     ! cell_methods: xq:point yh:sum
@@ -3770,11 +7328,23 @@
     ! long_name: Vertically Integrated Advective Meridional Flux of Heat
     ! units: W m-2
     ! cell_methods: xh:sum yq:point
+"ocean_model_d2", "T_ady_2d"  [Unused]
+    ! long_name: Vertically Integrated Advective Meridional Flux of Heat
+    ! units: W m-2
+    ! cell_methods: xh:sum yq:point
 "ocean_model", "T_diffx_2d"  [Unused]
     ! long_name: Vertically Integrated Diffusive Zonal Flux of Heat
     ! units: W m-2
     ! cell_methods: xq:point yh:sum
+"ocean_model_d2", "T_diffx_2d"  [Unused]
+    ! long_name: Vertically Integrated Diffusive Zonal Flux of Heat
+    ! units: W m-2
+    ! cell_methods: xq:point yh:sum
 "ocean_model", "T_diffy_2d"  [Unused]
+    ! long_name: Vertically Integrated Diffusive Meridional Flux of Heat
+    ! units: W m-2
+    ! cell_methods: xh:sum yq:point
+"ocean_model_d2", "T_diffy_2d"  [Unused]
     ! long_name: Vertically Integrated Diffusive Meridional Flux of Heat
     ! units: W m-2
     ! cell_methods: xh:sum yq:point
@@ -3794,7 +7364,27 @@
     ! long_name: Horizontal convergence of residual mean advective fluxes of heat
     ! units: W m-2
     ! cell_methods: z_l:sum
+"ocean_model_d2", "T_advection_xy"  [Unused]
+    ! long_name: Horizontal convergence of residual mean advective fluxes of heat
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "T_advection_xy_xyave"  [Unused]
+    ! long_name: Horizontal convergence of residual mean advective fluxes of heat
+    ! units: W m-2
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "T_advection_xy"  [Unused]
+    ! long_name: Horizontal convergence of residual mean advective fluxes of heat
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "T_advection_xy_xyave"  [Unused]
+    ! long_name: Horizontal convergence of residual mean advective fluxes of heat
+    ! units: W m-2
+    ! cell_methods: z_l:sum
 "ocean_model", "T_advection_xy_2d"  [Used]
+    ! long_name: Vertical sum of horizontal convergence of residual mean advective fluxes of heat
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "T_advection_xy_2d"  [Unused]
     ! long_name: Vertical sum of horizontal convergence of residual mean advective fluxes of heat
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -3811,6 +7401,22 @@
     ! units: degC s-1
     ! cell_methods: xh:mean yh:mean z_l:mean area:mean
 "ocean_model_z", "T_tendency_xyave"  [Unused]
+    ! long_name: Net time tendency for potential temperature
+    ! units: degC s-1
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "T_tendency"  [Unused]
+    ! long_name: Net time tendency for potential temperature
+    ! units: degC s-1
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "T_tendency_xyave"  [Unused]
+    ! long_name: Net time tendency for potential temperature
+    ! units: degC s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "T_tendency"  [Unused]
+    ! long_name: Net time tendency for potential temperature
+    ! units: degC s-1
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "T_tendency_xyave"  [Unused]
     ! long_name: Net time tendency for potential temperature
     ! units: degC s-1
     ! cell_methods: z_l:mean
@@ -3850,11 +7456,56 @@
     ! units: W m-2
     ! standard_name: tendency_of_sea_water_potential_temperature_expressed_as_heat_content_due_to_parameterized_mesoscale_diffusion
     ! cell_methods: z_l:sum
+"ocean_model_d2", "T_dfxy_cont_tendency"  [Unused] (CMOR equivalent is "opottemppmdiff")
+    ! long_name: Lateral or neutral diffusion tracer concentration tendency for T
+    ! units: W m-2
+    ! cell_methods: xh:sum yh:sum zl:sum area:sum
+"ocean_model_d2", "T_dfxy_cont_tendency_xyave"  [Unused] (CMOR equivalent is "opottemppmdiff_xyave")
+    ! long_name: Lateral or neutral diffusion tracer concentration tendency for T
+    ! units: W m-2
+    ! cell_methods: zl:sum
+"ocean_model_d2", "opottemppmdiff"  [Unused] (native name is "T_dfxy_cont_tendency")
+    ! long_name: Tendency of sea water potential temperature expressed as heat content due to parameterized mesoscale diffusion
+    ! units: W m-2
+    ! standard_name: tendency_of_sea_water_potential_temperature_expressed_as_heat_content_due_to_parameterized_mesoscale_diffusion
+    ! cell_methods: xh:sum yh:sum zl:sum area:sum
+"ocean_model_d2", "opottemppmdiff_xyave"  [Unused] (native name is "T_dfxy_cont_tendency_xyave")
+    ! long_name: Tendency of sea water potential temperature expressed as heat content due to parameterized mesoscale diffusion
+    ! units: W m-2
+    ! standard_name: tendency_of_sea_water_potential_temperature_expressed_as_heat_content_due_to_parameterized_mesoscale_diffusion
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "T_dfxy_cont_tendency"  [Unused] (CMOR equivalent is "opottemppmdiff")
+    ! long_name: Lateral or neutral diffusion tracer concentration tendency for T
+    ! units: W m-2
+    ! cell_methods: xh:sum yh:sum z_l:sum area:sum
+"ocean_model_z_d2", "T_dfxy_cont_tendency_xyave"  [Unused] (CMOR equivalent is "opottemppmdiff_xyave")
+    ! long_name: Lateral or neutral diffusion tracer concentration tendency for T
+    ! units: W m-2
+    ! cell_methods: z_l:sum
+"ocean_model_z_d2", "opottemppmdiff"  [Unused] (native name is "T_dfxy_cont_tendency")
+    ! long_name: Tendency of sea water potential temperature expressed as heat content due to parameterized mesoscale diffusion
+    ! units: W m-2
+    ! standard_name: tendency_of_sea_water_potential_temperature_expressed_as_heat_content_due_to_parameterized_mesoscale_diffusion
+    ! cell_methods: xh:sum yh:sum z_l:sum area:sum
+"ocean_model_z_d2", "opottemppmdiff_xyave"  [Unused] (native name is "T_dfxy_cont_tendency_xyave")
+    ! long_name: Tendency of sea water potential temperature expressed as heat content due to parameterized mesoscale diffusion
+    ! units: W m-2
+    ! standard_name: tendency_of_sea_water_potential_temperature_expressed_as_heat_content_due_to_parameterized_mesoscale_diffusion
+    ! cell_methods: z_l:sum
 "ocean_model", "T_dfxy_cont_tendency_2d"  [Unused] (CMOR equivalent is "opottemppmdiff_2d")
     ! long_name: Depth integrated lateral or neutral diffusion tracer concentration tendency for T
     ! units: W m-2
     ! cell_methods: xh:sum yh:sum area:sum
 "ocean_model", "opottemppmdiff_2d"  [Unused] (native name is "T_dfxy_cont_tendency_2d")
+    ! long_name: Tendency of sea water potential temperature expressed as heat content due to parameterized mesoscale diffusion
+    ! units: W m-2
+    ! standard_name: tendency_of_sea_water_potential_temperature_expressed_as_heat_content_due_to_parameterized_mesoscale_diffusion
+    ! cell_methods: xh:sum yh:sum area:sum
+"ocean_model_d2", "T_dfxy_cont_tendency_2d"  [Unused] (CMOR equivalent is "opottemppmdiff_2d")
+    ! long_name: Depth integrated lateral or neutral diffusion tracer concentration tendency for T
+    ! units: W m-2
+    ! cell_methods: xh:sum yh:sum area:sum
+"ocean_model_d2", "opottemppmdiff_2d"  [Unused] (native name is "T_dfxy_cont_tendency_2d")
     ! long_name: Tendency of sea water potential temperature expressed as heat content due to parameterized mesoscale diffusion
     ! units: W m-2
     ! standard_name: tendency_of_sea_water_potential_temperature_expressed_as_heat_content_due_to_parameterized_mesoscale_diffusion
@@ -3872,6 +7523,22 @@
     ! units: degC s-1
     ! cell_methods: xh:mean yh:mean z_l:mean area:mean
 "ocean_model_z", "T_dfxy_conc_tendency_xyave"  [Unused]
+    ! long_name: Lateral (neutral) tracer concentration tendency for T
+    ! units: degC s-1
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "T_dfxy_conc_tendency"  [Unused]
+    ! long_name: Lateral (neutral) tracer concentration tendency for T
+    ! units: degC s-1
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "T_dfxy_conc_tendency_xyave"  [Unused]
+    ! long_name: Lateral (neutral) tracer concentration tendency for T
+    ! units: degC s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "T_dfxy_conc_tendency"  [Unused]
+    ! long_name: Lateral (neutral) tracer concentration tendency for T
+    ! units: degC s-1
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "T_dfxy_conc_tendency_xyave"  [Unused]
     ! long_name: Lateral (neutral) tracer concentration tendency for T
     ! units: degC s-1
     ! cell_methods: z_l:mean
@@ -3911,11 +7578,56 @@
     ! units: W m-2
     ! standard_name: tendency_of_sea_water_potential_temperature_expressed_as_heat_content
     ! cell_methods: z_l:sum
+"ocean_model_d2", "Th_tendency"  [Unused] (CMOR equivalent is "opottemptend")
+    ! long_name: Net time tendency for heat
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "Th_tendency_xyave"  [Unused] (CMOR equivalent is "opottemptend_xyave")
+    ! long_name: Net time tendency for heat
+    ! units: W m-2
+    ! cell_methods: zl:sum
+"ocean_model_d2", "opottemptend"  [Unused] (native name is "Th_tendency")
+    ! long_name: Tendency of Sea Water Potential Temperature Expressed as Heat Content
+    ! units: W m-2
+    ! standard_name: tendency_of_sea_water_potential_temperature_expressed_as_heat_content
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "opottemptend_xyave"  [Unused] (native name is "Th_tendency_xyave")
+    ! long_name: Tendency of Sea Water Potential Temperature Expressed as Heat Content
+    ! units: W m-2
+    ! standard_name: tendency_of_sea_water_potential_temperature_expressed_as_heat_content
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "Th_tendency"  [Unused] (CMOR equivalent is "opottemptend")
+    ! long_name: Net time tendency for heat
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "Th_tendency_xyave"  [Unused] (CMOR equivalent is "opottemptend_xyave")
+    ! long_name: Net time tendency for heat
+    ! units: W m-2
+    ! cell_methods: z_l:sum
+"ocean_model_z_d2", "opottemptend"  [Unused] (native name is "Th_tendency")
+    ! long_name: Tendency of Sea Water Potential Temperature Expressed as Heat Content
+    ! units: W m-2
+    ! standard_name: tendency_of_sea_water_potential_temperature_expressed_as_heat_content
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "opottemptend_xyave"  [Unused] (native name is "Th_tendency_xyave")
+    ! long_name: Tendency of Sea Water Potential Temperature Expressed as Heat Content
+    ! units: W m-2
+    ! standard_name: tendency_of_sea_water_potential_temperature_expressed_as_heat_content
+    ! cell_methods: z_l:sum
 "ocean_model", "Th_tendency_2d"  [Unused] (CMOR equivalent is "opottemptend_2d")
     ! long_name: Vertical sum of net time tendency for heat
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "opottemptend_2d"  [Used] (native name is "Th_tendency_2d")
+    ! long_name: Tendency of Sea Water Potential Temperature Expressed as Heat Content Vertical Sum
+    ! units: W m-2
+    ! standard_name: tendency_of_sea_water_potential_temperature_expressed_as_heat_content_vertical_sum
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "Th_tendency_2d"  [Unused] (CMOR equivalent is "opottemptend_2d")
+    ! long_name: Vertical sum of net time tendency for heat
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "opottemptend_2d"  [Unused] (native name is "Th_tendency_2d")
     ! long_name: Tendency of Sea Water Potential Temperature Expressed as Heat Content Vertical Sum
     ! units: W m-2
     ! standard_name: tendency_of_sea_water_potential_temperature_expressed_as_heat_content_vertical_sum
@@ -3928,11 +7640,19 @@
     ! long_name: Potential Temperature
     ! units: degC
     ! standard_name: not provided
+"ocean_model_zold_d2", "temp_xyave"  [Unused]
+    ! long_name: Potential Temperature
+    ! units: degC
+    ! standard_name: not provided
 "ocean_model_zold", "thetao"  [Unused]
     ! long_name: Sea Water Potential Temperature
     ! units: degC
     ! standard_name: sea_water_potential_temperature
 "ocean_model_zold", "thetao_xyave"  [Unused]
+    ! long_name: Sea Water Potential Temperature
+    ! units: degC
+    ! standard_name: sea_water_potential_temperature
+"ocean_model_zold_d2", "thetao_xyave"  [Unused]
     ! long_name: Sea Water Potential Temperature
     ! units: degC
     ! standard_name: sea_water_potential_temperature
@@ -3952,6 +7672,22 @@
     ! long_name: Vertical remapping tracer concentration tendency for temp
     ! units: degC s-1
     ! cell_methods: z_l:mean
+"ocean_model_d2", "T_tendency_vert_remap"  [Unused]
+    ! long_name: Vertical remapping tracer concentration tendency for temp
+    ! units: degC s-1
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "T_tendency_vert_remap_xyave"  [Unused]
+    ! long_name: Vertical remapping tracer concentration tendency for temp
+    ! units: degC s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "T_tendency_vert_remap"  [Unused]
+    ! long_name: Vertical remapping tracer concentration tendency for temp
+    ! units: degC s-1
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "T_tendency_vert_remap_xyave"  [Unused]
+    ! long_name: Vertical remapping tracer concentration tendency for temp
+    ! units: degC s-1
+    ! cell_methods: z_l:mean
 "ocean_model", "Th_tendency_vert_remap"  [Unused]
     ! long_name: Vertical remapping tracer content tendency for Heat
     ! units: W m-2
@@ -3968,7 +7704,27 @@
     ! long_name: Vertical remapping tracer content tendency for Heat
     ! units: W m-2
     ! cell_methods: z_l:sum
+"ocean_model_d2", "Th_tendency_vert_remap"  [Unused]
+    ! long_name: Vertical remapping tracer content tendency for Heat
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "Th_tendency_vert_remap_xyave"  [Unused]
+    ! long_name: Vertical remapping tracer content tendency for Heat
+    ! units: W m-2
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "Th_tendency_vert_remap"  [Unused]
+    ! long_name: Vertical remapping tracer content tendency for Heat
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "Th_tendency_vert_remap_xyave"  [Unused]
+    ! long_name: Vertical remapping tracer content tendency for Heat
+    ! units: W m-2
+    ! cell_methods: z_l:sum
 "ocean_model", "Th_tendency_vert_remap_2d"  [Unused]
+    ! long_name: Vertical sum of vertical remapping tracer content tendency for Heat
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "Th_tendency_vert_remap_2d"  [Unused]
     ! long_name: Vertical sum of vertical remapping tracer content tendency for Heat
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -3985,6 +7741,22 @@
     ! units: degC2 s-1
     ! cell_methods: xh:mean yh:mean z_l:mean area:mean
 "ocean_model_z", "T_vardec_xyave"  [Unused]
+    ! long_name: ALE variance decay for potential temperature
+    ! units: degC2 s-1
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "T_vardec"  [Unused]
+    ! long_name: ALE variance decay for potential temperature
+    ! units: degC2 s-1
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "T_vardec_xyave"  [Unused]
+    ! long_name: ALE variance decay for potential temperature
+    ! units: degC2 s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "T_vardec"  [Unused]
+    ! long_name: ALE variance decay for potential temperature
+    ! units: degC2 s-1
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "T_vardec_xyave"  [Unused]
     ! long_name: ALE variance decay for potential temperature
     ! units: degC2 s-1
     ! cell_methods: z_l:mean
@@ -4024,6 +7796,42 @@
     ! units: psu
     ! standard_name: sea_water_salinity
     ! cell_methods: z_l:mean
+"ocean_model_d2", "salt"  [Unused] (CMOR equivalent is "so")
+    ! long_name: Salinity
+    ! units: psu
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "salt_xyave"  [Unused] (CMOR equivalent is "so_xyave")
+    ! long_name: Salinity
+    ! units: psu
+    ! cell_methods: zl:mean
+"ocean_model_d2", "so"  [Unused] (native name is "salt")
+    ! long_name: Sea Water Salinity
+    ! units: psu
+    ! standard_name: sea_water_salinity
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "so_xyave"  [Unused] (native name is "salt_xyave")
+    ! long_name: Sea Water Salinity
+    ! units: psu
+    ! standard_name: sea_water_salinity
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "salt"  [Unused] (CMOR equivalent is "so")
+    ! long_name: Salinity
+    ! units: psu
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "salt_xyave"  [Unused] (CMOR equivalent is "so_xyave")
+    ! long_name: Salinity
+    ! units: psu
+    ! cell_methods: z_l:mean
+"ocean_model_z_d2", "so"  [Unused] (native name is "salt")
+    ! long_name: Sea Water Salinity
+    ! units: psu
+    ! standard_name: sea_water_salinity
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "so_xyave"  [Unused] (native name is "salt_xyave")
+    ! long_name: Sea Water Salinity
+    ! units: psu
+    ! standard_name: sea_water_salinity
+    ! cell_methods: z_l:mean
 "ocean_model", "S_adx"  [Used]
     ! long_name: Advective (by residual mean) Zonal Flux of Salt
     ! units: psu m3 s-1
@@ -4037,6 +7845,22 @@
     ! units: psu m3 s-1
     ! cell_methods: xq:point yh:sum z_l:sum
 "ocean_model_z", "S_adx_xyave"  [Unused]
+    ! long_name: Advective (by residual mean) Zonal Flux of Salt
+    ! units: psu m3 s-1
+    ! cell_methods: z_l:sum
+"ocean_model_d2", "S_adx"  [Unused]
+    ! long_name: Advective (by residual mean) Zonal Flux of Salt
+    ! units: psu m3 s-1
+    ! cell_methods: xq:point yh:sum zl:sum
+"ocean_model_d2", "S_adx_xyave"  [Unused]
+    ! long_name: Advective (by residual mean) Zonal Flux of Salt
+    ! units: psu m3 s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "S_adx"  [Unused]
+    ! long_name: Advective (by residual mean) Zonal Flux of Salt
+    ! units: psu m3 s-1
+    ! cell_methods: xq:point yh:sum z_l:sum
+"ocean_model_z_d2", "S_adx_xyave"  [Unused]
     ! long_name: Advective (by residual mean) Zonal Flux of Salt
     ! units: psu m3 s-1
     ! cell_methods: z_l:sum
@@ -4056,6 +7880,22 @@
     ! long_name: Advective (by residual mean) Meridional Flux of Salt
     ! units: psu m3 s-1
     ! cell_methods: z_l:sum
+"ocean_model_d2", "S_ady"  [Unused]
+    ! long_name: Advective (by residual mean) Meridional Flux of Salt
+    ! units: psu m3 s-1
+    ! cell_methods: xh:sum yq:point zl:sum
+"ocean_model_d2", "S_ady_xyave"  [Unused]
+    ! long_name: Advective (by residual mean) Meridional Flux of Salt
+    ! units: psu m3 s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "S_ady"  [Unused]
+    ! long_name: Advective (by residual mean) Meridional Flux of Salt
+    ! units: psu m3 s-1
+    ! cell_methods: xh:sum yq:point z_l:sum
+"ocean_model_z_d2", "S_ady_xyave"  [Unused]
+    ! long_name: Advective (by residual mean) Meridional Flux of Salt
+    ! units: psu m3 s-1
+    ! cell_methods: z_l:sum
 "ocean_model", "S_diffx"  [Used]
     ! long_name: Diffusive Zonal Flux of Salt
     ! units: psu m3 s-1
@@ -4069,6 +7909,22 @@
     ! units: psu m3 s-1
     ! cell_methods: xq:point yh:sum z_l:sum
 "ocean_model_z", "S_diffx_xyave"  [Unused]
+    ! long_name: Diffusive Zonal Flux of Salt
+    ! units: psu m3 s-1
+    ! cell_methods: z_l:sum
+"ocean_model_d2", "S_diffx"  [Unused]
+    ! long_name: Diffusive Zonal Flux of Salt
+    ! units: psu m3 s-1
+    ! cell_methods: xq:point yh:sum zl:sum
+"ocean_model_d2", "S_diffx_xyave"  [Unused]
+    ! long_name: Diffusive Zonal Flux of Salt
+    ! units: psu m3 s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "S_diffx"  [Unused]
+    ! long_name: Diffusive Zonal Flux of Salt
+    ! units: psu m3 s-1
+    ! cell_methods: xq:point yh:sum z_l:sum
+"ocean_model_z_d2", "S_diffx_xyave"  [Unused]
     ! long_name: Diffusive Zonal Flux of Salt
     ! units: psu m3 s-1
     ! cell_methods: z_l:sum
@@ -4088,7 +7944,27 @@
     ! long_name: Diffusive Meridional Flux of Salt
     ! units: psu m3 s-1
     ! cell_methods: z_l:sum
+"ocean_model_d2", "S_diffy"  [Unused]
+    ! long_name: Diffusive Meridional Flux of Salt
+    ! units: psu m3 s-1
+    ! cell_methods: xh:sum yq:point zl:sum
+"ocean_model_d2", "S_diffy_xyave"  [Unused]
+    ! long_name: Diffusive Meridional Flux of Salt
+    ! units: psu m3 s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "S_diffy"  [Unused]
+    ! long_name: Diffusive Meridional Flux of Salt
+    ! units: psu m3 s-1
+    ! cell_methods: xh:sum yq:point z_l:sum
+"ocean_model_z_d2", "S_diffy_xyave"  [Unused]
+    ! long_name: Diffusive Meridional Flux of Salt
+    ! units: psu m3 s-1
+    ! cell_methods: z_l:sum
 "ocean_model", "S_adx_2d"  [Unused]
+    ! long_name: Vertically Integrated Advective Zonal Flux of Salt
+    ! units: psu m3 s-1
+    ! cell_methods: xq:point yh:sum
+"ocean_model_d2", "S_adx_2d"  [Unused]
     ! long_name: Vertically Integrated Advective Zonal Flux of Salt
     ! units: psu m3 s-1
     ! cell_methods: xq:point yh:sum
@@ -4096,11 +7972,23 @@
     ! long_name: Vertically Integrated Advective Meridional Flux of Salt
     ! units: psu m3 s-1
     ! cell_methods: xh:sum yq:point
+"ocean_model_d2", "S_ady_2d"  [Unused]
+    ! long_name: Vertically Integrated Advective Meridional Flux of Salt
+    ! units: psu m3 s-1
+    ! cell_methods: xh:sum yq:point
 "ocean_model", "S_diffx_2d"  [Unused]
     ! long_name: Vertically Integrated Diffusive Zonal Flux of Salt
     ! units: psu m3 s-1
     ! cell_methods: xq:point yh:sum
+"ocean_model_d2", "S_diffx_2d"  [Unused]
+    ! long_name: Vertically Integrated Diffusive Zonal Flux of Salt
+    ! units: psu m3 s-1
+    ! cell_methods: xq:point yh:sum
 "ocean_model", "S_diffy_2d"  [Unused]
+    ! long_name: Vertically Integrated Diffusive Meridional Flux of Salt
+    ! units: psu m3 s-1
+    ! cell_methods: xh:sum yq:point
+"ocean_model_d2", "S_diffy_2d"  [Unused]
     ! long_name: Vertically Integrated Diffusive Meridional Flux of Salt
     ! units: psu m3 s-1
     ! cell_methods: xh:sum yq:point
@@ -4120,7 +8008,27 @@
     ! long_name: Horizontal convergence of residual mean advective fluxes of salt
     ! units: kg m-2 s-1
     ! cell_methods: z_l:sum
+"ocean_model_d2", "S_advection_xy"  [Unused]
+    ! long_name: Horizontal convergence of residual mean advective fluxes of salt
+    ! units: kg m-2 s-1
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "S_advection_xy_xyave"  [Unused]
+    ! long_name: Horizontal convergence of residual mean advective fluxes of salt
+    ! units: kg m-2 s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "S_advection_xy"  [Unused]
+    ! long_name: Horizontal convergence of residual mean advective fluxes of salt
+    ! units: kg m-2 s-1
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "S_advection_xy_xyave"  [Unused]
+    ! long_name: Horizontal convergence of residual mean advective fluxes of salt
+    ! units: kg m-2 s-1
+    ! cell_methods: z_l:sum
 "ocean_model", "S_advection_xy_2d"  [Used]
+    ! long_name: Vertical sum of horizontal convergence of residual mean advective fluxes of salt
+    ! units: kg m-2 s-1
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "S_advection_xy_2d"  [Unused]
     ! long_name: Vertical sum of horizontal convergence of residual mean advective fluxes of salt
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
@@ -4137,6 +8045,22 @@
     ! units: psu s-1
     ! cell_methods: xh:mean yh:mean z_l:mean area:mean
 "ocean_model_z", "S_tendency_xyave"  [Unused]
+    ! long_name: Net time tendency for salinity
+    ! units: psu s-1
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "S_tendency"  [Unused]
+    ! long_name: Net time tendency for salinity
+    ! units: psu s-1
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "S_tendency_xyave"  [Unused]
+    ! long_name: Net time tendency for salinity
+    ! units: psu s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "S_tendency"  [Unused]
+    ! long_name: Net time tendency for salinity
+    ! units: psu s-1
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "S_tendency_xyave"  [Unused]
     ! long_name: Net time tendency for salinity
     ! units: psu s-1
     ! cell_methods: z_l:mean
@@ -4176,11 +8100,56 @@
     ! units: kg m-2 s-1
     ! standard_name: tendency_of_sea_water_salinity_expressed_as_salt_content_due_to_parameterized_mesoscale_diffusion
     ! cell_methods: z_l:sum
+"ocean_model_d2", "S_dfxy_cont_tendency"  [Unused] (CMOR equivalent is "osaltpmdiff")
+    ! long_name: Lateral or neutral diffusion tracer concentration tendency for S
+    ! units: kg m-2 s-1
+    ! cell_methods: xh:sum yh:sum zl:sum area:sum
+"ocean_model_d2", "S_dfxy_cont_tendency_xyave"  [Unused] (CMOR equivalent is "osaltpmdiff_xyave")
+    ! long_name: Lateral or neutral diffusion tracer concentration tendency for S
+    ! units: kg m-2 s-1
+    ! cell_methods: zl:sum
+"ocean_model_d2", "osaltpmdiff"  [Unused] (native name is "S_dfxy_cont_tendency")
+    ! long_name: Tendency of sea water salinity expressed as salt content due to parameterized mesoscale diffusion
+    ! units: kg m-2 s-1
+    ! standard_name: tendency_of_sea_water_salinity_expressed_as_salt_content_due_to_parameterized_mesoscale_diffusion
+    ! cell_methods: xh:sum yh:sum zl:sum area:sum
+"ocean_model_d2", "osaltpmdiff_xyave"  [Unused] (native name is "S_dfxy_cont_tendency_xyave")
+    ! long_name: Tendency of sea water salinity expressed as salt content due to parameterized mesoscale diffusion
+    ! units: kg m-2 s-1
+    ! standard_name: tendency_of_sea_water_salinity_expressed_as_salt_content_due_to_parameterized_mesoscale_diffusion
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "S_dfxy_cont_tendency"  [Unused] (CMOR equivalent is "osaltpmdiff")
+    ! long_name: Lateral or neutral diffusion tracer concentration tendency for S
+    ! units: kg m-2 s-1
+    ! cell_methods: xh:sum yh:sum z_l:sum area:sum
+"ocean_model_z_d2", "S_dfxy_cont_tendency_xyave"  [Unused] (CMOR equivalent is "osaltpmdiff_xyave")
+    ! long_name: Lateral or neutral diffusion tracer concentration tendency for S
+    ! units: kg m-2 s-1
+    ! cell_methods: z_l:sum
+"ocean_model_z_d2", "osaltpmdiff"  [Unused] (native name is "S_dfxy_cont_tendency")
+    ! long_name: Tendency of sea water salinity expressed as salt content due to parameterized mesoscale diffusion
+    ! units: kg m-2 s-1
+    ! standard_name: tendency_of_sea_water_salinity_expressed_as_salt_content_due_to_parameterized_mesoscale_diffusion
+    ! cell_methods: xh:sum yh:sum z_l:sum area:sum
+"ocean_model_z_d2", "osaltpmdiff_xyave"  [Unused] (native name is "S_dfxy_cont_tendency_xyave")
+    ! long_name: Tendency of sea water salinity expressed as salt content due to parameterized mesoscale diffusion
+    ! units: kg m-2 s-1
+    ! standard_name: tendency_of_sea_water_salinity_expressed_as_salt_content_due_to_parameterized_mesoscale_diffusion
+    ! cell_methods: z_l:sum
 "ocean_model", "S_dfxy_cont_tendency_2d"  [Unused] (CMOR equivalent is "osaltpmdiff_2d")
     ! long_name: Depth integrated lateral or neutral diffusion tracer concentration tendency for S
     ! units: kg m-2 s-1
     ! cell_methods: xh:sum yh:sum area:sum
 "ocean_model", "osaltpmdiff_2d"  [Unused] (native name is "S_dfxy_cont_tendency_2d")
+    ! long_name: Tendency of sea water salinity expressed as salt content due to parameterized mesoscale diffusion
+    ! units: kg m-2 s-1
+    ! standard_name: tendency_of_sea_water_salinity_expressed_as_salt_content_due_to_parameterized_mesoscale_diffusion
+    ! cell_methods: xh:sum yh:sum area:sum
+"ocean_model_d2", "S_dfxy_cont_tendency_2d"  [Unused] (CMOR equivalent is "osaltpmdiff_2d")
+    ! long_name: Depth integrated lateral or neutral diffusion tracer concentration tendency for S
+    ! units: kg m-2 s-1
+    ! cell_methods: xh:sum yh:sum area:sum
+"ocean_model_d2", "osaltpmdiff_2d"  [Unused] (native name is "S_dfxy_cont_tendency_2d")
     ! long_name: Tendency of sea water salinity expressed as salt content due to parameterized mesoscale diffusion
     ! units: kg m-2 s-1
     ! standard_name: tendency_of_sea_water_salinity_expressed_as_salt_content_due_to_parameterized_mesoscale_diffusion
@@ -4198,6 +8167,22 @@
     ! units: psu s-1
     ! cell_methods: xh:mean yh:mean z_l:mean area:mean
 "ocean_model_z", "S_dfxy_conc_tendency_xyave"  [Unused]
+    ! long_name: Lateral (neutral) tracer concentration tendency for S
+    ! units: psu s-1
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "S_dfxy_conc_tendency"  [Unused]
+    ! long_name: Lateral (neutral) tracer concentration tendency for S
+    ! units: psu s-1
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "S_dfxy_conc_tendency_xyave"  [Unused]
+    ! long_name: Lateral (neutral) tracer concentration tendency for S
+    ! units: psu s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "S_dfxy_conc_tendency"  [Unused]
+    ! long_name: Lateral (neutral) tracer concentration tendency for S
+    ! units: psu s-1
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "S_dfxy_conc_tendency_xyave"  [Unused]
     ! long_name: Lateral (neutral) tracer concentration tendency for S
     ! units: psu s-1
     ! cell_methods: z_l:mean
@@ -4237,11 +8222,56 @@
     ! units: kg m-2 s-1
     ! standard_name: tendency_of_sea_water_salinity_expressed_as_salt_content
     ! cell_methods: z_l:sum
+"ocean_model_d2", "Sh_tendency"  [Unused] (CMOR equivalent is "osalttend")
+    ! long_name: Net time tendency for salt
+    ! units: kg m-2 s-1
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "Sh_tendency_xyave"  [Unused] (CMOR equivalent is "osalttend_xyave")
+    ! long_name: Net time tendency for salt
+    ! units: kg m-2 s-1
+    ! cell_methods: zl:sum
+"ocean_model_d2", "osalttend"  [Unused] (native name is "Sh_tendency")
+    ! long_name: Tendency of Sea Water Salinity Expressed as Salt Content
+    ! units: kg m-2 s-1
+    ! standard_name: tendency_of_sea_water_salinity_expressed_as_salt_content
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "osalttend_xyave"  [Unused] (native name is "Sh_tendency_xyave")
+    ! long_name: Tendency of Sea Water Salinity Expressed as Salt Content
+    ! units: kg m-2 s-1
+    ! standard_name: tendency_of_sea_water_salinity_expressed_as_salt_content
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "Sh_tendency"  [Unused] (CMOR equivalent is "osalttend")
+    ! long_name: Net time tendency for salt
+    ! units: kg m-2 s-1
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "Sh_tendency_xyave"  [Unused] (CMOR equivalent is "osalttend_xyave")
+    ! long_name: Net time tendency for salt
+    ! units: kg m-2 s-1
+    ! cell_methods: z_l:sum
+"ocean_model_z_d2", "osalttend"  [Unused] (native name is "Sh_tendency")
+    ! long_name: Tendency of Sea Water Salinity Expressed as Salt Content
+    ! units: kg m-2 s-1
+    ! standard_name: tendency_of_sea_water_salinity_expressed_as_salt_content
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "osalttend_xyave"  [Unused] (native name is "Sh_tendency_xyave")
+    ! long_name: Tendency of Sea Water Salinity Expressed as Salt Content
+    ! units: kg m-2 s-1
+    ! standard_name: tendency_of_sea_water_salinity_expressed_as_salt_content
+    ! cell_methods: z_l:sum
 "ocean_model", "Sh_tendency_2d"  [Unused] (CMOR equivalent is "osalttend_2d")
     ! long_name: Vertical sum of net time tendency for salt
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "osalttend_2d"  [Used] (native name is "Sh_tendency_2d")
+    ! long_name: Tendency of Sea Water Salinity Expressed as Salt Content Vertical Sum
+    ! units: kg m-2 s-1
+    ! standard_name: tendency_of_sea_water_salinity_expressed_as_salt_content_vertical_sum
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "Sh_tendency_2d"  [Unused] (CMOR equivalent is "osalttend_2d")
+    ! long_name: Vertical sum of net time tendency for salt
+    ! units: kg m-2 s-1
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "osalttend_2d"  [Unused] (native name is "Sh_tendency_2d")
     ! long_name: Tendency of Sea Water Salinity Expressed as Salt Content Vertical Sum
     ! units: kg m-2 s-1
     ! standard_name: tendency_of_sea_water_salinity_expressed_as_salt_content_vertical_sum
@@ -4254,11 +8284,19 @@
     ! long_name: Salinity
     ! units: psu
     ! standard_name: not provided
+"ocean_model_zold_d2", "salt_xyave"  [Unused]
+    ! long_name: Salinity
+    ! units: psu
+    ! standard_name: not provided
 "ocean_model_zold", "so"  [Unused]
     ! long_name: Sea Water Salinity
     ! units: psu
     ! standard_name: sea_water_salinity
 "ocean_model_zold", "so_xyave"  [Unused]
+    ! long_name: Sea Water Salinity
+    ! units: psu
+    ! standard_name: sea_water_salinity
+"ocean_model_zold_d2", "so_xyave"  [Unused]
     ! long_name: Sea Water Salinity
     ! units: psu
     ! standard_name: sea_water_salinity
@@ -4278,6 +8316,22 @@
     ! long_name: Vertical remapping tracer concentration tendency for salt
     ! units: psu s-1
     ! cell_methods: z_l:mean
+"ocean_model_d2", "S_tendency_vert_remap"  [Unused]
+    ! long_name: Vertical remapping tracer concentration tendency for salt
+    ! units: psu s-1
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "S_tendency_vert_remap_xyave"  [Unused]
+    ! long_name: Vertical remapping tracer concentration tendency for salt
+    ! units: psu s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "S_tendency_vert_remap"  [Unused]
+    ! long_name: Vertical remapping tracer concentration tendency for salt
+    ! units: psu s-1
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "S_tendency_vert_remap_xyave"  [Unused]
+    ! long_name: Vertical remapping tracer concentration tendency for salt
+    ! units: psu s-1
+    ! cell_methods: z_l:mean
 "ocean_model", "Sh_tendency_vert_remap"  [Unused]
     ! long_name: Vertical remapping tracer content tendency for Salt
     ! units: psu m3 s-1
@@ -4294,7 +8348,27 @@
     ! long_name: Vertical remapping tracer content tendency for Salt
     ! units: psu m3 s-1
     ! cell_methods: z_l:sum
+"ocean_model_d2", "Sh_tendency_vert_remap"  [Unused]
+    ! long_name: Vertical remapping tracer content tendency for Salt
+    ! units: psu m3 s-1
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "Sh_tendency_vert_remap_xyave"  [Unused]
+    ! long_name: Vertical remapping tracer content tendency for Salt
+    ! units: psu m3 s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "Sh_tendency_vert_remap"  [Unused]
+    ! long_name: Vertical remapping tracer content tendency for Salt
+    ! units: psu m3 s-1
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "Sh_tendency_vert_remap_xyave"  [Unused]
+    ! long_name: Vertical remapping tracer content tendency for Salt
+    ! units: psu m3 s-1
+    ! cell_methods: z_l:sum
 "ocean_model", "Sh_tendency_vert_remap_2d"  [Unused]
+    ! long_name: Vertical sum of vertical remapping tracer content tendency for Salt
+    ! units: psu m3 s-1
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "Sh_tendency_vert_remap_2d"  [Unused]
     ! long_name: Vertical sum of vertical remapping tracer content tendency for Salt
     ! units: psu m3 s-1
     ! cell_methods: xh:mean yh:mean area:mean
@@ -4311,6 +8385,22 @@
     ! units: psu2 s-1
     ! cell_methods: xh:mean yh:mean z_l:mean area:mean
 "ocean_model_z", "S_vardec_xyave"  [Unused]
+    ! long_name: ALE variance decay for salinity
+    ! units: psu2 s-1
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "S_vardec"  [Unused]
+    ! long_name: ALE variance decay for salinity
+    ! units: psu2 s-1
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "S_vardec_xyave"  [Unused]
+    ! long_name: ALE variance decay for salinity
+    ! units: psu2 s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "S_vardec"  [Unused]
+    ! long_name: ALE variance decay for salinity
+    ! units: psu2 s-1
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "S_vardec_xyave"  [Unused]
     ! long_name: ALE variance decay for salinity
     ! units: psu2 s-1
     ! cell_methods: z_l:mean
@@ -4350,6 +8440,42 @@
     ! units: yr
     ! standard_name: ideal_age_tracer
     ! cell_methods: z_l:mean
+"ocean_model_d2", "age"  [Unused] (CMOR equivalent is "agessc")
+    ! long_name: Ideal Age Tracer
+    ! units: yr
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "age_xyave"  [Unused] (CMOR equivalent is "agessc_xyave")
+    ! long_name: Ideal Age Tracer
+    ! units: yr
+    ! cell_methods: zl:mean
+"ocean_model_d2", "agessc"  [Unused] (native name is "age")
+    ! long_name: Ideal Age Tracer
+    ! units: yr
+    ! standard_name: ideal_age_tracer
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "agessc_xyave"  [Unused] (native name is "age_xyave")
+    ! long_name: Ideal Age Tracer
+    ! units: yr
+    ! standard_name: ideal_age_tracer
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "age"  [Unused] (CMOR equivalent is "agessc")
+    ! long_name: Ideal Age Tracer
+    ! units: yr
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "age_xyave"  [Unused] (CMOR equivalent is "agessc_xyave")
+    ! long_name: Ideal Age Tracer
+    ! units: yr
+    ! cell_methods: z_l:mean
+"ocean_model_z_d2", "agessc"  [Unused] (native name is "age")
+    ! long_name: Ideal Age Tracer
+    ! units: yr
+    ! standard_name: ideal_age_tracer
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "agessc_xyave"  [Unused] (native name is "age_xyave")
+    ! long_name: Ideal Age Tracer
+    ! units: yr
+    ! standard_name: ideal_age_tracer
+    ! cell_methods: z_l:mean
 "ocean_model", "age_adx"  [Unused]
     ! long_name: Ideal Age Tracer advective zonal flux
     ! units: yr m3 s-1
@@ -4363,6 +8489,22 @@
     ! units: yr m3 s-1
     ! cell_methods: xq:point yh:sum z_l:sum
 "ocean_model_z", "age_adx_xyave"  [Unused]
+    ! long_name: Ideal Age Tracer advective zonal flux
+    ! units: yr m3 s-1
+    ! cell_methods: z_l:sum
+"ocean_model_d2", "age_adx"  [Unused]
+    ! long_name: Ideal Age Tracer advective zonal flux
+    ! units: yr m3 s-1
+    ! cell_methods: xq:point yh:sum zl:sum
+"ocean_model_d2", "age_adx_xyave"  [Unused]
+    ! long_name: Ideal Age Tracer advective zonal flux
+    ! units: yr m3 s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "age_adx"  [Unused]
+    ! long_name: Ideal Age Tracer advective zonal flux
+    ! units: yr m3 s-1
+    ! cell_methods: xq:point yh:sum z_l:sum
+"ocean_model_z_d2", "age_adx_xyave"  [Unused]
     ! long_name: Ideal Age Tracer advective zonal flux
     ! units: yr m3 s-1
     ! cell_methods: z_l:sum
@@ -4382,6 +8524,22 @@
     ! long_name: Ideal Age Tracer advective meridional flux
     ! units: yr m3 s-1
     ! cell_methods: z_l:sum
+"ocean_model_d2", "age_ady"  [Unused]
+    ! long_name: Ideal Age Tracer advective meridional flux
+    ! units: yr m3 s-1
+    ! cell_methods: xh:sum yq:point zl:sum
+"ocean_model_d2", "age_ady_xyave"  [Unused]
+    ! long_name: Ideal Age Tracer advective meridional flux
+    ! units: yr m3 s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "age_ady"  [Unused]
+    ! long_name: Ideal Age Tracer advective meridional flux
+    ! units: yr m3 s-1
+    ! cell_methods: xh:sum yq:point z_l:sum
+"ocean_model_z_d2", "age_ady_xyave"  [Unused]
+    ! long_name: Ideal Age Tracer advective meridional flux
+    ! units: yr m3 s-1
+    ! cell_methods: z_l:sum
 "ocean_model", "age_dfx"  [Unused]
     ! long_name: Ideal Age Tracer diffusive zonal flux
     ! units: yr m3 s-1
@@ -4395,6 +8553,22 @@
     ! units: yr m3 s-1
     ! cell_methods: xq:point yh:sum z_l:sum
 "ocean_model_z", "age_dfx_xyave"  [Unused]
+    ! long_name: Ideal Age Tracer diffusive zonal flux
+    ! units: yr m3 s-1
+    ! cell_methods: z_l:sum
+"ocean_model_d2", "age_dfx"  [Unused]
+    ! long_name: Ideal Age Tracer diffusive zonal flux
+    ! units: yr m3 s-1
+    ! cell_methods: xq:point yh:sum zl:sum
+"ocean_model_d2", "age_dfx_xyave"  [Unused]
+    ! long_name: Ideal Age Tracer diffusive zonal flux
+    ! units: yr m3 s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "age_dfx"  [Unused]
+    ! long_name: Ideal Age Tracer diffusive zonal flux
+    ! units: yr m3 s-1
+    ! cell_methods: xq:point yh:sum z_l:sum
+"ocean_model_z_d2", "age_dfx_xyave"  [Unused]
     ! long_name: Ideal Age Tracer diffusive zonal flux
     ! units: yr m3 s-1
     ! cell_methods: z_l:sum
@@ -4414,7 +8588,27 @@
     ! long_name: Ideal Age Tracer diffusive zonal flux
     ! units: yr m3 s-1
     ! cell_methods: z_l:sum
+"ocean_model_d2", "age_dfy"  [Unused]
+    ! long_name: Ideal Age Tracer diffusive zonal flux
+    ! units: yr m3 s-1
+    ! cell_methods: xh:sum yq:point zl:sum
+"ocean_model_d2", "age_dfy_xyave"  [Unused]
+    ! long_name: Ideal Age Tracer diffusive zonal flux
+    ! units: yr m3 s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "age_dfy"  [Unused]
+    ! long_name: Ideal Age Tracer diffusive zonal flux
+    ! units: yr m3 s-1
+    ! cell_methods: xh:sum yq:point z_l:sum
+"ocean_model_z_d2", "age_dfy_xyave"  [Unused]
+    ! long_name: Ideal Age Tracer diffusive zonal flux
+    ! units: yr m3 s-1
+    ! cell_methods: z_l:sum
 "ocean_model", "age_adx_2d"  [Unused]
+    ! long_name: Vertically Integrated Advective Zonal Flux of Ideal Age Tracer
+    ! units: yr m3 s-1
+    ! cell_methods: xq:point yh:sum
+"ocean_model_d2", "age_adx_2d"  [Unused]
     ! long_name: Vertically Integrated Advective Zonal Flux of Ideal Age Tracer
     ! units: yr m3 s-1
     ! cell_methods: xq:point yh:sum
@@ -4422,11 +8616,23 @@
     ! long_name: Vertically Integrated Advective Meridional Flux of Ideal Age Tracer
     ! units: yr m3 s-1
     ! cell_methods: xh:sum yq:point
+"ocean_model_d2", "age_ady_2d"  [Unused]
+    ! long_name: Vertically Integrated Advective Meridional Flux of Ideal Age Tracer
+    ! units: yr m3 s-1
+    ! cell_methods: xh:sum yq:point
 "ocean_model", "age_diffx_2d"  [Unused]
     ! long_name: Vertically Integrated Diffusive Zonal Flux of Ideal Age Tracer
     ! units: yr m3 s-1
     ! cell_methods: xq:point yh:sum
+"ocean_model_d2", "age_diffx_2d"  [Unused]
+    ! long_name: Vertically Integrated Diffusive Zonal Flux of Ideal Age Tracer
+    ! units: yr m3 s-1
+    ! cell_methods: xq:point yh:sum
 "ocean_model", "age_diffy_2d"  [Unused]
+    ! long_name: Vertically Integrated Diffusive Meridional Flux of Ideal Age Tracer
+    ! units: yr m3 s-1
+    ! cell_methods: xh:sum yq:point
+"ocean_model_d2", "age_diffy_2d"  [Unused]
     ! long_name: Vertically Integrated Diffusive Meridional Flux of Ideal Age Tracer
     ! units: yr m3 s-1
     ! cell_methods: xh:sum yq:point
@@ -4446,7 +8652,27 @@
     ! long_name: Horizontal convergence of residual mean advective fluxes of ideal age tracer
     ! units: yr m s-1
     ! cell_methods: z_l:sum
+"ocean_model_d2", "age_advection_xy"  [Unused]
+    ! long_name: Horizontal convergence of residual mean advective fluxes of ideal age tracer
+    ! units: yr m s-1
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "age_advection_xy_xyave"  [Unused]
+    ! long_name: Horizontal convergence of residual mean advective fluxes of ideal age tracer
+    ! units: yr m s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "age_advection_xy"  [Unused]
+    ! long_name: Horizontal convergence of residual mean advective fluxes of ideal age tracer
+    ! units: yr m s-1
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "age_advection_xy_xyave"  [Unused]
+    ! long_name: Horizontal convergence of residual mean advective fluxes of ideal age tracer
+    ! units: yr m s-1
+    ! cell_methods: z_l:sum
 "ocean_model", "age_advection_xy_2d"  [Unused]
+    ! long_name: Vertical sum of horizontal convergence of residual mean advective fluxes of ideal age tracer
+    ! units: yr m s-1
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "age_advection_xy_2d"  [Unused]
     ! long_name: Vertical sum of horizontal convergence of residual mean advective fluxes of ideal age tracer
     ! units: yr m s-1
     ! cell_methods: xh:mean yh:mean area:mean
@@ -4466,6 +8692,22 @@
     ! long_name: Net time tendency for ideal age tracer
     ! units: yr s-1
     ! cell_methods: z_l:mean
+"ocean_model_d2", "age_tendency"  [Unused]
+    ! long_name: Net time tendency for ideal age tracer
+    ! units: yr s-1
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "age_tendency_xyave"  [Unused]
+    ! long_name: Net time tendency for ideal age tracer
+    ! units: yr s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "age_tendency"  [Unused]
+    ! long_name: Net time tendency for ideal age tracer
+    ! units: yr s-1
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "age_tendency_xyave"  [Unused]
+    ! long_name: Net time tendency for ideal age tracer
+    ! units: yr s-1
+    ! cell_methods: z_l:mean
 "ocean_model", "age_dfxy_cont_tendency"  [Unused]
     ! long_name: Lateral or neutral diffusion tracer content tendency for age
     ! units: yr m s-1
@@ -4482,7 +8724,27 @@
     ! long_name: Lateral or neutral diffusion tracer content tendency for age
     ! units: yr m s-1
     ! cell_methods: z_l:sum
+"ocean_model_d2", "age_dfxy_cont_tendency"  [Unused]
+    ! long_name: Lateral or neutral diffusion tracer content tendency for age
+    ! units: yr m s-1
+    ! cell_methods: xh:sum yh:sum zl:sum area:sum
+"ocean_model_d2", "age_dfxy_cont_tendency_xyave"  [Unused]
+    ! long_name: Lateral or neutral diffusion tracer content tendency for age
+    ! units: yr m s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "age_dfxy_cont_tendency"  [Unused]
+    ! long_name: Lateral or neutral diffusion tracer content tendency for age
+    ! units: yr m s-1
+    ! cell_methods: xh:sum yh:sum z_l:sum area:sum
+"ocean_model_z_d2", "age_dfxy_cont_tendency_xyave"  [Unused]
+    ! long_name: Lateral or neutral diffusion tracer content tendency for age
+    ! units: yr m s-1
+    ! cell_methods: z_l:sum
 "ocean_model", "age_dfxy_cont_tendency_2d"  [Unused]
+    ! long_name: Depth integrated lateral or neutral diffusion tracer concentration tendency for age
+    ! units: yr m s-1
+    ! cell_methods: xh:sum yh:sum area:sum
+"ocean_model_d2", "age_dfxy_cont_tendency_2d"  [Unused]
     ! long_name: Depth integrated lateral or neutral diffusion tracer concentration tendency for age
     ! units: yr m s-1
     ! cell_methods: xh:sum yh:sum area:sum
@@ -4502,6 +8764,22 @@
     ! long_name: Lateral (neutral) tracer concentration tendency for age
     ! units: yr s-1
     ! cell_methods: z_l:mean
+"ocean_model_d2", "age_dfxy_conc_tendency"  [Unused]
+    ! long_name: Lateral (neutral) tracer concentration tendency for age
+    ! units: yr s-1
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "age_dfxy_conc_tendency_xyave"  [Unused]
+    ! long_name: Lateral (neutral) tracer concentration tendency for age
+    ! units: yr s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "age_dfxy_conc_tendency"  [Unused]
+    ! long_name: Lateral (neutral) tracer concentration tendency for age
+    ! units: yr s-1
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "age_dfxy_conc_tendency_xyave"  [Unused]
+    ! long_name: Lateral (neutral) tracer concentration tendency for age
+    ! units: yr s-1
+    ! cell_methods: z_l:mean
 "ocean_model", "ageh_tendency"  [Unused]
     ! long_name: Net time tendency for ideal age tracer
     ! units: yr m s-1
@@ -4518,7 +8796,27 @@
     ! long_name: Net time tendency for ideal age tracer
     ! units: yr m s-1
     ! cell_methods: z_l:sum
+"ocean_model_d2", "ageh_tendency"  [Unused]
+    ! long_name: Net time tendency for ideal age tracer
+    ! units: yr m s-1
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "ageh_tendency_xyave"  [Unused]
+    ! long_name: Net time tendency for ideal age tracer
+    ! units: yr m s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "ageh_tendency"  [Unused]
+    ! long_name: Net time tendency for ideal age tracer
+    ! units: yr m s-1
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "ageh_tendency_xyave"  [Unused]
+    ! long_name: Net time tendency for ideal age tracer
+    ! units: yr m s-1
+    ! cell_methods: z_l:sum
 "ocean_model", "ageh_tendency_2d"  [Unused]
+    ! long_name: Vertical sum of net time tendency for ideal age tracer
+    ! units: yr m s-1
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "ageh_tendency_2d"  [Unused]
     ! long_name: Vertical sum of net time tendency for ideal age tracer
     ! units: yr m s-1
     ! cell_methods: xh:mean yh:mean area:mean
@@ -4530,11 +8828,19 @@
     ! long_name: Ideal Age Tracer
     ! units: yr
     ! standard_name: not provided
+"ocean_model_zold_d2", "age_xyave"  [Unused]
+    ! long_name: Ideal Age Tracer
+    ! units: yr
+    ! standard_name: not provided
 "ocean_model_zold", "agessc"  [Unused]
     ! long_name: Ideal Age Tracer
     ! units: yr
     ! standard_name: ideal_age_tracer
 "ocean_model_zold", "agessc_xyave"  [Unused]
+    ! long_name: Ideal Age Tracer
+    ! units: yr
+    ! standard_name: ideal_age_tracer
+"ocean_model_zold_d2", "agessc_xyave"  [Unused]
     ! long_name: Ideal Age Tracer
     ! units: yr
     ! standard_name: ideal_age_tracer
@@ -4554,6 +8860,22 @@
     ! long_name: Vertical remapping tracer concentration tendency for age
     ! units: yr s-1
     ! cell_methods: z_l:mean
+"ocean_model_d2", "age_tendency_vert_remap"  [Unused]
+    ! long_name: Vertical remapping tracer concentration tendency for age
+    ! units: yr s-1
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "age_tendency_vert_remap_xyave"  [Unused]
+    ! long_name: Vertical remapping tracer concentration tendency for age
+    ! units: yr s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "age_tendency_vert_remap"  [Unused]
+    ! long_name: Vertical remapping tracer concentration tendency for age
+    ! units: yr s-1
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "age_tendency_vert_remap_xyave"  [Unused]
+    ! long_name: Vertical remapping tracer concentration tendency for age
+    ! units: yr s-1
+    ! cell_methods: z_l:mean
 "ocean_model", "ageh_tendency_vert_remap"  [Unused]
     ! long_name: Vertical remapping tracer content tendency for Ideal Age Tracer
     ! units: yr m3 s-1
@@ -4570,7 +8892,27 @@
     ! long_name: Vertical remapping tracer content tendency for Ideal Age Tracer
     ! units: yr m3 s-1
     ! cell_methods: z_l:sum
+"ocean_model_d2", "ageh_tendency_vert_remap"  [Unused]
+    ! long_name: Vertical remapping tracer content tendency for Ideal Age Tracer
+    ! units: yr m3 s-1
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "ageh_tendency_vert_remap_xyave"  [Unused]
+    ! long_name: Vertical remapping tracer content tendency for Ideal Age Tracer
+    ! units: yr m3 s-1
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "ageh_tendency_vert_remap"  [Unused]
+    ! long_name: Vertical remapping tracer content tendency for Ideal Age Tracer
+    ! units: yr m3 s-1
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "ageh_tendency_vert_remap_xyave"  [Unused]
+    ! long_name: Vertical remapping tracer content tendency for Ideal Age Tracer
+    ! units: yr m3 s-1
+    ! cell_methods: z_l:sum
 "ocean_model", "ageh_tendency_vert_remap_2d"  [Unused]
+    ! long_name: Vertical sum of vertical remapping tracer content tendency for Ideal Age Tracer
+    ! units: yr m3 s-1
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "ageh_tendency_vert_remap_2d"  [Unused]
     ! long_name: Vertical sum of vertical remapping tracer content tendency for Ideal Age Tracer
     ! units: yr m3 s-1
     ! cell_methods: xh:mean yh:mean area:mean
@@ -4590,6 +8932,22 @@
     ! long_name: ALE variance decay for ideal age tracer
     ! units: yr2 s-1
     ! cell_methods: z_l:mean
+"ocean_model_d2", "age_vardec"  [Unused]
+    ! long_name: ALE variance decay for ideal age tracer
+    ! units: yr2 s-1
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "age_vardec_xyave"  [Unused]
+    ! long_name: ALE variance decay for ideal age tracer
+    ! units: yr2 s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "age_vardec"  [Unused]
+    ! long_name: ALE variance decay for ideal age tracer
+    ! units: yr2 s-1
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "age_vardec_xyave"  [Unused]
+    ! long_name: ALE variance decay for ideal age tracer
+    ! units: yr2 s-1
+    ! cell_methods: z_l:mean
 "ocean_model", "u_preale"  [Unused]
     ! long_name: Zonal velocity before remapping
     ! units: m s-1
@@ -4603,6 +8961,22 @@
     ! units: m s-1
     ! cell_methods: xq:point yh:mean z_l:mean
 "ocean_model_z", "u_preale_xyave"  [Unused]
+    ! long_name: Zonal velocity before remapping
+    ! units: m s-1
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "u_preale"  [Unused]
+    ! long_name: Zonal velocity before remapping
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean zl:mean
+"ocean_model_d2", "u_preale_xyave"  [Unused]
+    ! long_name: Zonal velocity before remapping
+    ! units: m s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "u_preale"  [Unused]
+    ! long_name: Zonal velocity before remapping
+    ! units: m s-1
+    ! cell_methods: xq:point yh:mean z_l:mean
+"ocean_model_z_d2", "u_preale_xyave"  [Unused]
     ! long_name: Zonal velocity before remapping
     ! units: m s-1
     ! cell_methods: z_l:mean
@@ -4622,6 +8996,22 @@
     ! long_name: Meridional velocity before remapping
     ! units: m s-1
     ! cell_methods: z_l:mean
+"ocean_model_d2", "v_preale"  [Unused]
+    ! long_name: Meridional velocity before remapping
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point zl:mean
+"ocean_model_d2", "v_preale_xyave"  [Unused]
+    ! long_name: Meridional velocity before remapping
+    ! units: m s-1
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "v_preale"  [Unused]
+    ! long_name: Meridional velocity before remapping
+    ! units: m s-1
+    ! cell_methods: xh:mean yq:point z_l:mean
+"ocean_model_z_d2", "v_preale_xyave"  [Unused]
+    ! long_name: Meridional velocity before remapping
+    ! units: m s-1
+    ! cell_methods: z_l:mean
 "ocean_model", "h_preale"  [Unused]
     ! long_name: Layer Thickness before remapping
     ! units: m
@@ -4635,6 +9025,22 @@
     ! units: m
     ! cell_methods: xh:mean yh:mean z_l:sum area:mean
 "ocean_model_z", "h_preale_xyave"  [Unused]
+    ! long_name: Layer Thickness before remapping
+    ! units: m
+    ! cell_methods: z_l:sum
+"ocean_model_d2", "h_preale"  [Unused]
+    ! long_name: Layer Thickness before remapping
+    ! units: m
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "h_preale_xyave"  [Unused]
+    ! long_name: Layer Thickness before remapping
+    ! units: m
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "h_preale"  [Unused]
+    ! long_name: Layer Thickness before remapping
+    ! units: m
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "h_preale_xyave"  [Unused]
     ! long_name: Layer Thickness before remapping
     ! units: m
     ! cell_methods: z_l:sum
@@ -4654,6 +9060,22 @@
     ! long_name: Temperature before remapping
     ! units: degC
     ! cell_methods: z_l:mean
+"ocean_model_d2", "T_preale"  [Unused]
+    ! long_name: Temperature before remapping
+    ! units: degC
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "T_preale_xyave"  [Unused]
+    ! long_name: Temperature before remapping
+    ! units: degC
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "T_preale"  [Unused]
+    ! long_name: Temperature before remapping
+    ! units: degC
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "T_preale_xyave"  [Unused]
+    ! long_name: Temperature before remapping
+    ! units: degC
+    ! cell_methods: z_l:mean
 "ocean_model", "S_preale"  [Unused]
     ! long_name: Salinity before remapping
     ! units: PSU
@@ -4667,6 +9089,22 @@
     ! units: PSU
     ! cell_methods: xh:mean yh:mean z_l:mean area:mean
 "ocean_model_z", "S_preale_xyave"  [Unused]
+    ! long_name: Salinity before remapping
+    ! units: PSU
+    ! cell_methods: z_l:mean
+"ocean_model_d2", "S_preale"  [Unused]
+    ! long_name: Salinity before remapping
+    ! units: PSU
+    ! cell_methods: xh:mean yh:mean zl:mean area:mean
+"ocean_model_d2", "S_preale_xyave"  [Unused]
+    ! long_name: Salinity before remapping
+    ! units: PSU
+    ! cell_methods: zl:mean
+"ocean_model_z_d2", "S_preale"  [Unused]
+    ! long_name: Salinity before remapping
+    ! units: PSU
+    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
+"ocean_model_z_d2", "S_preale_xyave"  [Unused]
     ! long_name: Salinity before remapping
     ! units: PSU
     ! cell_methods: z_l:mean
@@ -4686,6 +9124,22 @@
     ! long_name: Interface Heights before remapping
     ! units: m
     ! cell_methods: z_i:point
+"ocean_model_d2", "e_preale"  [Unused]
+    ! long_name: Interface Heights before remapping
+    ! units: m
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "e_preale_xyave"  [Unused]
+    ! long_name: Interface Heights before remapping
+    ! units: m
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "e_preale"  [Unused]
+    ! long_name: Interface Heights before remapping
+    ! units: m
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "e_preale_xyave"  [Unused]
+    ! long_name: Interface Heights before remapping
+    ! units: m
+    ! cell_methods: z_i:point
 "ocean_model", "dzRegrid"  [Unused]
     ! long_name: Change in interface height due to ALE regridding
     ! units: m
@@ -4699,6 +9153,22 @@
     ! units: m
     ! cell_methods: xh:mean yh:mean z_i:point area:mean
 "ocean_model_z", "dzRegrid_xyave"  [Unused]
+    ! long_name: Change in interface height due to ALE regridding
+    ! units: m
+    ! cell_methods: z_i:point
+"ocean_model_d2", "dzRegrid"  [Unused]
+    ! long_name: Change in interface height due to ALE regridding
+    ! units: m
+    ! cell_methods: xh:mean yh:mean zi:point area:mean
+"ocean_model_d2", "dzRegrid_xyave"  [Unused]
+    ! long_name: Change in interface height due to ALE regridding
+    ! units: m
+    ! cell_methods: zi:point
+"ocean_model_z_d2", "dzRegrid"  [Unused]
+    ! long_name: Change in interface height due to ALE regridding
+    ! units: m
+    ! cell_methods: xh:mean yh:mean z_i:point area:mean
+"ocean_model_z_d2", "dzRegrid_xyave"  [Unused]
     ! long_name: Change in interface height due to ALE regridding
     ! units: m
     ! cell_methods: z_i:point
@@ -4718,6 +9188,22 @@
     ! long_name: layer thicknesses after ALE regridding and remapping
     ! units: m
     ! cell_methods: z_l:sum
+"ocean_model_d2", "vert_remap_h"  [Unused]
+    ! long_name: layer thicknesses after ALE regridding and remapping
+    ! units: m
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "vert_remap_h_xyave"  [Unused]
+    ! long_name: layer thicknesses after ALE regridding and remapping
+    ! units: m
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "vert_remap_h"  [Unused]
+    ! long_name: layer thicknesses after ALE regridding and remapping
+    ! units: m
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "vert_remap_h_xyave"  [Unused]
+    ! long_name: layer thicknesses after ALE regridding and remapping
+    ! units: m
+    ! cell_methods: z_l:sum
 "ocean_model", "vert_remap_h_tendency"  [Unused]
     ! long_name: Layer thicknesses tendency due to ALE regridding and remapping
     ! units: m
@@ -4734,12 +9220,38 @@
     ! long_name: Layer thicknesses tendency due to ALE regridding and remapping
     ! units: m
     ! cell_methods: z_l:sum
+"ocean_model_d2", "vert_remap_h_tendency"  [Unused]
+    ! long_name: Layer thicknesses tendency due to ALE regridding and remapping
+    ! units: m
+    ! cell_methods: xh:mean yh:mean zl:sum area:mean
+"ocean_model_d2", "vert_remap_h_tendency_xyave"  [Unused]
+    ! long_name: Layer thicknesses tendency due to ALE regridding and remapping
+    ! units: m
+    ! cell_methods: zl:sum
+"ocean_model_z_d2", "vert_remap_h_tendency"  [Unused]
+    ! long_name: Layer thicknesses tendency due to ALE regridding and remapping
+    ! units: m
+    ! cell_methods: xh:mean yh:mean z_l:sum area:mean
+"ocean_model_z_d2", "vert_remap_h_tendency_xyave"  [Unused]
+    ! long_name: Layer thicknesses tendency due to ALE regridding and remapping
+    ! units: m
+    ! cell_methods: z_l:sum
 "ocean_model", "taux"  [Used] (CMOR equivalent is "tauuo")
     ! long_name: Zonal surface stress from ocean interactions with atmos and ice
     ! units: Pa
     ! standard_name: surface_downward_x_stress
     ! cell_methods: xq:point yh:mean
 "ocean_model", "tauuo"  [Used] (native name is "taux")
+    ! long_name: Surface Downward X Stress
+    ! units: N m-2
+    ! standard_name: surface_downward_x_stress
+    ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "taux"  [Unused] (CMOR equivalent is "tauuo")
+    ! long_name: Zonal surface stress from ocean interactions with atmos and ice
+    ! units: Pa
+    ! standard_name: surface_downward_x_stress
+    ! cell_methods: xq:point yh:mean
+"ocean_model_d2", "tauuo"  [Unused] (native name is "taux")
     ! long_name: Surface Downward X Stress
     ! units: N m-2
     ! standard_name: surface_downward_x_stress
@@ -4754,7 +9266,21 @@
     ! units: N m-2
     ! standard_name: surface_downward_y_stress
     ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "tauy"  [Unused] (CMOR equivalent is "tauvo")
+    ! long_name: Meridional surface stress ocean interactions with atmos and ice
+    ! units: Pa
+    ! standard_name: surface_downward_y_stress
+    ! cell_methods: xh:mean yq:point
+"ocean_model_d2", "tauvo"  [Unused] (native name is "tauy")
+    ! long_name: Surface Downward Y Stress
+    ! units: N m-2
+    ! standard_name: surface_downward_y_stress
+    ! cell_methods: xh:mean yq:point
 "ocean_model", "ustar"  [Used]
+    ! long_name: Surface friction velocity = [(gustiness + tau_magnitude)/rho0]^(1/2)
+    ! units: m s-1
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "ustar"  [Unused]
     ! long_name: Surface friction velocity = [(gustiness + tau_magnitude)/rho0]^(1/2)
     ! units: m s-1
     ! cell_methods: xh:mean yh:mean area:mean
@@ -4767,7 +9293,20 @@
     ! units: Pa
     ! standard_name: sea_water_pressure_at_sea_water_surface
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "p_surf"  [Unused] (CMOR equivalent is "pso")
+    ! long_name: Pressure at ice-ocean or atmosphere-ocean interface
+    ! units: Pa
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "pso"  [Unused] (native name is "p_surf")
+    ! long_name: Sea Water Pressure at Sea Water Surface
+    ! units: Pa
+    ! standard_name: sea_water_pressure_at_sea_water_surface
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "TKE_tidal"  [Unused]
+    ! long_name: Tidal source of BBL mixing
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "TKE_tidal"  [Unused]
     ! long_name: Tidal source of BBL mixing
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -4777,6 +9316,16 @@
     ! standard_name: water_flux_into_sea_water
     ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "wfo"  [Used] (native name is "PRCmE")
+    ! long_name: Water Flux Into Sea Water
+    ! units: kg m-2 s-1
+    ! standard_name: water_flux_into_sea_water
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "PRCmE"  [Unused] (CMOR equivalent is "wfo")
+    ! long_name: Net surface water flux (precip+melt+lrunoff+ice calving-evap)
+    ! units: kg m-2 s-1
+    ! standard_name: water_flux_into_sea_water
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "wfo"  [Unused] (native name is "PRCmE")
     ! long_name: Water Flux Into Sea Water
     ! units: kg m-2 s-1
     ! standard_name: water_flux_into_sea_water
@@ -4791,6 +9340,16 @@
     ! units: kg m-2 s-1
     ! standard_name: water_evaporation_flux
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "evap"  [Unused] (CMOR equivalent is "evs")
+    ! long_name: Evaporation/condensation at ocean surface (evaporation is negative)
+    ! units: kg m-2 s-1
+    ! standard_name: water_evaporation_flux
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "evs"  [Unused] (native name is "evap")
+    ! long_name: Water Evaporation Flux Where Ice Free Ocean over Sea
+    ! units: kg m-2 s-1
+    ! standard_name: water_evaporation_flux
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "seaice_melt"  [Unused] (CMOR equivalent is "fsitherm")
     ! long_name: water flux to ocean from snow/sea ice melting(> 0) or formation(< 0)
     ! units: kg m-2 s-1
@@ -4801,7 +9360,21 @@
     ! units: kg m-2 s-1
     ! standard_name: water_flux_into_sea_water_due_to_sea_ice_thermodynamics
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "seaice_melt"  [Unused] (CMOR equivalent is "fsitherm")
+    ! long_name: water flux to ocean from snow/sea ice melting(> 0) or formation(< 0)
+    ! units: kg m-2 s-1
+    ! standard_name: water_flux_into_sea_water_due_to_sea_ice_thermodynamics
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "fsitherm"  [Unused] (native name is "seaice_melt")
+    ! long_name: water flux to ocean from sea ice melt(> 0) or form(< 0)
+    ! units: kg m-2 s-1
+    ! standard_name: water_flux_into_sea_water_due_to_sea_ice_thermodynamics
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "precip"  [Unused]
+    ! long_name: Liquid + frozen precipitation into ocean
+    ! units: kg m-2 s-1
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "precip"  [Unused]
     ! long_name: Liquid + frozen precipitation into ocean
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
@@ -4811,6 +9384,16 @@
     ! standard_name: snowfall_flux
     ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "prsn"  [Used] (native name is "fprec")
+    ! long_name: Snowfall Flux where Ice Free Ocean over Sea
+    ! units: kg m-2 s-1
+    ! standard_name: snowfall_flux
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "fprec"  [Unused] (CMOR equivalent is "prsn")
+    ! long_name: Frozen precipitation into ocean
+    ! units: kg m-2 s-1
+    ! standard_name: snowfall_flux
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "prsn"  [Unused] (native name is "fprec")
     ! long_name: Snowfall Flux where Ice Free Ocean over Sea
     ! units: kg m-2 s-1
     ! standard_name: snowfall_flux
@@ -4825,7 +9408,21 @@
     ! units: kg m-2 s-1
     ! standard_name: rainfall_flux
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "lprec"  [Unused] (CMOR equivalent is "prlq")
+    ! long_name: Liquid precipitation into ocean
+    ! units: kg m-2 s-1
+    ! standard_name: rainfall_flux
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "prlq"  [Unused] (native name is "lprec")
+    ! long_name: Rainfall Flux where Ice Free Ocean over Sea
+    ! units: kg m-2 s-1
+    ! standard_name: rainfall_flux
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "vprec"  [Used]
+    ! long_name: Virtual liquid precip into ocean due to SSS restoring
+    ! units: kg m-2 s-1
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "vprec"  [Unused]
     ! long_name: Virtual liquid precip into ocean due to SSS restoring
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
@@ -4835,6 +9432,16 @@
     ! standard_name: water_flux_into_sea_water_from_icebergs
     ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "ficeberg"  [Unused] (native name is "frunoff")
+    ! long_name: Water Flux into Seawater from Icebergs
+    ! units: kg m-2 s-1
+    ! standard_name: water_flux_into_sea_water_from_icebergs
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "frunoff"  [Unused] (CMOR equivalent is "ficeberg")
+    ! long_name: Frozen runoff (calving) and iceberg melt into ocean
+    ! units: kg m-2 s-1
+    ! standard_name: water_flux_into_sea_water_from_icebergs
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "ficeberg"  [Unused] (native name is "frunoff")
     ! long_name: Water Flux into Seawater from Icebergs
     ! units: kg m-2 s-1
     ! standard_name: water_flux_into_sea_water_from_icebergs
@@ -4849,7 +9456,21 @@
     ! units: kg m-2 s-1
     ! standard_name: water_flux_into_sea_water_from_rivers
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "lrunoff"  [Unused] (CMOR equivalent is "friver")
+    ! long_name: Liquid runoff (rivers) into ocean
+    ! units: kg m-2 s-1
+    ! standard_name: water_flux_into_sea_water_from_rivers
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "friver"  [Unused] (native name is "lrunoff")
+    ! long_name: Water Flux into Sea Water From Rivers
+    ! units: kg m-2 s-1
+    ! standard_name: water_flux_into_sea_water_from_rivers
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "net_massout"  [Used]
+    ! long_name: Net mass leaving the ocean due to evaporation, seaice formation
+    ! units: kg m-2 s-1
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "net_massout"  [Unused]
     ! long_name: Net mass leaving the ocean due to evaporation, seaice formation
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
@@ -4857,11 +9478,23 @@
     ! long_name: Net mass entering ocean due to precip, runoff, ice melt
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "net_massin"  [Unused]
+    ! long_name: Net mass entering ocean due to precip, runoff, ice melt
+    ! units: kg m-2 s-1
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "massout_flux"  [Unused]
     ! long_name: Net mass flux of freshwater out of the ocean (used in the boundary flux calculation)
     ! units: kg m-2
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "massout_flux"  [Unused]
+    ! long_name: Net mass flux of freshwater out of the ocean (used in the boundary flux calculation)
+    ! units: kg m-2
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "massin_flux"  [Unused]
+    ! long_name: Net mass flux of freshwater into the ocean (used in boundary flux calculation)
+    ! units: kg m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "massin_flux"  [Unused]
     ! long_name: Net mass flux of freshwater into the ocean (used in boundary flux calculation)
     ! units: kg m-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -4974,7 +9607,17 @@
     ! units: W m-2
     ! standard_name: temperature_flux_due_to_solid_runoff_expressed_as_heat_flux_into_sea_water
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "heat_content_frunoff"  [Unused]
+    ! long_name: Heat content (relative to 0C) of solid runoff into ocean
+    ! units: W m-2
+    ! standard_name: temperature_flux_due_to_solid_runoff_expressed_as_heat_flux_into_sea_water
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "heat_content_lrunoff"  [Used]
+    ! long_name: Heat content (relative to 0C) of liquid runoff into ocean
+    ! units: W m-2
+    ! standard_name: temperature_flux_due_to_runoff_expressed_as_heat_flux_into_sea_water
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "heat_content_lrunoff"  [Unused]
     ! long_name: Heat content (relative to 0C) of liquid runoff into ocean
     ! units: W m-2
     ! standard_name: temperature_flux_due_to_runoff_expressed_as_heat_flux_into_sea_water
@@ -4984,7 +9627,16 @@
     ! units: W m-2
     ! standard_name: temperature_flux_due_to_runoff_expressed_as_heat_flux_into_sea_water
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "hfrunoffds"  [Unused]
+    ! long_name: Heat content (relative to 0C) of liquid+solid runoff into ocean
+    ! units: W m-2
+    ! standard_name: temperature_flux_due_to_runoff_expressed_as_heat_flux_into_sea_water
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "heat_content_lprec"  [Used]
+    ! long_name: Heat content (relative to 0degC) of liquid precip entering ocean
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "heat_content_lprec"  [Unused]
     ! long_name: Heat content (relative to 0degC) of liquid precip entering ocean
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -4992,7 +9644,15 @@
     ! long_name: Heat content (relative to 0degC) of frozen prec entering ocean
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "heat_content_fprec"  [Unused]
+    ! long_name: Heat content (relative to 0degC) of frozen prec entering ocean
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "heat_content_icemelt"  [Unused]
+    ! long_name: Heat content (relative to 0degC) of water flux due to sea ice melting/freezing
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "heat_content_icemelt"  [Unused]
     ! long_name: Heat content (relative to 0degC) of water flux due to sea ice melting/freezing
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -5000,7 +9660,15 @@
     ! long_name: Heat content (relative to 0degC) of virtual precip entering ocean
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "heat_content_vprec"  [Unused]
+    ! long_name: Heat content (relative to 0degC) of virtual precip entering ocean
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "heat_content_cond"  [Used]
+    ! long_name: Heat content (relative to 0degC) of water condensing into ocean
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "heat_content_cond"  [Unused]
     ! long_name: Heat content (relative to 0degC) of water condensing into ocean
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -5009,7 +9677,16 @@
     ! units: W m-2
     ! standard_name: temperature_flux_due_to_rainfall_expressed_as_heat_flux_into_sea_water
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "hfrainds"  [Unused]
+    ! long_name: Heat content (relative to 0degC) of liquid+frozen precip entering ocean
+    ! units: W m-2
+    ! standard_name: temperature_flux_due_to_rainfall_expressed_as_heat_flux_into_sea_water
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "heat_content_surfwater"  [Used]
+    ! long_name: Heat content (relative to 0degC) of net water crossing ocean surface (frozen+liquid)
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "heat_content_surfwater"  [Unused]
     ! long_name: Heat content (relative to 0degC) of net water crossing ocean surface (frozen+liquid)
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -5022,11 +9699,28 @@
     ! units: W m-2
     ! standard_name: temperature_flux_due_to_evaporation_expressed_as_heat_flux_out_of_sea_water
     ! cell_methods: xh:mean yh:mean area:mean
-"ocean_model", "heat_content_massin"  [Used]
+"ocean_model_d2", "heat_content_massout"  [Unused] (CMOR equivalent is "hfevapds")
+    ! long_name: Heat content (relative to 0degC) of net mass leaving ocean ocean via evap and ice form
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "hfevapds"  [Unused] (native name is "heat_content_massout")
+    ! long_name: Heat Content (relative to 0degC) of Water Leaving Ocean via Evaporation and Ice Formation
+    ! units: W m-2
+    ! standard_name: temperature_flux_due_to_evaporation_expressed_as_heat_flux_out_of_sea_water
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model", "heat_content_massin"  [Unused]
+    ! long_name: Heat content (relative to 0degC) of net mass entering ocean ocean
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "heat_content_massin"  [Unused]
     ! long_name: Heat content (relative to 0degC) of net mass entering ocean ocean
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "net_heat_coupler"  [Used]
+    ! long_name: Surface ocean heat flux from SW+LW+latent+sensible+seaice_melt_heat (via the coupler)
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "net_heat_coupler"  [Unused]
     ! long_name: Surface ocean heat flux from SW+LW+latent+sensible+seaice_melt_heat (via the coupler)
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -5036,6 +9730,16 @@
     ! standard_name: surface_downward_heat_flux_in_sea_water
     ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "hfds"  [Used] (native name is "net_heat_surface")
+    ! long_name: Surface ocean heat flux from SW+LW+latent+sensible+masstransfer+frazil+seaice_melt_heat
+    ! units: W m-2
+    ! standard_name: surface_downward_heat_flux_in_sea_water
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "net_heat_surface"  [Unused] (CMOR equivalent is "hfds")
+    ! long_name: Surface ocean heat flux from SW+LW+lat+sens+mass transfer+frazil+restore+seaice_melt_heat or flux adjustments
+    ! units: W m-2
+    ! standard_name: surface_downward_heat_flux_in_sea_water
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "hfds"  [Unused] (native name is "net_heat_surface")
     ! long_name: Surface ocean heat flux from SW+LW+latent+sensible+masstransfer+frazil+seaice_melt_heat
     ! units: W m-2
     ! standard_name: surface_downward_heat_flux_in_sea_water
@@ -5050,7 +9754,21 @@
     ! units: W m-2
     ! standard_name: net_downward_shortwave_flux_at_sea_water_surface
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "SW"  [Unused] (CMOR equivalent is "rsntds")
+    ! long_name: Shortwave radiation flux into ocean
+    ! units: W m-2
+    ! standard_name: net_downward_shortwave_flux_at_sea_water_surface
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "rsntds"  [Unused] (native name is "SW")
+    ! long_name: Net Downward Shortwave Radiation at Sea Water Surface
+    ! units: W m-2
+    ! standard_name: net_downward_shortwave_flux_at_sea_water_surface
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "sw_vis"  [Unused]
+    ! long_name: Shortwave radiation direct and diffuse flux into the ocean in the visible band
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "sw_vis"  [Unused]
     ! long_name: Shortwave radiation direct and diffuse flux into the ocean in the visible band
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -5058,7 +9776,15 @@
     ! long_name: Shortwave radiation direct and diffuse flux into the ocean in the near-infrared band
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "sw_nir"  [Unused]
+    ! long_name: Shortwave radiation direct and diffuse flux into the ocean in the near-infrared band
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "LwLatSens"  [Used]
+    ! long_name: Combined longwave, latent, and sensible heating at ocean surface
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "LwLatSens"  [Unused]
     ! long_name: Combined longwave, latent, and sensible heating at ocean surface
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -5072,6 +9798,16 @@
     ! units: W m-2
     ! standard_name: surface_net_downward_longwave_flux
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "LW"  [Unused] (CMOR equivalent is "rlntds")
+    ! long_name: Longwave radiation flux into ocean
+    ! units: W m-2
+    ! standard_name: surface_net_downward_longwave_flux
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "rlntds"  [Unused] (native name is "LW")
+    ! long_name: Surface Net Downward Longwave Radiation
+    ! units: W m-2
+    ! standard_name: surface_net_downward_longwave_flux
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "latent"  [Unused] (CMOR equivalent is "hflso")
     ! long_name: Latent heat flux into ocean due to fusion and evaporation (negative means ocean heat loss)
     ! units: W m-2
@@ -5081,7 +9817,20 @@
     ! units: W m-2
     ! standard_name: surface_downward_latent_heat_flux
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "latent"  [Unused] (CMOR equivalent is "hflso")
+    ! long_name: Latent heat flux into ocean due to fusion and evaporation (negative means ocean heat loss)
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "hflso"  [Unused] (native name is "latent")
+    ! long_name: Surface Downward Latent Heat Flux due to Evap + Melt Snow/Ice
+    ! units: W m-2
+    ! standard_name: surface_downward_latent_heat_flux
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "latent_evap"  [Unused]
+    ! long_name: Latent heat flux into ocean due to evaporation/condensation
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "latent_evap"  [Unused]
     ! long_name: Latent heat flux into ocean due to evaporation/condensation
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -5094,11 +9843,29 @@
     ! units: W m-2
     ! standard_name: heat_flux_into_sea_water_due_to_snow_thermodynamics
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "latent_fprec_diag"  [Unused] (CMOR equivalent is "hfsnthermds")
+    ! long_name: Latent heat flux into ocean due to melting of frozen precipitation
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "hfsnthermds"  [Unused] (native name is "latent_fprec_diag")
+    ! long_name: Latent Heat to Melt Frozen Precipitation
+    ! units: W m-2
+    ! standard_name: heat_flux_into_sea_water_due_to_snow_thermodynamics
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "latent_frunoff"  [Unused] (CMOR equivalent is "hfibthermds")
     ! long_name: Latent heat flux into ocean due to melting of icebergs
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "hfibthermds"  [Used] (native name is "latent_frunoff")
+    ! long_name: Latent Heat to Melt Frozen Runoff/Iceberg
+    ! units: W m-2
+    ! standard_name: heat_flux_into_sea_water_due_to_iceberg_thermodynamics
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "latent_frunoff"  [Unused] (CMOR equivalent is "hfibthermds")
+    ! long_name: Latent heat flux into ocean due to melting of icebergs
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "hfibthermds"  [Unused] (native name is "latent_frunoff")
     ! long_name: Latent Heat to Melt Frozen Runoff/Iceberg
     ! units: W m-2
     ! standard_name: heat_flux_into_sea_water_due_to_iceberg_thermodynamics
@@ -5113,12 +9880,31 @@
     ! units: W m-2
     ! standard_name: surface_downward_sensible_heat_flux
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "sensible"  [Unused] (CMOR equivalent is "hfsso")
+    ! long_name: Sensible heat flux into ocean
+    ! units: W m-2
+    ! standard_name: surface_downward_sensible_heat_flux
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "hfsso"  [Unused] (native name is "sensible")
+    ! long_name: Surface Downward Sensible Heat Flux
+    ! units: W m-2
+    ! standard_name: surface_downward_sensible_heat_flux
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "seaice_melt_heat"  [Unused]
     ! long_name: Heat flux into ocean due to snow and sea ice melt/freeze
     ! units: W m-2
     ! standard_name: snow_ice_melt_heat_flux
     ! cell_methods: xh:mean yh:mean area:mean
-"ocean_model", "heat_added"  [Used]
+"ocean_model_d2", "seaice_melt_heat"  [Unused]
+    ! long_name: Heat flux into ocean due to snow and sea ice melt/freeze
+    ! units: W m-2
+    ! standard_name: snow_ice_melt_heat_flux
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model", "heat_added"  [Unused]
+    ! long_name: Flux Adjustment or restoring surface heat flux into ocean
+    ! units: W m-2
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "heat_added"  [Unused]
     ! long_name: Flux Adjustment or restoring surface heat flux into ocean
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
@@ -5282,11 +10068,28 @@
     ! units: kg m-2 s-1
     ! standard_name: downward_sea_ice_basal_salt_flux
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "salt_flux"  [Unused] (CMOR equivalent is "sfdsi")
+    ! long_name: Net salt flux into ocean at surface (restoring + sea-ice)
+    ! units: kg m-2 s-1
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "sfdsi"  [Unused] (native name is "salt_flux")
+    ! long_name: Downward Sea Ice Basal Salt Flux
+    ! units: kg m-2 s-1
+    ! standard_name: downward_sea_ice_basal_salt_flux
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "salt_flux_in"  [Unused]
     ! long_name: Salt flux into ocean at surface from coupler
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "salt_flux_in"  [Unused]
+    ! long_name: Salt flux into ocean at surface from coupler
+    ! units: kg m-2 s-1
+    ! cell_methods: xh:mean yh:mean area:mean
 "ocean_model", "salt_flux_added"  [Unused]
+    ! long_name: Salt flux into ocean at surface due to restoring or flux adjustment
+    ! units: kg m-2 s-1
+    ! cell_methods: xh:mean yh:mean area:mean
+"ocean_model_d2", "salt_flux_added"  [Unused]
     ! long_name: Salt flux into ocean at surface due to restoring or flux adjustment
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean area:mean


### PR DESCRIPTION
  Updated the versions of MOM6 and SIS2 in the MOM6_examples.  The MOM6 changes
add new downsampled diagnostic capabilities and new arguments to step_MOM to
support interspersed ice coupling.  The SIS2 changes are a significant
restructuring to enable interspersed ice coupling, clean-up and document the
code, and introduce multiple new runtime parameters.  Also updated the version
of the coupler being used to the Xanadu-prerelease version. The SIS2 changes can
change answers in cases that are not tested by MOM6_examples.  There are updated
versions of the SIS_parameter_doc and MOM_parameter_doc files.

The MOM6 and SIS2 commits with this PR include:
 - NOAA-GFDL/MOM6@00f634b Merge pull request #869 from nikizadehgfdl/nikizadeh_diag_decimation
 - NOAA-GFDL/MOM6@3ebcb68 Merge pull request #896 from Hallberg-NOAA/coupling_options
 - NOAA-GFDL/MOM6@9997f41 Merge pull request #897 from nikizadehgfdl/nikizadehgfdl/fix_openmp_answers
 - NOAA-GFDL/MOM6@0a1a313 Correct thermo clock with update_ocean_model calls
 - NOAA-GFDL/MOM6@1603ed9 Fix bug causing openmp answers change
 - NOAA-GFDL/MOM6@b6fa342 +Opt args to step_MOM can override DIABATIC_FIRST
 - NOAA-GFDL/MOM6@0ff4c5b Trap or deal with instances when dt=0 in diabatic
 - NOAA-GFDL/MOM6@9b7b127 +New variants of safe_alloc_ptr & safe_alloc_alloc
 - NOAA-GFDL/MOM6@8233da2 Diagnostics downsampling, shorten line more than 120 chars long
 - NOAA-GFDL/MOM6@6d77f39 Merge branch 'dev/gfdl' into nikizadeh_diag_decimation
 - NOAA-GFDL/MOM6@48a4915 Merge branch 'nikizadehgfdl/fix_compile_generics' into nikizadeh_diag_decimation
 - NOAA-GFDL/MOM6@9d7099f Merge branch 'dev/gfdl' into nikizadeh_diag_decimation
 - NOAA-GFDL/MOM6@c98fb73 Diagnostics Downsample, implement Hallberg's suggestion
 - NOAA-GFDL/MOM6@1cfc384 Downsample Diagnostics, fix symmetric memory case
 - NOAA-GFDL/MOM6@16fef4f Diagnostics downsampling, fix the issue for symmetric case
 - NOAA-GFDL/MOM6@fe0c041 Diagnostics downsampling, implement suggestions in reviews
 - NOAA-GFDL/MOM6@de8f1b6 Diag decimation, check the commensurate condition
 - NOAA-GFDL/MOM6@861397c Merge branch 'dev/gfdl' into nikizadeh_diag_decimation
 - NOAA-GFDL/MOM6@d748764 Diag decimation, fixed the decimated fields indices
 - NOAA-GFDL/MOM6@0a3335f Diag decimation prototype, decimation algorithm extension
 - NOAA-GFDL/MOM6@2dd042a Diag decimation prototype, first attemp at general algorithm
 - NOAA-GFDL/MOM6@373c232 Diag decimation prototype, fix masks for non-native grids
 - NOAA-GFDL/MOM6@5f3949f Diag decimation prototype, fixed masks and cleanup
 - NOAA-GFDL/MOM6@dfe674c Diag decimation prototype, aggregating methods
 - NOAA-GFDL/MOM6@7e3d368 Diag decimation prototype, fixing memory leaks
 - NOAA-GFDL/MOM6@8802dd2 Diag decimation prototype, requesting in diag_table
 - NOAA-GFDL/MOM6@d1b15c4 Diag decimation prototype, requesting in - NOAA-GFDL/MOM6@diag_table
 - NOAA-GFDL/MOM6@b9d714b Diag decimation prototype, works for native and _z
 - NOAA-GFDL/MOM6@7c4adcb Diag decimation prototype, coarsening by a factor of 2
 - NOAA-GFDL/MOM6@dcdd9ae Effort to decimate the diag output at runtime
 - NOAA-GFDL/SIS2@e9434c5 Merge pull request #99 from Hallberg-NOAA/restructure_dyn2
 - NOAA-GFDL/SIS2@fd49919 Merge pull request #98 from Hallberg-NOAA/restructure_dynamics
 - NOAA-GFDL/SIS2@8d30b9c Revised OMP directives in SIS_continuity
 - NOAA-GFDL/SIS2@d1d011a (*)+Add end_call optional arg to SIS_merged_dyn_cont
 - NOAA-GFDL/SIS2@86714ab +Add DT_COUPLED_ICE_OCEAN_DYN to ice_ocean_driver
 - NOAA-GFDL/SIS2@aacd3ad +Pass optional args to update_ice_dynamics_trans
 - NOAA-GFDL/SIS2@5d5257c +Add optional arguments to SIS_multi_dyn_trans
 - NOAA-GFDL/SIS2@38f6fd8 +Added ice_mass_from_IST
 - NOAA-GFDL/SIS2@c0bb017 +Set and unset valid_IST
 - NOAA-GFDL/SIS2@fcde2c1 (*)Added pond mass in ice pressure.
 - NOAA-GFDL/SIS2@c974b2d Renamed coupled driver log root CIOD_parameter_doc
 - NOAA-GFDL/SIS2@bc3362b +Added the new runtime flag INTERSPERSE_ICE_OCEAN
 - NOAA-GFDL/SIS2@a5519c5 +New optional args for update_ice_dynamics_trans
 - NOAA-GFDL/SIS2@75f907d +Added IST%valid_IST and IOF%mass_ice_sn_p
 - NOAA-GFDL/SIS2@3a61538 Corrected diagnostic messages in specified_ice
 - NOAA-GFDL/SIS2@938f950 Commented on the SIS_dynamics_trans code
 - NOAA-GFDL/SIS2@6e7094a SIS_multi_dyn_trans code in SIS_dyanmics_trans
 - NOAA-GFDL/SIS2@ed9505f +(*)Prohibit WARSAW_SUM_ORDER and MERGED_CONTINUITY
 - NOAA-GFDL/SIS2@cf06501 +Create 3 new subroutines from SIS_multi_dyn_trans
 - NOAA-GFDL/SIS2@7a25763 +Created new module specified_ice
 - NOAA-GFDL/SIS2@36f13b4 +Created new module SIS_ice_diags
 - NOAA-GFDL/SIS2@f6225f5 +Created ice_state_diags type
 - NOAA-GFDL/SIS2@af57845 +Split dyn_state_2d type ouf of dyn_trans_CS
 - NOAA-GFDL/SIS2@a3ca222 +Added SIS_merged_dyn_cont
 - NOAA-GFDL/SIS2@d94c403 (*)Corrected time argument to ice_cat_transport
 - NOAA-GFDL/SIS2@567963d (*)Introduce dt_adv_cycle in SIS_multi_dyn_trans
 - NOAA-GFDL/SIS2@3fbf01c Move code out of SIS_multi_dyn_trans dynamics loop
 - NOAA-GFDL/SIS2@9e2b5d1 Add advective cycle loop in SIS_multi_dyn_trans
 - NOAA-GFDL/SIS2@ff19e8f +Add DT_ICE_ADVECT and remove MAX_TRACER_SUBSTEPS
 - NOAA-GFDL/SIS2@0c21435 (*)Standardized parentheses in summed_continuity
 - NOAA-GFDL/SIS2@5b8a1fa +Added increase_max_tracer_step_memory
 - NOAA-GFDL/SIS2@caedb96 +Added mi_sum and other elements to dyn_trans_CS
 - NOAA-GFDL/SIS2@eef65be (*)Change ice_free calculation in SIS_dyn_trans
 - NOAA-GFDL/SIS2@2979c50 +(*)INCONSISTENT_COVER_BUG=False if MERGED_CONT=True
 - NOAA-GFDL/SIS2@8094582 +Added INCONSISTENT_COVER_BUG runtime parameter
 - NOAA-GFDL/SIS2@c159885 Reduce reporting tolerance of sum_part_size errors
 - NOAA-GFDL/SIS2@ef16e22 Replaced misp_sum with CS%mca_step(:,:,n)
 - NOAA-GFDL/SIS2@6e3792e Shifted the time-step index for CS%mca_step
 - NOAA-GFDL/SIS2@28955cc +Added new subroutine SIS_multi_dyn_trans
 - NOAA-GFDL/SIS2@59341f5 (*)+Added calls correcting MERGED_CONTINUITY
 - NOAA-GFDL/SIS2@6b39542 +Added ice_cover_transport
 - NOAA-GFDL/SIS2@06a03da +Pass complete_ice_cover to set_wind_stresses_[BC]
 - NOAA-GFDL/SIS2@5965e3e (*)Corrected a halo update in SIS_dyn_trans
 - NOAA-GFDL/SIS2@38cecbe +Always allocate IST%u_ice_C and IST%v_ice_C
 - NOAA-GFDL/SIS2@9d5589e +Introduced slab_ice_dyn_trans
 - NOAA-GFDL/SIS2@2a5356a +Added IST%snow_to_ocn and IST%enth_snow_to_ocn
 - NOAA-GFDL/SIS2@1c1ad48 +Introduced specified_ice_dynamics
 - NOAA-GFDL/SIS2@ae3735b Paired B-velocity checksum calls in IST_chksum
 - NOAA-GFDL/SIS2@8c7dd19 +Changed interface to ice_line
 - NOAA-GFDL/SIS2@3d718e8 Merge branch 'dev/gfdl' into restructure_dynamics
 - NOAA-GFDL/SIS2@12a290b Merge branch 'nikizadehgfdl-fix_ice_restore_issues' into dev/gfdl
 - NOAA-GFDL/SIS2@adc33ee Merge branch 'fix_ice_restore_issues' of https://github.com/nikizadehgfdl/SIS2 into nikizadehgfdl-fix_ice_restore_issues
 - NOAA-GFDL/SIS2@340c19e Documented 98 nondimensional variable units
 - NOAA-GFDL/SIS2@2e32660 Documented 53 enthalpy-related variable units
 - NOAA-GFDL/SIS2@0c114e6 Documented 72 salinity-related variable units
 - NOAA-GFDL/SIS2@62e1aa1 Documented 48 tracer-related variable units
 - NOAA-GFDL/SIS2@d3355b6 Documented 101 length and stress variable units
 - NOAA-GFDL/SIS2@cc1e58b Documented 212 length and velocity variable units
 - NOAA-GFDL/SIS2@6298e8f Documented 116 thickness variable units
 - NOAA-GFDL/SIS2@76c6651 Documented 65 heat content variable units
 - NOAA-GFDL/SIS2@e8d65be Documented 82 time variable units
 - NOAA-GFDL/SIS2@42d6116 Documented 105 heat flux variable units
 - NOAA-GFDL/SIS2@e7de91a Documented 206 density variable units
 - NOAA-GFDL/SIS2@b45fccd ocumented 123 stress variable units
 - NOAA-GFDL/SIS2@e84a0ce ocumented 142 thermodynamic variable units
 - NOAA-GFDL/SIS2@2d08207 Added set_wind_stresses_C and set_wind_stresses_B
 - NOAA-GFDL/SIS2@50423df +(*)Added the runtime parameter WARSAW_SUM_ORDER
 - NOAA-GFDL/SIS2@d8fdc91 (*)Set mca_step(:,:,1) from misp_sum(:,:)
 - NOAA-GFDL/SIS2@3b82d4f Corrected uh_tot size in zonal_mass_flux
 - NOAA-GFDL/SIS2@5ec4861 +Eliminated ice_transport
 - NOAA-GFDL/SIS2@b71e5b2 +Store the total transports for advective substeps
 - NOAA-GFDL/SIS2@5356f5a Spread out and collect common ice_transport calls
 - NOAA-GFDL/SIS2@7771010 +Made snow2ice optional for finish_ice_transport
 - NOAA-GFDL/SIS2@fbe33c5 +Call separate parts of ice_transport on a B-grid
 - NOAA-GFDL/SIS2@78bc652 +Add cell_mass_from_CAS & new arg to ice_transport
 - NOAA-GFDL/SIS2@e35b406 Fix the ice restoring issues
 - NOAA-GFDL/SIS2@bb60e7a +Call separate parts of ice_transport
 - NOAA-GFDL/SIS2@2bb7749 +Added continuity_CSp arg to SIS_transport_init
 - NOAA-GFDL/SIS2@a04688c +Changed interface to ice_cat_transport
 - NOAA-GFDL/SIS2@4f06216 Store fluxes from continuity substeps
 - NOAA-GFDL/SIS2@78beaed +Added h_in argument to summed_continuity
 - NOAA-GFDL/SIS2@e52e43f +Added ice_cat_transport and finish_ice_transport
 - NOAA-GFDL/SIS2@47270bf +Call slab_ice code from SIS_dyn_trans
 - NOAA-GFDL/SIS2@6079251 +Added nsteps argument to ice_transport
 - NOAA-GFDL/SIS2@d3d184e +Store mass and enthalpy in cell_average_state_type
 - NOAA-GFDL/SIS2@90a4cb7 +Added module slab_ice
 - NOAA-GFDL/SIS2@6c6df59 +Changed interface to compress_ice
 - NOAA-GFDL/SIS2@3706248 +Use elements of CAS for ice transport diagnostics
 - NOAA-GFDL/SIS2@bfb4c5f Fix restart issue when DO_ICE_RESTORE=True
 - NOAA-GFDL/SIS2@da8a82f +Changed arguments to slab_ice_advect
 - NOAA-GFDL/SIS2@7293fbb +Added cell_ave_state_to_ice_state
 - NOAA-GFDL/SIS2@20ca2a1 +Added ice_state_to_cell_ave_state
 - NOAA-GFDL/SIS2@54270a8 Made IG intent(in) in SIS_tracer_advect.F90
 - NOAA-GFDL/SIS2@1c6e582 +Added cell_average_state_type & related routines
 - NOAA-GFDL/SIS2@3790877 Fix restart issue when DO_ICE_RESTORE=True
 - NOAA-GFDL/SIS2@51bcbb9 +Refactored subroutines finding total ice amounts
 - NOAA-GFDL/SIS2@533a866 +(*)Consolidated slab_ice advection code
 - NOAA-GFDL/SIS2@47427c4 +Replaced 5 arguments to ice_transport with IST
 - NOAA-GFDL/SIS2@a9b178e Eliminated an unneeded pass_var call for part_sz
 - NOAA-GFDL/SIS2@aacde82 Rearranged code in SIS_dynamics_trans
 - NOAA-GFDL/SIS2@fe740e6 +Added MERGED_CONTINUITY runtime option
 - NOAA-GFDL/SIS2@6b0af86 +Added proportionate_continuity
 - NOAA-GFDL/SIS2@04a9793 +Add summed_continuity & alter zonal_mass_flux
 - NOAA-GFDL/SIS2@572fbc3 +Moved ridging diagnostics into ice_transport
 - NOAA-GFDL/SIS2@02bf864 +(*)Replaced msnow args to dynamics with misp
 - NOAA-GFDL/SIS2@c8dcff8 +Moves XPRT diagnostic into SIS_transport