### PR TITLE
MOM6: +(*)Added MIN_SALINITY and fixed subML_N2

### DIFF
--- a/coupled_AM2_LM3_SIS/CM2G63L/MOM_parameter_doc.all
+++ b/coupled_AM2_LM3_SIS/CM2G63L/MOM_parameter_doc.all
@@ -1247,6 +1247,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP

--- a/coupled_AM2_LM3_SIS/CM2G63L/MOM_parameter_doc.all
+++ b/coupled_AM2_LM3_SIS/CM2G63L/MOM_parameter_doc.all
@@ -109,6 +109,10 @@ BOUND_SALINITY = True           !   [Boolean] default = False
                                 ! If true, limit salinity to being positive. (The sea-ice
                                 ! model may ask for more salt than is available and
                                 ! drive the salinity negative otherwise.)
+MIN_SALINITY = 0.01             !   [PPT] default = 0.01
+                                ! The minimum value of salinity when BOUND_SALINITY=True.
+                                ! The default is 0.01 for backward compatibility but ideally
+                                ! should be 0.
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
                                 ! The heat capacity of sea water, approximated as a
                                 ! constant. This is only used if ENABLE_THERMODYNAMICS is
@@ -180,7 +184,7 @@ RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -246,7 +250,8 @@ MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -455,8 +460,8 @@ COORD_VAR = "Layer"             ! default = "Layer"
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
@@ -524,7 +529,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 SPONGE = False                  !   [Boolean] default = False
                                 ! If true, sponges may be applied anywhere in the domain.
@@ -543,7 +548,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000030" ! default = "available_diags.000030"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -647,7 +652,8 @@ GILL_EQUATORIAL_LD = False      !   [Boolean] default = False
                                 ! If true, uses Gill's definition of the baroclinic
                                 ! equatorial deformation radius, otherwise, if false, use
                                 ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 infront of the beta term in the denominator. Gill'sis the more appropriate definition.
+                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
@@ -664,8 +670,8 @@ LINEAR_DRAG = False             !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 0.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -726,7 +732,7 @@ KV = 1.0E-04                    !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -780,7 +786,7 @@ MONOTONIC_CONTINUITY = True     !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -885,7 +891,8 @@ RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -907,7 +914,7 @@ KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
                                 ! The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latidutinally-dependent background
+                                ! The amplitude of a latitudinally-dependent background
                                 ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
@@ -973,7 +980,8 @@ HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
                                 ! stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
@@ -1001,7 +1009,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -1026,7 +1034,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
                                 ! If true, and BOUND_BT_CORRECTION is true, use the
                                 ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocites
+                                ! MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
                                 ! If true, adjust the curve fit to the BT_cont type
@@ -1058,7 +1066,7 @@ NONLIN_BT_CONT_UPDATE_PERIOD = 1 !   [nondim] default = 1
                                 ! areas, or 0 to update only before the barotropic stepping.
 BT_PROJECT_VELOCITY = False     !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -1093,7 +1101,7 @@ BT_STRONG_DRAG = False          !   [Boolean] default = False
                                 ! barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
                                 ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _vdivided by the depth of
+                                ! using rates set by lin_drag_u & _v divided by the depth of
                                 ! the ocean.  This was introduced to facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
                                 ! If true, limit any velocity components that exceed
@@ -1149,7 +1157,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1217,7 +1225,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of
@@ -1274,7 +1283,7 @@ INT_TIDE_PROFILE = "STLAURENT_02" ! default = "STLAURENT_02"
                                 ! dissipation with INT_TIDE_DISSIPATION. Valid values are:
                                 !    STLAURENT_02 - Use the St. Laurent et al exponential
                                 !                   decay profile.
-                                !    POLZIN_09 - Use the Polzin WKB-streched algebraic
+                                !    POLZIN_09 - Use the Polzin WKB-stretched algebraic
                                 !                   decay profile.
 LEE_WAVE_DISSIPATION = False    !   [Boolean] default = False
                                 ! If true, use an lee wave driven dissipation scheme to
@@ -1306,9 +1315,10 @@ KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
 UTIDE = 0.0                     !   [m s-1] default = 0.0
                                 ! The constant tidal amplitude used with INT_TIDE_DISSIPATION.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with nINT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with
+                                ! INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source availble to mix
+                                ! The maximum internal tide energy source available to mix
                                 ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
                                 ! If true, read a file (given by TIDEAMP_FILE) containing
@@ -1402,7 +1412,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1410,7 +1420,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1632,7 +1643,7 @@ CORRECT_ABSORPTION_DEPTH = True !   [Boolean] default = False
                                 ! heating depth of an exponential profile by moving some
                                 ! of the heating upward in the water column.
 DO_RIVERMIX = True              !   [Boolean] default = False
-                                ! If true, apply additional mixing whereever there is
+                                ! If true, apply additional mixing wherever there is
                                 ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
                                 ! if the ocean is that deep.
 RIVERMIX_DEPTH = 40.0           !   [m] default = 0.0
@@ -1709,12 +1720,12 @@ KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 3.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = True   !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1818,7 +1829,7 @@ RESTORE_SALINITY = False        !   [Boolean] default = False
                                 ! toward specified values.
 RESTORE_TEMPERATURE = False     !   [Boolean] default = False
                                 ! If true, the coupled driver will add a
-                                ! heat flux that drives sea-surface temperauture
+                                ! heat flux that drives sea-surface temperature
                                 ! toward specified values.
 ADJUST_NET_SRESTORE_TO_ZERO = False !   [Boolean] default = False
                                 ! If true, adjusts the salinity restoring seen to zero
@@ -1878,7 +1889,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_file_parser ===
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False

--- a/coupled_AM2_LM3_SIS/CM2G63L/MOM_parameter_doc.short
+++ b/coupled_AM2_LM3_SIS/CM2G63L/MOM_parameter_doc.short
@@ -118,7 +118,8 @@ MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 CHANNEL_CONFIG = "global_1deg"  ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:
@@ -174,8 +175,8 @@ COORD_FILE = "Vertical_coordinate.nc" !
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
@@ -412,9 +413,10 @@ KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
                                 ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
                                 ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with nINT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with
+                                ! INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source availble to mix
+                                ! The maximum internal tide energy source available to mix
                                 ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
                                 ! If true, read a file (given by TIDEAMP_FILE) containing
@@ -461,7 +463,7 @@ TKE_DECAY = 10.0                !   [nondim] default = 2.5
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -531,7 +533,7 @@ CORRECT_ABSORPTION_DEPTH = True !   [Boolean] default = False
                                 ! heating depth of an exponential profile by moving some
                                 ! of the heating upward in the water column.
 DO_RIVERMIX = True              !   [Boolean] default = False
-                                ! If true, apply additional mixing whereever there is
+                                ! If true, apply additional mixing wherever there is
                                 ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
                                 ! if the ocean is that deep.
 RIVERMIX_DEPTH = 40.0           !   [m] default = 0.0
@@ -563,8 +565,8 @@ KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 3.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 DIFFUSE_ML_TO_INTERIOR = True   !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface

--- a/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/MOM_parameter_doc.all
+++ b/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/MOM_parameter_doc.all
@@ -250,7 +250,8 @@ MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -890,7 +891,8 @@ RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -978,7 +980,8 @@ HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
                                 ! stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
@@ -1218,7 +1221,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of

--- a/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/MOM_parameter_doc.all
+++ b/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/MOM_parameter_doc.all
@@ -109,6 +109,10 @@ BOUND_SALINITY = True           !   [Boolean] default = False
                                 ! If true, limit salinity to being positive. (The sea-ice
                                 ! model may ask for more salt than is available and
                                 ! drive the salinity negative otherwise.)
+MIN_SALINITY = 0.01             !   [PPT] default = 0.01
+                                ! The minimum value of salinity when BOUND_SALINITY=True.
+                                ! The default is 0.01 for backward compatibility but ideally
+                                ! should be 0.
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
                                 ! The heat capacity of sea water, approximated as a
                                 ! constant. This is only used if ENABLE_THERMODYNAMICS is
@@ -180,7 +184,7 @@ RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -455,8 +459,8 @@ COORD_VAR = "Layer"             ! default = "Layer"
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
@@ -524,7 +528,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 SPONGE = False                  !   [Boolean] default = False
                                 ! If true, sponges may be applied anywhere in the domain.
@@ -543,7 +547,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000030" ! default = "available_diags.000030"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -647,7 +651,8 @@ GILL_EQUATORIAL_LD = False      !   [Boolean] default = False
                                 ! If true, uses Gill's definition of the baroclinic
                                 ! equatorial deformation radius, otherwise, if false, use
                                 ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 infront of the beta term in the denominator. Gill'sis the more appropriate definition.
+                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
@@ -664,8 +669,8 @@ LINEAR_DRAG = False             !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 0.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -726,7 +731,7 @@ KV = 1.0E-04                    !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -780,7 +785,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -907,7 +912,7 @@ KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
                                 ! The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latidutinally-dependent background
+                                ! The amplitude of a latitudinally-dependent background
                                 ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
@@ -1001,7 +1006,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -1026,7 +1031,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
                                 ! If true, and BOUND_BT_CORRECTION is true, use the
                                 ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocites
+                                ! MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
                                 ! If true, adjust the curve fit to the BT_cont type
@@ -1054,7 +1059,7 @@ NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
                                 ! USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -1089,7 +1094,7 @@ BT_STRONG_DRAG = False          !   [Boolean] default = False
                                 ! barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
                                 ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _vdivided by the depth of
+                                ! using rates set by lin_drag_u & _v divided by the depth of
                                 ! the ocean.  This was introduced to facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
                                 ! If true, limit any velocity components that exceed
@@ -1145,7 +1150,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1243,6 +1248,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1267,7 +1275,7 @@ INT_TIDE_PROFILE = "STLAURENT_02" ! default = "STLAURENT_02"
                                 ! dissipation with INT_TIDE_DISSIPATION. Valid values are:
                                 !    STLAURENT_02 - Use the St. Laurent et al exponential
                                 !                   decay profile.
-                                !    POLZIN_09 - Use the Polzin WKB-streched algebraic
+                                !    POLZIN_09 - Use the Polzin WKB-stretched algebraic
                                 !                   decay profile.
 LEE_WAVE_DISSIPATION = False    !   [Boolean] default = False
                                 ! If true, use an lee wave driven dissipation scheme to
@@ -1299,9 +1307,10 @@ KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
 UTIDE = 0.0                     !   [m s-1] default = 0.0
                                 ! The constant tidal amplitude used with INT_TIDE_DISSIPATION.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with nINT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with
+                                ! INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source availble to mix
+                                ! The maximum internal tide energy source available to mix
                                 ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
                                 ! If true, read a file (given by TIDEAMP_FILE) containing
@@ -1395,7 +1404,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1403,7 +1412,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1625,7 +1635,7 @@ CORRECT_ABSORPTION_DEPTH = True !   [Boolean] default = False
                                 ! heating depth of an exponential profile by moving some
                                 ! of the heating upward in the water column.
 DO_RIVERMIX = True              !   [Boolean] default = False
-                                ! If true, apply additional mixing whereever there is
+                                ! If true, apply additional mixing wherever there is
                                 ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
                                 ! if the ocean is that deep.
 RIVERMIX_DEPTH = 40.0           !   [m] default = 0.0
@@ -1706,12 +1716,12 @@ KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 3.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = True   !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1815,7 +1825,7 @@ RESTORE_SALINITY = False        !   [Boolean] default = False
                                 ! toward specified values.
 RESTORE_TEMPERATURE = False     !   [Boolean] default = False
                                 ! If true, the coupled driver will add a
-                                ! heat flux that drives sea-surface temperauture
+                                ! heat flux that drives sea-surface temperature
                                 ! toward specified values.
 ADJUST_NET_SRESTORE_TO_ZERO = False !   [Boolean] default = False
                                 ! If true, adjusts the salinity restoring seen to zero
@@ -1875,7 +1885,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_file_parser ===
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False

--- a/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/MOM_parameter_doc.short
+++ b/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/MOM_parameter_doc.short
@@ -126,7 +126,8 @@ MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 CHANNEL_CONFIG = "global_1deg"  ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:

--- a/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/MOM_parameter_doc.short
+++ b/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/MOM_parameter_doc.short
@@ -182,8 +182,8 @@ COORD_FILE = "GOLD_IC.2010.11.15.nc" !
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
@@ -335,7 +335,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
                                 ! less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -408,9 +408,10 @@ KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
                                 ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
                                 ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with nINT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with
+                                ! INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source availble to mix
+                                ! The maximum internal tide energy source available to mix
                                 ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
                                 ! If true, read a file (given by TIDEAMP_FILE) containing
@@ -457,7 +458,7 @@ TKE_DECAY = 10.0                !   [nondim] default = 2.5
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -527,7 +528,7 @@ CORRECT_ABSORPTION_DEPTH = True !   [Boolean] default = False
                                 ! heating depth of an exponential profile by moving some
                                 ! of the heating upward in the water column.
 DO_RIVERMIX = True              !   [Boolean] default = False
-                                ! If true, apply additional mixing whereever there is
+                                ! If true, apply additional mixing wherever there is
                                 ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
                                 ! if the ocean is that deep.
 RIVERMIX_DEPTH = 40.0           !   [m] default = 0.0
@@ -563,8 +564,8 @@ KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 3.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 DIFFUSE_ML_TO_INTERIOR = True   !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface

--- a/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/SIS_parameter_doc.all
+++ b/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/SIS_parameter_doc.all
@@ -453,7 +453,8 @@ STATISTICS_FILE = "seaice.stats" ! default = "seaice.stats"
 ! This module handles sea-ice state diagnostics.
 
 ! === module SIS_fast_thermo ===
-! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.
+! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature
+! calculation.
 REORDER_0C_HEATFLUX = False     !   [Boolean] default = False
                                 ! If true, rearrange the calculation of the heat fluxes
                                 ! projected back to 0C to work on each contribution

--- a/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/SIS_parameter_doc.short
+++ b/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/SIS_parameter_doc.short
@@ -121,7 +121,8 @@ SIS_TRACER_ADVECTION_SCHEME = "PPM:H3" ! default = "UPWIND_2D"
 ! This module handles sea-ice state diagnostics.
 
 ! === module SIS_fast_thermo ===
-! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.
+! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature
+! calculation.
 
 ! === module SIS2_ice_thm (updates) ===
 ! This sub-module does updates of the sea-ice due to thermodynamic changes.

--- a/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/MOM_parameter_doc.all
+++ b/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/MOM_parameter_doc.all
@@ -250,7 +250,8 @@ MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -890,7 +891,8 @@ RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -978,7 +980,8 @@ HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
                                 ! stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
@@ -1218,7 +1221,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of

--- a/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/MOM_parameter_doc.all
+++ b/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/MOM_parameter_doc.all
@@ -109,6 +109,10 @@ BOUND_SALINITY = True           !   [Boolean] default = False
                                 ! If true, limit salinity to being positive. (The sea-ice
                                 ! model may ask for more salt than is available and
                                 ! drive the salinity negative otherwise.)
+MIN_SALINITY = 0.01             !   [PPT] default = 0.01
+                                ! The minimum value of salinity when BOUND_SALINITY=True.
+                                ! The default is 0.01 for backward compatibility but ideally
+                                ! should be 0.
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
                                 ! The heat capacity of sea water, approximated as a
                                 ! constant. This is only used if ENABLE_THERMODYNAMICS is
@@ -180,7 +184,7 @@ RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -455,8 +459,8 @@ COORD_VAR = "Layer"             ! default = "Layer"
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
@@ -524,7 +528,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 SPONGE = False                  !   [Boolean] default = False
                                 ! If true, sponges may be applied anywhere in the domain.
@@ -543,7 +547,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000030" ! default = "available_diags.000030"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -647,7 +651,8 @@ GILL_EQUATORIAL_LD = False      !   [Boolean] default = False
                                 ! If true, uses Gill's definition of the baroclinic
                                 ! equatorial deformation radius, otherwise, if false, use
                                 ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 infront of the beta term in the denominator. Gill'sis the more appropriate definition.
+                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
@@ -664,8 +669,8 @@ LINEAR_DRAG = False             !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 0.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -726,7 +731,7 @@ KV = 1.0E-04                    !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -780,7 +785,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -907,7 +912,7 @@ KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
                                 ! The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latidutinally-dependent background
+                                ! The amplitude of a latitudinally-dependent background
                                 ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
@@ -1001,7 +1006,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -1026,7 +1031,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
                                 ! If true, and BOUND_BT_CORRECTION is true, use the
                                 ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocites
+                                ! MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
                                 ! If true, adjust the curve fit to the BT_cont type
@@ -1054,7 +1059,7 @@ NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
                                 ! USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -1089,7 +1094,7 @@ BT_STRONG_DRAG = False          !   [Boolean] default = False
                                 ! barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
                                 ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _vdivided by the depth of
+                                ! using rates set by lin_drag_u & _v divided by the depth of
                                 ! the ocean.  This was introduced to facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
                                 ! If true, limit any velocity components that exceed
@@ -1145,7 +1150,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1243,6 +1248,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1267,7 +1275,7 @@ INT_TIDE_PROFILE = "STLAURENT_02" ! default = "STLAURENT_02"
                                 ! dissipation with INT_TIDE_DISSIPATION. Valid values are:
                                 !    STLAURENT_02 - Use the St. Laurent et al exponential
                                 !                   decay profile.
-                                !    POLZIN_09 - Use the Polzin WKB-streched algebraic
+                                !    POLZIN_09 - Use the Polzin WKB-stretched algebraic
                                 !                   decay profile.
 LEE_WAVE_DISSIPATION = False    !   [Boolean] default = False
                                 ! If true, use an lee wave driven dissipation scheme to
@@ -1299,9 +1307,10 @@ KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
 UTIDE = 0.0                     !   [m s-1] default = 0.0
                                 ! The constant tidal amplitude used with INT_TIDE_DISSIPATION.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with nINT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with
+                                ! INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source availble to mix
+                                ! The maximum internal tide energy source available to mix
                                 ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
                                 ! If true, read a file (given by TIDEAMP_FILE) containing
@@ -1395,7 +1404,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1403,7 +1412,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1625,7 +1635,7 @@ CORRECT_ABSORPTION_DEPTH = True !   [Boolean] default = False
                                 ! heating depth of an exponential profile by moving some
                                 ! of the heating upward in the water column.
 DO_RIVERMIX = True              !   [Boolean] default = False
-                                ! If true, apply additional mixing whereever there is
+                                ! If true, apply additional mixing wherever there is
                                 ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
                                 ! if the ocean is that deep.
 RIVERMIX_DEPTH = 40.0           !   [m] default = 0.0
@@ -1706,12 +1716,12 @@ KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 3.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = True   !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1815,7 +1825,7 @@ RESTORE_SALINITY = False        !   [Boolean] default = False
                                 ! toward specified values.
 RESTORE_TEMPERATURE = False     !   [Boolean] default = False
                                 ! If true, the coupled driver will add a
-                                ! heat flux that drives sea-surface temperauture
+                                ! heat flux that drives sea-surface temperature
                                 ! toward specified values.
 ADJUST_NET_SRESTORE_TO_ZERO = False !   [Boolean] default = False
                                 ! If true, adjusts the salinity restoring seen to zero
@@ -1875,7 +1885,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_file_parser ===
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False

--- a/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/MOM_parameter_doc.short
+++ b/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/MOM_parameter_doc.short
@@ -126,7 +126,8 @@ MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 CHANNEL_CONFIG = "global_1deg"  ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:

--- a/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/MOM_parameter_doc.short
+++ b/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/MOM_parameter_doc.short
@@ -182,8 +182,8 @@ COORD_FILE = "GOLD_IC.2010.11.15.nc" !
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
@@ -335,7 +335,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
                                 ! less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -408,9 +408,10 @@ KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
                                 ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
                                 ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with nINT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with
+                                ! INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source availble to mix
+                                ! The maximum internal tide energy source available to mix
                                 ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
                                 ! If true, read a file (given by TIDEAMP_FILE) containing
@@ -457,7 +458,7 @@ TKE_DECAY = 10.0                !   [nondim] default = 2.5
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -527,7 +528,7 @@ CORRECT_ABSORPTION_DEPTH = True !   [Boolean] default = False
                                 ! heating depth of an exponential profile by moving some
                                 ! of the heating upward in the water column.
 DO_RIVERMIX = True              !   [Boolean] default = False
-                                ! If true, apply additional mixing whereever there is
+                                ! If true, apply additional mixing wherever there is
                                 ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
                                 ! if the ocean is that deep.
 RIVERMIX_DEPTH = 40.0           !   [m] default = 0.0
@@ -563,8 +564,8 @@ KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 3.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 DIFFUSE_ML_TO_INTERIOR = True   !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface

--- a/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/SIS_parameter_doc.all
+++ b/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/SIS_parameter_doc.all
@@ -450,7 +450,8 @@ STATISTICS_FILE = "seaice.stats" ! default = "seaice.stats"
 ! This module handles sea-ice state diagnostics.
 
 ! === module SIS_fast_thermo ===
-! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.
+! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature
+! calculation.
 REORDER_0C_HEATFLUX = False     !   [Boolean] default = False
                                 ! If true, rearrange the calculation of the heat fluxes
                                 ! projected back to 0C to work on each contribution

--- a/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/SIS_parameter_doc.short
+++ b/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/SIS_parameter_doc.short
@@ -121,7 +121,8 @@ SIS_TRACER_ADVECTION_SCHEME = "PPM:H3" ! default = "UPWIND_2D"
 ! This module handles sea-ice state diagnostics.
 
 ! === module SIS_fast_thermo ===
-! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.
+! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature
+! calculation.
 
 ! === module SIS2_ice_thm (updates) ===
 ! This sub-module does updates of the sea-ice due to thermodynamic changes.

--- a/ice_ocean_SIS2/Baltic/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/Baltic/MOM_parameter_doc.all
@@ -109,6 +109,10 @@ BOUND_SALINITY = True           !   [Boolean] default = False
                                 ! If true, limit salinity to being positive. (The sea-ice
                                 ! model may ask for more salt than is available and
                                 ! drive the salinity negative otherwise.)
+MIN_SALINITY = 0.01             !   [PPT] default = 0.01
+                                ! The minimum value of salinity when BOUND_SALINITY=True.
+                                ! The default is 0.01 for backward compatibility but ideally
+                                ! should be 0.
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
                                 ! The heat capacity of sea water, approximated as a
                                 ! constant. This is only used if ENABLE_THERMODYNAMICS is
@@ -180,7 +184,7 @@ RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -455,8 +459,8 @@ COORD_VAR = "Layer"             ! default = "Layer"
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
@@ -524,7 +528,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 SPONGE = False                  !   [Boolean] default = False
                                 ! If true, sponges may be applied anywhere in the domain.
@@ -543,7 +547,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -647,7 +651,8 @@ GILL_EQUATORIAL_LD = False      !   [Boolean] default = False
                                 ! If true, uses Gill's definition of the baroclinic
                                 ! equatorial deformation radius, otherwise, if false, use
                                 ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 infront of the beta term in the denominator. Gill'sis the more appropriate definition.
+                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
@@ -664,8 +669,8 @@ LINEAR_DRAG = False             !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 0.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -726,7 +731,7 @@ KV = 1.0E-04                    !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -780,7 +785,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -907,7 +912,7 @@ KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
                                 ! The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latidutinally-dependent background
+                                ! The amplitude of a latitudinally-dependent background
                                 ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
@@ -1001,7 +1006,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -1026,7 +1031,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
                                 ! If true, and BOUND_BT_CORRECTION is true, use the
                                 ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocites
+                                ! MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
                                 ! If true, adjust the curve fit to the BT_cont type
@@ -1054,7 +1059,7 @@ NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
                                 ! USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -1089,7 +1094,7 @@ BT_STRONG_DRAG = False          !   [Boolean] default = False
                                 ! barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
                                 ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _vdivided by the depth of
+                                ! using rates set by lin_drag_u & _v divided by the depth of
                                 ! the ocean.  This was introduced to facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
                                 ! If true, limit any velocity components that exceed
@@ -1145,7 +1150,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1243,6 +1248,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1267,7 +1275,7 @@ INT_TIDE_PROFILE = "STLAURENT_02" ! default = "STLAURENT_02"
                                 ! dissipation with INT_TIDE_DISSIPATION. Valid values are:
                                 !    STLAURENT_02 - Use the St. Laurent et al exponential
                                 !                   decay profile.
-                                !    POLZIN_09 - Use the Polzin WKB-streched algebraic
+                                !    POLZIN_09 - Use the Polzin WKB-stretched algebraic
                                 !                   decay profile.
 LEE_WAVE_DISSIPATION = False    !   [Boolean] default = False
                                 ! If true, use an lee wave driven dissipation scheme to
@@ -1299,9 +1307,10 @@ KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
 UTIDE = 0.0                     !   [m s-1] default = 0.0
                                 ! The constant tidal amplitude used with INT_TIDE_DISSIPATION.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with nINT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with
+                                ! INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source availble to mix
+                                ! The maximum internal tide energy source available to mix
                                 ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
                                 ! If true, read a file (given by TIDEAMP_FILE) containing
@@ -1395,7 +1404,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1403,7 +1412,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1625,7 +1635,7 @@ CORRECT_ABSORPTION_DEPTH = True !   [Boolean] default = False
                                 ! heating depth of an exponential profile by moving some
                                 ! of the heating upward in the water column.
 DO_RIVERMIX = True              !   [Boolean] default = False
-                                ! If true, apply additional mixing whereever there is
+                                ! If true, apply additional mixing wherever there is
                                 ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
                                 ! if the ocean is that deep.
 RIVERMIX_DEPTH = 40.0           !   [m] default = 0.0
@@ -1706,12 +1716,12 @@ KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 3.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = True   !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1815,7 +1825,7 @@ RESTORE_SALINITY = True         !   [Boolean] default = False
                                 ! toward specified values.
 RESTORE_TEMPERATURE = False     !   [Boolean] default = False
                                 ! If true, the coupled driver will add a
-                                ! heat flux that drives sea-surface temperauture
+                                ! heat flux that drives sea-surface temperature
                                 ! toward specified values.
 ADJUST_NET_SRESTORE_TO_ZERO = True !   [Boolean] default = True
                                 ! If true, adjusts the salinity restoring seen to zero
@@ -1902,7 +1912,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_file_parser ===
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False

--- a/ice_ocean_SIS2/Baltic/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/Baltic/MOM_parameter_doc.all
@@ -250,7 +250,8 @@ MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -890,7 +891,8 @@ RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -978,7 +980,8 @@ HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
                                 ! stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
@@ -1218,7 +1221,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of
@@ -1870,7 +1874,8 @@ FLUXCONST = 0.5                 !   [m day-1]
 SALT_RESTORE_FILE = "salt_restore.nc" ! default = "salt_restore.nc"
                                 ! A file in which to find the surface salinity to use for restoring.
 SALT_RESTORE_VARIABLE = "salt"  ! default = "salt"
-                                ! The name of the surface salinity variable to read from SALT_RESTORE_FILE for restoring salinity.
+                                ! The name of the surface salinity variable to read from SALT_RESTORE_FILE for
+                                ! restoring salinity.
 SRESTORE_AS_SFLUX = False       !   [Boolean] default = False
                                 ! If true, the restoring of salinity is applied as a salt
                                 ! flux instead of as a freshwater flux.

--- a/ice_ocean_SIS2/Baltic/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/Baltic/MOM_parameter_doc.short
@@ -179,8 +179,8 @@ COORD_FILE = "GOLD_IC.2010.11.15.nc" !
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
@@ -347,7 +347,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
                                 ! less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -420,9 +420,10 @@ KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
                                 ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
                                 ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with nINT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with
+                                ! INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source availble to mix
+                                ! The maximum internal tide energy source available to mix
                                 ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
                                 ! If true, read a file (given by TIDEAMP_FILE) containing
@@ -469,7 +470,7 @@ TKE_DECAY = 10.0                !   [nondim] default = 2.5
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -539,7 +540,7 @@ CORRECT_ABSORPTION_DEPTH = True !   [Boolean] default = False
                                 ! heating depth of an exponential profile by moving some
                                 ! of the heating upward in the water column.
 DO_RIVERMIX = True              !   [Boolean] default = False
-                                ! If true, apply additional mixing whereever there is
+                                ! If true, apply additional mixing wherever there is
                                 ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
                                 ! if the ocean is that deep.
 RIVERMIX_DEPTH = 40.0           !   [m] default = 0.0
@@ -575,8 +576,8 @@ KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 3.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 DIFFUSE_ML_TO_INTERIOR = True   !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface

--- a/ice_ocean_SIS2/Baltic/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/Baltic/MOM_parameter_doc.short
@@ -123,7 +123,8 @@ MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 CHANNEL_CONFIG = "global_1deg"  ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:

--- a/ice_ocean_SIS2/Baltic/SIS_parameter_doc.all
+++ b/ice_ocean_SIS2/Baltic/SIS_parameter_doc.all
@@ -471,7 +471,8 @@ STATISTICS_FILE = "seaice.stats" ! default = "seaice.stats"
 ! This module handles sea-ice state diagnostics.
 
 ! === module SIS_fast_thermo ===
-! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.
+! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature
+! calculation.
 REORDER_0C_HEATFLUX = False     !   [Boolean] default = False
                                 ! If true, rearrange the calculation of the heat fluxes
                                 ! projected back to 0C to work on each contribution

--- a/ice_ocean_SIS2/Baltic/SIS_parameter_doc.short
+++ b/ice_ocean_SIS2/Baltic/SIS_parameter_doc.short
@@ -131,7 +131,8 @@ SIS_TRACER_ADVECTION_SCHEME = "PPM:H3" ! default = "UPWIND_2D"
 ! This module handles sea-ice state diagnostics.
 
 ! === module SIS_fast_thermo ===
-! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.
+! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature
+! calculation.
 
 ! === module SIS2_ice_thm (updates) ===
 ! This sub-module does updates of the sea-ice due to thermodynamic changes.

--- a/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/MOM_parameter_doc.all
@@ -267,7 +267,8 @@ MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -715,7 +716,8 @@ MEKE_COLD_START = False         !   [Boolean] default = False
                                 ! is used as an initial condition for EKE.
 MEKE_BACKSCAT_RO_C = 0.0        !   [nondim] default = 0.0
                                 ! The coefficient in the Rossby number function for scaling the biharmonic
-                                ! frictional energy source. Setting to non-zero enables the Rossby number function.
+                                ! frictional energy source. Setting to non-zero enables the Rossby number
+                                ! function.
 MEKE_BACKSCAT_RO_POW = 0.0      !   [nondim] default = 0.0
                                 ! The power in the Rossby number function for scaling the biharmonic
                                 ! frictional energy source.
@@ -1084,7 +1086,8 @@ RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -1172,7 +1175,8 @@ HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
                                 ! stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
@@ -1450,7 +1454,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of

--- a/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/MOM_parameter_doc.all
@@ -117,6 +117,10 @@ BOUND_SALINITY = True           !   [Boolean] default = False
                                 ! If true, limit salinity to being positive. (The sea-ice
                                 ! model may ask for more salt than is available and
                                 ! drive the salinity negative otherwise.)
+MIN_SALINITY = 0.01             !   [PPT] default = 0.01
+                                ! The minimum value of salinity when BOUND_SALINITY=True.
+                                ! The default is 0.01 for backward compatibility but ideally
+                                ! should be 0.
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
                                 ! The heat capacity of sea water, approximated as a
                                 ! constant. This is only used if ENABLE_THERMODYNAMICS is
@@ -197,7 +201,7 @@ RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -441,15 +445,15 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
-                                ! Units of the regridding coordinuate.
+                                ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "FILE:vgrid.nc,dz" ! default = "UNIFORM"
                                 ! Determines how to specify the coordinate
                                 ! resolution. Valid options are:
@@ -486,7 +490,7 @@ REMAPPING_SCHEME = "PPM_H4"     ! default = "PLM"
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
                                 ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicty or an inconsistency is
+                                ! consistency and if non-monotonicity or an inconsistency is
                                 ! detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
                                 ! If true, the results of remapping are checked for
@@ -515,15 +519,15 @@ REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
-                                ! REGRID_FILTER_SHALLOW_DEPTH the filter wieghts adopt a cubic profile.
+                                ! REGRID_FILTER_SHALLOW_DEPTH the filter weights adopt a cubic profile.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
@@ -582,7 +586,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
@@ -601,7 +605,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -626,7 +630,7 @@ USE_MEKE = True                 !   [Boolean] default = False
                                 ! If true, turns on the MEKE scheme which calculates
                                 ! a sub-grid mesoscale eddy kinetic energy budget.
 MEKE_DAMPING = 0.0              !   [s-1] default = 0.0
-                                ! The local depth-indepented MEKE dissipation rate.
+                                ! The local depth-independent MEKE dissipation rate.
 MEKE_CD_SCALE = 0.0             !   [nondim] default = 0.0
                                 ! The ratio of the bottom eddy velocity to the column mean
                                 ! eddy velocity, i.e. sqrt(2*MEKE). This should be less than 1
@@ -690,34 +694,34 @@ MEKE_VISCOSITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! represent backscatter from the unresolved eddies.
 MEKE_FIXED_MIXING_LENGTH = 0.0  !   [m] default = 0.0
                                 ! If positive, is a fixed length contribution to the expression
-                                ! for mixing length used in MEKE-derived diffusiviity.
+                                ! for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_DEFORM = 0.0         !   [nondim] default = 0.0
                                 ! If positive, is a coefficient weighting the deformation scale
-                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+                                ! in the expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_RHINES = 0.05        !   [nondim] default = 0.05
                                 ! If positive, is a coefficient weighting the Rhines scale
-                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+                                ! in the expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_EADY = 0.05          !   [nondim] default = 0.05
                                 ! If positive, is a coefficient weighting the Eady length scale
-                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+                                ! in the expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_FRICT = 0.0          !   [nondim] default = 0.0
                                 ! If positive, is a coefficient weighting the frictional arrest scale
-                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+                                ! in the expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_GRID = 0.0           !   [nondim] default = 0.0
                                 ! If positive, is a coefficient weighting the grid-spacing as a scale
-                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+                                ! in the expression for mixing length used in MEKE-derived diffusivity.
 MEKE_COLD_START = False         !   [Boolean] default = False
                                 ! If true, initialize EKE to zero. Otherwise a local equilibrium solution
                                 ! is used as an initial condition for EKE.
 MEKE_BACKSCAT_RO_C = 0.0        !   [nondim] default = 0.0
-                                ! The coefficient in the Rossby number function for scaling the buharmonic
+                                ! The coefficient in the Rossby number function for scaling the biharmonic
                                 ! frictional energy source. Setting to non-zero enables the Rossby number function.
 MEKE_BACKSCAT_RO_POW = 0.0      !   [nondim] default = 0.0
-                                ! The power in the Rossby number function for scaling the biharmomnic
+                                ! The power in the Rossby number function for scaling the biharmonic
                                 ! frictional energy source.
 MEKE_ADVECTION_FACTOR = 0.0     !   [nondim] default = 0.0
                                 ! A scale factor in front of advection of eddy energy. Zero turns advection off.
-                                ! Using unity would be normal but other values could accomodate a mismatch
+                                ! Using unity would be normal but other values could accommodate a mismatch
                                 ! between the advecting barotropic flow and the vertical structure of MEKE.
 MEKE_TOPOGRAPHIC_BETA = 0.0     !   [nondim] default = 0.0
                                 ! A scale factor to determine how much topographic beta is weighed in
@@ -803,7 +807,8 @@ GILL_EQUATORIAL_LD = True       !   [Boolean] default = False
                                 ! If true, uses Gill's definition of the baroclinic
                                 ! equatorial deformation radius, otherwise, if false, use
                                 ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 infront of the beta term in the denominator. Gill'sis the more appropriate definition.
+                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
@@ -820,8 +825,8 @@ LINEAR_DRAG = False             !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -863,7 +868,7 @@ KV = 1.0E-04                    !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -917,7 +922,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -1101,7 +1106,7 @@ KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
                                 ! The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latidutinally-dependent background
+                                ! The amplitude of a latitudinally-dependent background
                                 ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
@@ -1203,7 +1208,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 7200.0 !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -1228,7 +1233,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
                                 ! If true, and BOUND_BT_CORRECTION is true, use the
                                 ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocites
+                                ! MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
                                 ! If true, adjust the curve fit to the BT_cont type
@@ -1256,7 +1261,7 @@ NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
                                 ! USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -1291,7 +1296,7 @@ BT_STRONG_DRAG = False          !   [Boolean] default = False
                                 ! barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
                                 ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _vdivided by the depth of
+                                ! using rates set by lin_drag_u & _v divided by the depth of
                                 ! the ocean.  This was introduced to facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
                                 ! If true, limit any velocity components that exceed
@@ -1347,7 +1352,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1475,6 +1480,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1499,7 +1507,7 @@ INT_TIDE_PROFILE = "STLAURENT_02" ! default = "STLAURENT_02"
                                 ! dissipation with INT_TIDE_DISSIPATION. Valid values are:
                                 !    STLAURENT_02 - Use the St. Laurent et al exponential
                                 !                   decay profile.
-                                !    POLZIN_09 - Use the Polzin WKB-streched algebraic
+                                !    POLZIN_09 - Use the Polzin WKB-stretched algebraic
                                 !                   decay profile.
 LEE_WAVE_DISSIPATION = False    !   [Boolean] default = False
                                 ! If true, use an lee wave driven dissipation scheme to
@@ -1531,9 +1539,10 @@ KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
 UTIDE = 0.0                     !   [m s-1] default = 0.0
                                 ! The constant tidal amplitude used with INT_TIDE_DISSIPATION.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with nINT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with
+                                ! INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source availble to mix
+                                ! The maximum internal tide energy source available to mix
                                 ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
                                 ! If true, read a file (given by TIDEAMP_FILE) containing
@@ -1606,7 +1615,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = True !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1617,7 +1626,8 @@ LOTW_BBL_USE_OMEGA = True       !   [Boolean] default = True
 SIMPLE_TKE_TO_KD = True         !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1774,7 +1784,7 @@ IGNORE_FLUXES_OVER_LAND = False !   [Boolean] default = False
                                 ! be different than the ocean mask to avoid sea ice formation
                                 ! under ice shelves. This flag only works when use_ePBL = True.
 DO_RIVERMIX = False             !   [Boolean] default = False
-                                ! If true, apply additional mixing whereever there is
+                                ! If true, apply additional mixing wherever there is
                                 ! runoff, so that it is mixed down to RIVERMIX_DEPTH
                                 ! if the ocean is that deep.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
@@ -1850,7 +1860,7 @@ EKMAN_SCALE_COEF = 1.0          !   [nondim] default = 1.0
                                 ! decreases the PBL diffusivity.
 USE_MLD_ITERATION = False       !   [Boolean] default = False
                                 ! A logical that specifies whether or not to use the
-                                ! distance to the bottom of the actively turblent boundary
+                                ! distance to the bottom of the actively turbulent boundary
                                 ! layer to help set the EPBL length scale.
 ORIG_MLD_ITERATION = True       !   [Boolean] default = True
                                 ! A logical that specifies whether or not to use the
@@ -1952,12 +1962,12 @@ KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -2067,7 +2077,7 @@ RESTORE_SALINITY = False        !   [Boolean] default = False
                                 ! toward specified values.
 RESTORE_TEMPERATURE = False     !   [Boolean] default = False
                                 ! If true, the coupled driver will add a
-                                ! heat flux that drives sea-surface temperauture
+                                ! heat flux that drives sea-surface temperature
                                 ! toward specified values.
 ADJUST_NET_SRESTORE_TO_ZERO = False !   [Boolean] default = False
                                 ! If true, adjusts the salinity restoring seen to zero
@@ -2127,7 +2137,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_file_parser ===
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False

--- a/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/MOM_parameter_doc.short
@@ -128,7 +128,8 @@ MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 CHANNEL_CONFIG = "global_1deg"  ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:

--- a/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/MOM_parameter_doc.short
@@ -190,8 +190,8 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
@@ -234,8 +234,8 @@ REMAPPING_SCHEME = "PPM_H4"     ! default = "PLM"
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
@@ -293,7 +293,8 @@ GILL_EQUATORIAL_LD = True       !   [Boolean] default = False
                                 ! If true, uses Gill's definition of the baroclinic
                                 ! equatorial deformation radius, otherwise, if false, use
                                 ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 infront of the beta term in the denominator. Gill'sis the more appropriate definition.
+                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 CHANNEL_DRAG = True             !   [Boolean] default = False
@@ -397,7 +398,7 @@ MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity
                                 ! components are truncated.
 CFL_TRUNCATE_RAMP_TIME = 7200.0 !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 
 ! === module MOM_PointAccel ===
@@ -409,7 +410,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
                                 ! less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -486,9 +487,10 @@ KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
                                 ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
                                 ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with nINT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with
+                                ! INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source availble to mix
+                                ! The maximum internal tide energy source available to mix
                                 ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
                                 ! If true, read a file (given by TIDEAMP_FILE) containing
@@ -520,7 +522,7 @@ GEOTHERMAL_FILE = "geothermal_heating_cm2g.nc" ! default = ""
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = True !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -528,7 +530,8 @@ USE_LOTW_BBL_DIFFUSIVITY = True !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = True         !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients

--- a/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/SIS_parameter_doc.all
+++ b/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/SIS_parameter_doc.all
@@ -453,7 +453,8 @@ STATISTICS_FILE = "seaice.stats" ! default = "seaice.stats"
 ! This module handles sea-ice state diagnostics.
 
 ! === module SIS_fast_thermo ===
-! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.
+! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature
+! calculation.
 REORDER_0C_HEATFLUX = False     !   [Boolean] default = False
                                 ! If true, rearrange the calculation of the heat fluxes
                                 ! projected back to 0C to work on each contribution

--- a/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/SIS_parameter_doc.short
+++ b/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/SIS_parameter_doc.short
@@ -101,7 +101,8 @@ SIS_TRACER_ADVECTION_SCHEME = "PPM:H3" ! default = "UPWIND_2D"
 ! This module handles sea-ice state diagnostics.
 
 ! === module SIS_fast_thermo ===
-! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.
+! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature
+! calculation.
 
 ! === module SIS2_ice_thm (updates) ===
 ! This sub-module does updates of the sea-ice due to thermodynamic changes.

--- a/ice_ocean_SIS2/OM4_025/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/OM4_025/MOM_parameter_doc.all
@@ -267,7 +267,8 @@ MINIMUM_DEPTH = 9.5             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = 0.0             !   [m] default = -9999.0
@@ -771,7 +772,8 @@ MEKE_COLD_START = False         !   [Boolean] default = False
                                 ! is used as an initial condition for EKE.
 MEKE_BACKSCAT_RO_C = 0.0        !   [nondim] default = 0.0
                                 ! The coefficient in the Rossby number function for scaling the biharmonic
-                                ! frictional energy source. Setting to non-zero enables the Rossby number function.
+                                ! frictional energy source. Setting to non-zero enables the Rossby number
+                                ! function.
 MEKE_BACKSCAT_RO_POW = 0.0      !   [nondim] default = 0.0
                                 ! The power in the Rossby number function for scaling the biharmonic
                                 ! frictional energy source.
@@ -1089,7 +1091,8 @@ RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -1177,7 +1180,8 @@ HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
                                 ! stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
@@ -1463,7 +1467,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of
@@ -2171,7 +2176,8 @@ FLUXCONST = 0.1667              !   [m day-1]
 SALT_RESTORE_FILE = "salt_restore_PHC2.1440x1080.v20180405.nc" ! default = "salt_restore.nc"
                                 ! A file in which to find the surface salinity to use for restoring.
 SALT_RESTORE_VARIABLE = "salt"  ! default = "salt"
-                                ! The name of the surface salinity variable to read from SALT_RESTORE_FILE for restoring salinity.
+                                ! The name of the surface salinity variable to read from SALT_RESTORE_FILE for
+                                ! restoring salinity.
 SRESTORE_AS_SFLUX = True        !   [Boolean] default = False
                                 ! If true, the restoring of salinity is applied as a salt
                                 ! flux instead of as a freshwater flux.

--- a/ice_ocean_SIS2/OM4_025/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/OM4_025/MOM_parameter_doc.all
@@ -117,6 +117,10 @@ BOUND_SALINITY = True           !   [Boolean] default = False
                                 ! If true, limit salinity to being positive. (The sea-ice
                                 ! model may ask for more salt than is available and
                                 ! drive the salinity negative otherwise.)
+MIN_SALINITY = 0.01             !   [PPT] default = 0.01
+                                ! The minimum value of salinity when BOUND_SALINITY=True.
+                                ! The default is 0.01 for backward compatibility but ideally
+                                ! should be 0.
 C_P = 3992.0                    !   [J kg-1 K-1] default = 3991.86795711963
                                 ! The heat capacity of sea water, approximated as a
                                 ! constant. This is only used if ENABLE_THERMODYNAMICS is
@@ -197,7 +201,7 @@ RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -428,15 +432,15 @@ REGRIDDING_COORDINATE_MODE = "HYCOM1" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
-                                ! Units of the regridding coordinuate.
+                                ! Units of the regridding coordinate.
 INTERPOLATION_SCHEME = "P1M_H2" ! default = "P1M_H2"
                                 ! This sets the interpolation scheme to use to
                                 ! determine the new grid. These parameters are
@@ -481,10 +485,10 @@ ALE_COORDINATE_CONFIG = "HYBRID:hycom1_75_800m.nc,sigma2,FNC1:2,4000,4.5,.01" ! 
                                 ! thicknesses (in m). In sigma-coordinate mode, the list
                                 ! is of non-dimensional fractions of the water column.
 !TARGET_DENSITIES = 1010.0, 1014.3034, 1017.8088, 1020.843, 1023.5566, 1025.813, 1027.0275, 1027.9114, 1028.6422, 1029.2795, 1029.852, 1030.3762, 1030.8626, 1031.3183, 1031.7486, 1032.1572, 1032.5471, 1032.9207, 1033.2798, 1033.6261, 1033.9608, 1034.2519, 1034.4817, 1034.6774, 1034.8508, 1035.0082, 1035.1533, 1035.2886, 1035.4159, 1035.5364, 1035.6511, 1035.7608, 1035.8661, 1035.9675, 1036.0645, 1036.1554, 1036.2411, 1036.3223, 1036.3998, 1036.4739, 1036.5451, 1036.6137, 1036.68, 1036.7441, 1036.8062, 1036.8526, 1036.8874, 1036.9164, 1036.9418, 1036.9647, 1036.9857, 1037.0052, 1037.0236, 1037.0409, 1037.0574, 1037.0738, 1037.0902, 1037.1066, 1037.123, 1037.1394, 1037.1558, 1037.1722, 1037.1887, 1037.206, 1037.2241, 1037.2435, 1037.2642, 1037.2866, 1037.3112, 1037.3389, 1037.3713, 1037.4118, 1037.475, 1037.6332, 1037.8104, 1038.0 !   [m]
-                                ! HYBRID target densities for itnerfaces
+                                ! HYBRID target densities for interfaces
 REGRID_COMPRESSIBILITY_FRACTION = 0.01 !   [not defined] default = 0.0
                                 ! When interpolating potential density profiles we can add
-                                ! some artificial compressibility solely to make homogenous
+                                ! some artificial compressibility solely to make homogeneous
                                 ! regions appear stratified.
 MIN_THICKNESS = 0.001           !   [m] default = 0.001
                                 ! When regridding, this is the minimum layer
@@ -523,7 +527,7 @@ REMAPPING_SCHEME = "PPM_H4"     ! default = "PLM"
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
                                 ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicty or an inconsistency is
+                                ! consistency and if non-monotonicity or an inconsistency is
                                 ! detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
                                 ! If true, the results of remapping are checked for
@@ -552,15 +556,15 @@ REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
-                                ! REGRID_FILTER_SHALLOW_DEPTH the filter wieghts adopt a cubic profile.
+                                ! REGRID_FILTER_SHALLOW_DEPTH the filter weights adopt a cubic profile.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
@@ -619,7 +623,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
@@ -642,7 +646,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -682,7 +686,7 @@ USE_MEKE = True                 !   [Boolean] default = False
                                 ! If true, turns on the MEKE scheme which calculates
                                 ! a sub-grid mesoscale eddy kinetic energy budget.
 MEKE_DAMPING = 0.0              !   [s-1] default = 0.0
-                                ! The local depth-indepented MEKE dissipation rate.
+                                ! The local depth-independent MEKE dissipation rate.
 MEKE_CD_SCALE = 0.0             !   [nondim] default = 0.0
                                 ! The ratio of the bottom eddy velocity to the column mean
                                 ! eddy velocity, i.e. sqrt(2*MEKE). This should be less than 1
@@ -746,34 +750,34 @@ MEKE_VISCOSITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! represent backscatter from the unresolved eddies.
 MEKE_FIXED_MIXING_LENGTH = 0.0  !   [m] default = 0.0
                                 ! If positive, is a fixed length contribution to the expression
-                                ! for mixing length used in MEKE-derived diffusiviity.
+                                ! for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_DEFORM = 0.0         !   [nondim] default = 0.0
                                 ! If positive, is a coefficient weighting the deformation scale
-                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+                                ! in the expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_RHINES = 0.15        !   [nondim] default = 0.05
                                 ! If positive, is a coefficient weighting the Rhines scale
-                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+                                ! in the expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_EADY = 0.15          !   [nondim] default = 0.05
                                 ! If positive, is a coefficient weighting the Eady length scale
-                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+                                ! in the expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_FRICT = 0.0          !   [nondim] default = 0.0
                                 ! If positive, is a coefficient weighting the frictional arrest scale
-                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+                                ! in the expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_GRID = 0.0           !   [nondim] default = 0.0
                                 ! If positive, is a coefficient weighting the grid-spacing as a scale
-                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+                                ! in the expression for mixing length used in MEKE-derived diffusivity.
 MEKE_COLD_START = False         !   [Boolean] default = False
                                 ! If true, initialize EKE to zero. Otherwise a local equilibrium solution
                                 ! is used as an initial condition for EKE.
 MEKE_BACKSCAT_RO_C = 0.0        !   [nondim] default = 0.0
-                                ! The coefficient in the Rossby number function for scaling the buharmonic
+                                ! The coefficient in the Rossby number function for scaling the biharmonic
                                 ! frictional energy source. Setting to non-zero enables the Rossby number function.
 MEKE_BACKSCAT_RO_POW = 0.0      !   [nondim] default = 0.0
-                                ! The power in the Rossby number function for scaling the biharmomnic
+                                ! The power in the Rossby number function for scaling the biharmonic
                                 ! frictional energy source.
 MEKE_ADVECTION_FACTOR = 0.0     !   [nondim] default = 0.0
                                 ! A scale factor in front of advection of eddy energy. Zero turns advection off.
-                                ! Using unity would be normal but other values could accomodate a mismatch
+                                ! Using unity would be normal but other values could accommodate a mismatch
                                 ! between the advecting barotropic flow and the vertical structure of MEKE.
 MEKE_TOPOGRAPHIC_BETA = 0.0     !   [nondim] default = 0.0
                                 ! A scale factor to determine how much topographic beta is weighed in
@@ -865,7 +869,8 @@ GILL_EQUATORIAL_LD = True       !   [Boolean] default = False
                                 ! If true, uses Gill's definition of the baroclinic
                                 ! equatorial deformation radius, otherwise, if false, use
                                 ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 infront of the beta term in the denominator. Gill'sis the more appropriate definition.
+                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
@@ -882,8 +887,8 @@ LINEAR_DRAG = False             !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.25             !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -925,7 +930,7 @@ KV = 1.0E-04                    !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -979,7 +984,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -1106,7 +1111,7 @@ KH_VEL_SCALE = 0.0              !   [m s-1] default = 0.0
                                 ! The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latidutinally-dependent background
+                                ! The amplitude of a latitudinally-dependent background
                                 ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
@@ -1208,7 +1213,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -1233,7 +1238,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
                                 ! If true, and BOUND_BT_CORRECTION is true, use the
                                 ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocites
+                                ! MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
                                 ! If true, adjust the curve fit to the BT_cont type
@@ -1261,7 +1266,7 @@ NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
                                 ! USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -1308,7 +1313,7 @@ BT_STRONG_DRAG = False          !   [Boolean] default = False
                                 ! barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
                                 ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _vdivided by the depth of
+                                ! using rates set by lin_drag_u & _v divided by the depth of
                                 ! the ocean.  This was introduced to facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
                                 ! If true, limit any velocity components that exceed
@@ -1364,7 +1369,7 @@ KHTH_MAX_CFL = 0.1              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1488,6 +1493,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1512,7 +1520,7 @@ INT_TIDE_PROFILE = "POLZIN_09"  ! default = "STLAURENT_02"
                                 ! dissipation with INT_TIDE_DISSIPATION. Valid values are:
                                 !    STLAURENT_02 - Use the St. Laurent et al exponential
                                 !                   decay profile.
-                                !    POLZIN_09 - Use the Polzin WKB-streched algebraic
+                                !    POLZIN_09 - Use the Polzin WKB-stretched algebraic
                                 !                   decay profile.
 LEE_WAVE_DISSIPATION = False    !   [Boolean] default = False
                                 ! If true, use an lee wave driven dissipation scheme to
@@ -1531,7 +1539,7 @@ NU_POLZIN = 0.0697              !   [nondim] default = 0.0697
                                 ! vertical scale of decay for the tidal energy dissipation.
 NBOTREF_POLZIN = 9.61E-04       !   [s-1] default = 9.61E-04
                                 ! When the Polzin decay profile is used, this is the
-                                ! Rreference value of the buoyancy frequency at the ocean
+                                ! reference value of the buoyancy frequency at the ocean
                                 ! bottom in the Polzin formulation for the vertical
                                 ! scale of decay for the tidal energy dissipation.
 POLZIN_DECAY_SCALE_FACTOR = 1.0 !   [nondim] default = 1.0
@@ -1566,9 +1574,10 @@ KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
 UTIDE = 0.0                     !   [m s-1] default = 0.0
                                 ! The constant tidal amplitude used with INT_TIDE_DISSIPATION.
 KAPPA_H2_FACTOR = 0.84          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with nINT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with
+                                ! INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source availble to mix
+                                ! The maximum internal tide energy source available to mix
                                 ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
                                 ! If true, read a file (given by TIDEAMP_FILE) containing
@@ -1641,7 +1650,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = True !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1652,7 +1661,8 @@ LOTW_BBL_USE_OMEGA = True       !   [Boolean] default = True
 SIMPLE_TKE_TO_KD = True         !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1809,7 +1819,7 @@ IGNORE_FLUXES_OVER_LAND = False !   [Boolean] default = False
                                 ! be different than the ocean mask to avoid sea ice formation
                                 ! under ice shelves. This flag only works when use_ePBL = True.
 DO_RIVERMIX = False             !   [Boolean] default = False
-                                ! If true, apply additional mixing whereever there is
+                                ! If true, apply additional mixing wherever there is
                                 ! runoff, so that it is mixed down to RIVERMIX_DEPTH
                                 ! if the ocean is that deep.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
@@ -1885,7 +1895,7 @@ EKMAN_SCALE_COEF = 1.0          !   [nondim] default = 1.0
                                 ! decreases the PBL diffusivity.
 USE_MLD_ITERATION = True        !   [Boolean] default = False
                                 ! A logical that specifies whether or not to use the
-                                ! distance to the bottom of the actively turblent boundary
+                                ! distance to the bottom of the actively turbulent boundary
                                 ! layer to help set the EPBL length scale.
 ORIG_MLD_ITERATION = False      !   [Boolean] default = True
                                 ! A logical that specifies whether or not to use the
@@ -2011,12 +2021,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -2116,7 +2126,7 @@ RESTORE_SALINITY = True         !   [Boolean] default = False
                                 ! toward specified values.
 RESTORE_TEMPERATURE = False     !   [Boolean] default = False
                                 ! If true, the coupled driver will add a
-                                ! heat flux that drives sea-surface temperauture
+                                ! heat flux that drives sea-surface temperature
                                 ! toward specified values.
 ADJUST_NET_SRESTORE_TO_ZERO = True !   [Boolean] default = True
                                 ! If true, adjusts the salinity restoring seen to zero
@@ -2209,7 +2219,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_file_parser ===
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False

--- a/ice_ocean_SIS2/OM4_025/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/OM4_025/MOM_parameter_doc.short
@@ -147,7 +147,8 @@ MINIMUM_DEPTH = 9.5             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 MASKING_DEPTH = 0.0             !   [m] default = -9999.0
                                 ! The depth below which to mask points as land points, for which all
                                 ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.

--- a/ice_ocean_SIS2/OM4_025/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/OM4_025/MOM_parameter_doc.short
@@ -209,8 +209,8 @@ REGRIDDING_COORDINATE_MODE = "HYCOM1" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
@@ -244,10 +244,10 @@ ALE_COORDINATE_CONFIG = "HYBRID:hycom1_75_800m.nc,sigma2,FNC1:2,4000,4.5,.01" ! 
                                 ! thicknesses (in m). In sigma-coordinate mode, the list
                                 ! is of non-dimensional fractions of the water column.
 !TARGET_DENSITIES = 1010.0, 1014.3034, 1017.8088, 1020.843, 1023.5566, 1025.813, 1027.0275, 1027.9114, 1028.6422, 1029.2795, 1029.852, 1030.3762, 1030.8626, 1031.3183, 1031.7486, 1032.1572, 1032.5471, 1032.9207, 1033.2798, 1033.6261, 1033.9608, 1034.2519, 1034.4817, 1034.6774, 1034.8508, 1035.0082, 1035.1533, 1035.2886, 1035.4159, 1035.5364, 1035.6511, 1035.7608, 1035.8661, 1035.9675, 1036.0645, 1036.1554, 1036.2411, 1036.3223, 1036.3998, 1036.4739, 1036.5451, 1036.6137, 1036.68, 1036.7441, 1036.8062, 1036.8526, 1036.8874, 1036.9164, 1036.9418, 1036.9647, 1036.9857, 1037.0052, 1037.0236, 1037.0409, 1037.0574, 1037.0738, 1037.0902, 1037.1066, 1037.123, 1037.1394, 1037.1558, 1037.1722, 1037.1887, 1037.206, 1037.2241, 1037.2435, 1037.2642, 1037.2866, 1037.3112, 1037.3389, 1037.3713, 1037.4118, 1037.475, 1037.6332, 1037.8104, 1038.0 !   [m]
-                                ! HYBRID target densities for itnerfaces
+                                ! HYBRID target densities for interfaces
 REGRID_COMPRESSIBILITY_FRACTION = 0.01 !   [not defined] default = 0.0
                                 ! When interpolating potential density profiles we can add
-                                ! some artificial compressibility solely to make homogenous
+                                ! some artificial compressibility solely to make homogeneous
                                 ! regions appear stratified.
 MAXIMUM_INT_DEPTH_CONFIG = "FNC1:5,8000.0,1.0,.01" ! default = "NONE"
                                 ! Determines how to specify the maximum interface depths.
@@ -287,8 +287,8 @@ REMAPPING_SCHEME = "PPM_H4"     ! default = "PLM"
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
@@ -351,10 +351,10 @@ MEKE_KHMEKE_FAC = 1.0           !   [nondim] default = 0.0
                                 ! A factor that maps MEKE%Kh to Kh for MEKE itself.
 MEKE_ALPHA_RHINES = 0.15        !   [nondim] default = 0.05
                                 ! If positive, is a coefficient weighting the Rhines scale
-                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+                                ! in the expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_EADY = 0.15          !   [nondim] default = 0.05
                                 ! If positive, is a coefficient weighting the Eady length scale
-                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+                                ! in the expression for mixing length used in MEKE-derived diffusivity.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = True      !   [Boolean] default = False
@@ -387,7 +387,8 @@ GILL_EQUATORIAL_LD = True       !   [Boolean] default = False
                                 ! If true, uses Gill's definition of the baroclinic
                                 ! equatorial deformation radius, otherwise, if false, use
                                 ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 infront of the beta term in the denominator. Gill'sis the more appropriate definition.
+                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 CHANNEL_DRAG = True             !   [Boolean] default = False
@@ -501,7 +502,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
                                 ! less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -604,7 +605,7 @@ INT_TIDE_PROFILE = "POLZIN_09"  ! default = "STLAURENT_02"
                                 ! dissipation with INT_TIDE_DISSIPATION. Valid values are:
                                 !    STLAURENT_02 - Use the St. Laurent et al exponential
                                 !                   decay profile.
-                                !    POLZIN_09 - Use the Polzin WKB-streched algebraic
+                                !    POLZIN_09 - Use the Polzin WKB-stretched algebraic
                                 !                   decay profile.
 INT_TIDE_DECAY_SCALE = 300.3003003003003 !   [m] default = 500.0
                                 ! The decay scale away from the bottom for tidal TKE with
@@ -613,9 +614,10 @@ KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
                                 ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
                                 ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
 KAPPA_H2_FACTOR = 0.84          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with nINT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with
+                                ! INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source availble to mix
+                                ! The maximum internal tide energy source available to mix
                                 ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
                                 ! If true, read a file (given by TIDEAMP_FILE) containing
@@ -648,7 +650,7 @@ GEOTHERMAL_VARNAME = "geothermal_hf" ! default = "geo_heat"
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = True !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -656,7 +658,8 @@ USE_LOTW_BBL_DIFFUSIVITY = True !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = True         !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -735,7 +738,7 @@ ML_OMEGA_FRAC = 0.001           !   [nondim] default = 0.0
                                 ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
 USE_MLD_ITERATION = True        !   [Boolean] default = False
                                 ! A logical that specifies whether or not to use the
-                                ! distance to the bottom of the actively turblent boundary
+                                ! distance to the bottom of the actively turbulent boundary
                                 ! layer to help set the EPBL length scale.
 ORIG_MLD_ITERATION = False      !   [Boolean] default = True
                                 ! A logical that specifies whether or not to use the

--- a/ice_ocean_SIS2/OM4_025/SIS_parameter_doc.all
+++ b/ice_ocean_SIS2/OM4_025/SIS_parameter_doc.all
@@ -455,7 +455,8 @@ STATISTICS_FILE = "seaice.stats" ! default = "seaice.stats"
 ! This module handles sea-ice state diagnostics.
 
 ! === module SIS_fast_thermo ===
-! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.
+! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature
+! calculation.
 REORDER_0C_HEATFLUX = False     !   [Boolean] default = False
                                 ! If true, rearrange the calculation of the heat fluxes
                                 ! projected back to 0C to work on each contribution

--- a/ice_ocean_SIS2/OM4_025/SIS_parameter_doc.short
+++ b/ice_ocean_SIS2/OM4_025/SIS_parameter_doc.short
@@ -124,7 +124,8 @@ MAXTRUNC = 200                  !   [truncations save_interval-1] default = 0
 ! This module handles sea-ice state diagnostics.
 
 ! === module SIS_fast_thermo ===
-! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.
+! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature
+! calculation.
 
 ! === module SIS2_ice_thm (updates) ===
 ! This sub-module does updates of the sea-ice due to thermodynamic changes.

--- a/ice_ocean_SIS2/OM4_05/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/OM4_05/MOM_parameter_doc.all
@@ -267,7 +267,8 @@ MINIMUM_DEPTH = 9.5             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = 0.0             !   [m] default = -9999.0
@@ -771,7 +772,8 @@ MEKE_COLD_START = False         !   [Boolean] default = False
                                 ! is used as an initial condition for EKE.
 MEKE_BACKSCAT_RO_C = 0.0        !   [nondim] default = 0.0
                                 ! The coefficient in the Rossby number function for scaling the biharmonic
-                                ! frictional energy source. Setting to non-zero enables the Rossby number function.
+                                ! frictional energy source. Setting to non-zero enables the Rossby number
+                                ! function.
 MEKE_BACKSCAT_RO_POW = 0.0      !   [nondim] default = 0.0
                                 ! The power in the Rossby number function for scaling the biharmonic
                                 ! frictional energy source.
@@ -1092,7 +1094,8 @@ RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -1186,7 +1189,8 @@ HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
                                 ! stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
@@ -1482,7 +1486,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of
@@ -2200,7 +2205,8 @@ FLUXCONST = 0.1667              !   [m day-1]
 SALT_RESTORE_FILE = "salt_restore_PHC2.720x576.v20180405.nc" ! default = "salt_restore.nc"
                                 ! A file in which to find the surface salinity to use for restoring.
 SALT_RESTORE_VARIABLE = "salt"  ! default = "salt"
-                                ! The name of the surface salinity variable to read from SALT_RESTORE_FILE for restoring salinity.
+                                ! The name of the surface salinity variable to read from SALT_RESTORE_FILE for
+                                ! restoring salinity.
 SRESTORE_AS_SFLUX = True        !   [Boolean] default = False
                                 ! If true, the restoring of salinity is applied as a salt
                                 ! flux instead of as a freshwater flux.

--- a/ice_ocean_SIS2/OM4_05/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/OM4_05/MOM_parameter_doc.all
@@ -117,6 +117,10 @@ BOUND_SALINITY = True           !   [Boolean] default = False
                                 ! If true, limit salinity to being positive. (The sea-ice
                                 ! model may ask for more salt than is available and
                                 ! drive the salinity negative otherwise.)
+MIN_SALINITY = 0.01             !   [PPT] default = 0.01
+                                ! The minimum value of salinity when BOUND_SALINITY=True.
+                                ! The default is 0.01 for backward compatibility but ideally
+                                ! should be 0.
 C_P = 3992.0                    !   [J kg-1 K-1] default = 3991.86795711963
                                 ! The heat capacity of sea water, approximated as a
                                 ! constant. This is only used if ENABLE_THERMODYNAMICS is
@@ -197,7 +201,7 @@ RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -428,15 +432,15 @@ REGRIDDING_COORDINATE_MODE = "HYCOM1" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
-                                ! Units of the regridding coordinuate.
+                                ! Units of the regridding coordinate.
 INTERPOLATION_SCHEME = "P1M_H2" ! default = "P1M_H2"
                                 ! This sets the interpolation scheme to use to
                                 ! determine the new grid. These parameters are
@@ -481,10 +485,10 @@ ALE_COORDINATE_CONFIG = "HYBRID:hycom1_75_800m.nc,sigma2,FNC1:2,4000,4.5,.01" ! 
                                 ! thicknesses (in m). In sigma-coordinate mode, the list
                                 ! is of non-dimensional fractions of the water column.
 !TARGET_DENSITIES = 1010.0, 1014.3034, 1017.8088, 1020.843, 1023.5566, 1025.813, 1027.0275, 1027.9114, 1028.6422, 1029.2795, 1029.852, 1030.3762, 1030.8626, 1031.3183, 1031.7486, 1032.1572, 1032.5471, 1032.9207, 1033.2798, 1033.6261, 1033.9608, 1034.2519, 1034.4817, 1034.6774, 1034.8508, 1035.0082, 1035.1533, 1035.2886, 1035.4159, 1035.5364, 1035.6511, 1035.7608, 1035.8661, 1035.9675, 1036.0645, 1036.1554, 1036.2411, 1036.3223, 1036.3998, 1036.4739, 1036.5451, 1036.6137, 1036.68, 1036.7441, 1036.8062, 1036.8526, 1036.8874, 1036.9164, 1036.9418, 1036.9647, 1036.9857, 1037.0052, 1037.0236, 1037.0409, 1037.0574, 1037.0738, 1037.0902, 1037.1066, 1037.123, 1037.1394, 1037.1558, 1037.1722, 1037.1887, 1037.206, 1037.2241, 1037.2435, 1037.2642, 1037.2866, 1037.3112, 1037.3389, 1037.3713, 1037.4118, 1037.475, 1037.6332, 1037.8104, 1038.0 !   [m]
-                                ! HYBRID target densities for itnerfaces
+                                ! HYBRID target densities for interfaces
 REGRID_COMPRESSIBILITY_FRACTION = 0.01 !   [not defined] default = 0.0
                                 ! When interpolating potential density profiles we can add
-                                ! some artificial compressibility solely to make homogenous
+                                ! some artificial compressibility solely to make homogeneous
                                 ! regions appear stratified.
 MIN_THICKNESS = 0.001           !   [m] default = 0.001
                                 ! When regridding, this is the minimum layer
@@ -523,7 +527,7 @@ REMAPPING_SCHEME = "PPM_H4"     ! default = "PLM"
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
                                 ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicty or an inconsistency is
+                                ! consistency and if non-monotonicity or an inconsistency is
                                 ! detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
                                 ! If true, the results of remapping are checked for
@@ -552,15 +556,15 @@ REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
-                                ! REGRID_FILTER_SHALLOW_DEPTH the filter wieghts adopt a cubic profile.
+                                ! REGRID_FILTER_SHALLOW_DEPTH the filter weights adopt a cubic profile.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
@@ -619,7 +623,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
@@ -642,7 +646,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -682,7 +686,7 @@ USE_MEKE = True                 !   [Boolean] default = False
                                 ! If true, turns on the MEKE scheme which calculates
                                 ! a sub-grid mesoscale eddy kinetic energy budget.
 MEKE_DAMPING = 0.0              !   [s-1] default = 0.0
-                                ! The local depth-indepented MEKE dissipation rate.
+                                ! The local depth-independent MEKE dissipation rate.
 MEKE_CD_SCALE = 0.0             !   [nondim] default = 0.0
                                 ! The ratio of the bottom eddy velocity to the column mean
                                 ! eddy velocity, i.e. sqrt(2*MEKE). This should be less than 1
@@ -746,34 +750,34 @@ MEKE_VISCOSITY_COEFF = 1.0      !   [nondim] default = 0.0
                                 ! represent backscatter from the unresolved eddies.
 MEKE_FIXED_MIXING_LENGTH = 0.0  !   [m] default = 0.0
                                 ! If positive, is a fixed length contribution to the expression
-                                ! for mixing length used in MEKE-derived diffusiviity.
+                                ! for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_DEFORM = 0.0         !   [nondim] default = 0.0
                                 ! If positive, is a coefficient weighting the deformation scale
-                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+                                ! in the expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_RHINES = 0.15        !   [nondim] default = 0.05
                                 ! If positive, is a coefficient weighting the Rhines scale
-                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+                                ! in the expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_EADY = 0.15          !   [nondim] default = 0.05
                                 ! If positive, is a coefficient weighting the Eady length scale
-                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+                                ! in the expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_FRICT = 0.0          !   [nondim] default = 0.0
                                 ! If positive, is a coefficient weighting the frictional arrest scale
-                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+                                ! in the expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_GRID = 0.0           !   [nondim] default = 0.0
                                 ! If positive, is a coefficient weighting the grid-spacing as a scale
-                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+                                ! in the expression for mixing length used in MEKE-derived diffusivity.
 MEKE_COLD_START = False         !   [Boolean] default = False
                                 ! If true, initialize EKE to zero. Otherwise a local equilibrium solution
                                 ! is used as an initial condition for EKE.
 MEKE_BACKSCAT_RO_C = 0.0        !   [nondim] default = 0.0
-                                ! The coefficient in the Rossby number function for scaling the buharmonic
+                                ! The coefficient in the Rossby number function for scaling the biharmonic
                                 ! frictional energy source. Setting to non-zero enables the Rossby number function.
 MEKE_BACKSCAT_RO_POW = 0.0      !   [nondim] default = 0.0
-                                ! The power in the Rossby number function for scaling the biharmomnic
+                                ! The power in the Rossby number function for scaling the biharmonic
                                 ! frictional energy source.
 MEKE_ADVECTION_FACTOR = 0.0     !   [nondim] default = 0.0
                                 ! A scale factor in front of advection of eddy energy. Zero turns advection off.
-                                ! Using unity would be normal but other values could accomodate a mismatch
+                                ! Using unity would be normal but other values could accommodate a mismatch
                                 ! between the advecting barotropic flow and the vertical structure of MEKE.
 MEKE_TOPOGRAPHIC_BETA = 0.0     !   [nondim] default = 0.0
                                 ! A scale factor to determine how much topographic beta is weighed in
@@ -868,7 +872,8 @@ GILL_EQUATORIAL_LD = True       !   [Boolean] default = False
                                 ! If true, uses Gill's definition of the baroclinic
                                 ! equatorial deformation radius, otherwise, if false, use
                                 ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 infront of the beta term in the denominator. Gill'sis the more appropriate definition.
+                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
@@ -885,8 +890,8 @@ LINEAR_DRAG = False             !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.25             !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -928,7 +933,7 @@ KV = 1.0E-04                    !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -982,7 +987,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -1109,10 +1114,10 @@ KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
                                 ! The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 2000.0             !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latidutinally-dependent background
+                                ! The amplitude of a latitudinally-dependent background
                                 ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 KH_PWR_OF_SINE = 4.0            !   [nondim] default = 4.0
-                                ! The power used to raise SIN(LAT) when using a latidutinally-
+                                ! The power used to raise SIN(LAT) when using a latitudinally-
                                 ! dependent background viscosity.
 SMAGORINSKY_KH = True           !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
@@ -1217,7 +1222,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -1242,7 +1247,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
                                 ! If true, and BOUND_BT_CORRECTION is true, use the
                                 ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocites
+                                ! MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
                                 ! If true, adjust the curve fit to the BT_cont type
@@ -1270,7 +1275,7 @@ NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
                                 ! USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -1317,7 +1322,7 @@ BT_STRONG_DRAG = False          !   [Boolean] default = False
                                 ! barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
                                 ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _vdivided by the depth of
+                                ! using rates set by lin_drag_u & _v divided by the depth of
                                 ! the ocean.  This was introduced to facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
                                 ! If true, limit any velocity components that exceed
@@ -1373,7 +1378,7 @@ KHTH_MAX_CFL = 0.1              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1507,6 +1512,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1531,7 +1539,7 @@ INT_TIDE_PROFILE = "POLZIN_09"  ! default = "STLAURENT_02"
                                 ! dissipation with INT_TIDE_DISSIPATION. Valid values are:
                                 !    STLAURENT_02 - Use the St. Laurent et al exponential
                                 !                   decay profile.
-                                !    POLZIN_09 - Use the Polzin WKB-streched algebraic
+                                !    POLZIN_09 - Use the Polzin WKB-stretched algebraic
                                 !                   decay profile.
 LEE_WAVE_DISSIPATION = False    !   [Boolean] default = False
                                 ! If true, use an lee wave driven dissipation scheme to
@@ -1550,7 +1558,7 @@ NU_POLZIN = 0.0697              !   [nondim] default = 0.0697
                                 ! vertical scale of decay for the tidal energy dissipation.
 NBOTREF_POLZIN = 9.61E-04       !   [s-1] default = 9.61E-04
                                 ! When the Polzin decay profile is used, this is the
-                                ! Rreference value of the buoyancy frequency at the ocean
+                                ! reference value of the buoyancy frequency at the ocean
                                 ! bottom in the Polzin formulation for the vertical
                                 ! scale of decay for the tidal energy dissipation.
 POLZIN_DECAY_SCALE_FACTOR = 1.0 !   [nondim] default = 1.0
@@ -1585,9 +1593,10 @@ KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
 UTIDE = 0.0                     !   [m s-1] default = 0.0
                                 ! The constant tidal amplitude used with INT_TIDE_DISSIPATION.
 KAPPA_H2_FACTOR = 0.84          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with nINT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with
+                                ! INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source availble to mix
+                                ! The maximum internal tide energy source available to mix
                                 ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
                                 ! If true, read a file (given by TIDEAMP_FILE) containing
@@ -1660,7 +1669,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = True !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1671,7 +1680,8 @@ LOTW_BBL_USE_OMEGA = True       !   [Boolean] default = True
 SIMPLE_TKE_TO_KD = True         !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1828,7 +1838,7 @@ IGNORE_FLUXES_OVER_LAND = False !   [Boolean] default = False
                                 ! be different than the ocean mask to avoid sea ice formation
                                 ! under ice shelves. This flag only works when use_ePBL = True.
 DO_RIVERMIX = False             !   [Boolean] default = False
-                                ! If true, apply additional mixing whereever there is
+                                ! If true, apply additional mixing wherever there is
                                 ! runoff, so that it is mixed down to RIVERMIX_DEPTH
                                 ! if the ocean is that deep.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
@@ -1904,7 +1914,7 @@ EKMAN_SCALE_COEF = 1.0          !   [nondim] default = 1.0
                                 ! decreases the PBL diffusivity.
 USE_MLD_ITERATION = True        !   [Boolean] default = False
                                 ! A logical that specifies whether or not to use the
-                                ! distance to the bottom of the actively turblent boundary
+                                ! distance to the bottom of the actively turbulent boundary
                                 ! layer to help set the EPBL length scale.
 ORIG_MLD_ITERATION = False      !   [Boolean] default = True
                                 ! A logical that specifies whether or not to use the
@@ -2030,12 +2040,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -2145,7 +2155,7 @@ RESTORE_SALINITY = True         !   [Boolean] default = False
                                 ! toward specified values.
 RESTORE_TEMPERATURE = False     !   [Boolean] default = False
                                 ! If true, the coupled driver will add a
-                                ! heat flux that drives sea-surface temperauture
+                                ! heat flux that drives sea-surface temperature
                                 ! toward specified values.
 ADJUST_NET_SRESTORE_TO_ZERO = True !   [Boolean] default = True
                                 ! If true, adjusts the salinity restoring seen to zero
@@ -2238,7 +2248,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_file_parser ===
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False

--- a/ice_ocean_SIS2/OM4_05/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/OM4_05/MOM_parameter_doc.short
@@ -202,8 +202,8 @@ REGRIDDING_COORDINATE_MODE = "HYCOM1" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
@@ -237,10 +237,10 @@ ALE_COORDINATE_CONFIG = "HYBRID:hycom1_75_800m.nc,sigma2,FNC1:2,4000,4.5,.01" ! 
                                 ! thicknesses (in m). In sigma-coordinate mode, the list
                                 ! is of non-dimensional fractions of the water column.
 !TARGET_DENSITIES = 1010.0, 1014.3034, 1017.8088, 1020.843, 1023.5566, 1025.813, 1027.0275, 1027.9114, 1028.6422, 1029.2795, 1029.852, 1030.3762, 1030.8626, 1031.3183, 1031.7486, 1032.1572, 1032.5471, 1032.9207, 1033.2798, 1033.6261, 1033.9608, 1034.2519, 1034.4817, 1034.6774, 1034.8508, 1035.0082, 1035.1533, 1035.2886, 1035.4159, 1035.5364, 1035.6511, 1035.7608, 1035.8661, 1035.9675, 1036.0645, 1036.1554, 1036.2411, 1036.3223, 1036.3998, 1036.4739, 1036.5451, 1036.6137, 1036.68, 1036.7441, 1036.8062, 1036.8526, 1036.8874, 1036.9164, 1036.9418, 1036.9647, 1036.9857, 1037.0052, 1037.0236, 1037.0409, 1037.0574, 1037.0738, 1037.0902, 1037.1066, 1037.123, 1037.1394, 1037.1558, 1037.1722, 1037.1887, 1037.206, 1037.2241, 1037.2435, 1037.2642, 1037.2866, 1037.3112, 1037.3389, 1037.3713, 1037.4118, 1037.475, 1037.6332, 1037.8104, 1038.0 !   [m]
-                                ! HYBRID target densities for itnerfaces
+                                ! HYBRID target densities for interfaces
 REGRID_COMPRESSIBILITY_FRACTION = 0.01 !   [not defined] default = 0.0
                                 ! When interpolating potential density profiles we can add
-                                ! some artificial compressibility solely to make homogenous
+                                ! some artificial compressibility solely to make homogeneous
                                 ! regions appear stratified.
 MAXIMUM_INT_DEPTH_CONFIG = "FNC1:5,8000.0,1.0,.01" ! default = "NONE"
                                 ! Determines how to specify the maximum interface depths.
@@ -280,8 +280,8 @@ REMAPPING_SCHEME = "PPM_H4"     ! default = "PLM"
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
@@ -353,10 +353,10 @@ MEKE_VISCOSITY_COEFF = 1.0      !   [nondim] default = 0.0
                                 ! represent backscatter from the unresolved eddies.
 MEKE_ALPHA_RHINES = 0.15        !   [nondim] default = 0.05
                                 ! If positive, is a coefficient weighting the Rhines scale
-                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+                                ! in the expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_EADY = 0.15          !   [nondim] default = 0.05
                                 ! If positive, is a coefficient weighting the Eady length scale
-                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+                                ! in the expression for mixing length used in MEKE-derived diffusivity.
 
 ! === module MOM_lateral_mixing_coeffs ===
 USE_VARIABLE_MIXING = True      !   [Boolean] default = False
@@ -397,7 +397,8 @@ GILL_EQUATORIAL_LD = True       !   [Boolean] default = False
                                 ! If true, uses Gill's definition of the baroclinic
                                 ! equatorial deformation radius, otherwise, if false, use
                                 ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 infront of the beta term in the denominator. Gill'sis the more appropriate definition.
+                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 CHANNEL_DRAG = True             !   [Boolean] default = False
@@ -487,7 +488,7 @@ KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
                                 ! The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 2000.0             !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latidutinally-dependent background
+                                ! The amplitude of a latitudinally-dependent background
                                 ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = True           !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
@@ -524,7 +525,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
                                 ! less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -634,7 +635,7 @@ INT_TIDE_PROFILE = "POLZIN_09"  ! default = "STLAURENT_02"
                                 ! dissipation with INT_TIDE_DISSIPATION. Valid values are:
                                 !    STLAURENT_02 - Use the St. Laurent et al exponential
                                 !                   decay profile.
-                                !    POLZIN_09 - Use the Polzin WKB-streched algebraic
+                                !    POLZIN_09 - Use the Polzin WKB-stretched algebraic
                                 !                   decay profile.
 INT_TIDE_DECAY_SCALE = 300.3003003003003 !   [m] default = 500.0
                                 ! The decay scale away from the bottom for tidal TKE with
@@ -643,9 +644,10 @@ KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
                                 ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
                                 ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
 KAPPA_H2_FACTOR = 0.84          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with nINT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with
+                                ! INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source availble to mix
+                                ! The maximum internal tide energy source available to mix
                                 ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
                                 ! If true, read a file (given by TIDEAMP_FILE) containing
@@ -678,7 +680,7 @@ GEOTHERMAL_VARNAME = "geothermal_hf" ! default = "geo_heat"
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = True !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -686,7 +688,8 @@ USE_LOTW_BBL_DIFFUSIVITY = True !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = True         !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -765,7 +768,7 @@ ML_OMEGA_FRAC = 0.001           !   [nondim] default = 0.0
                                 ! local value of f, as sqrt((1-of)*f^2 + of*4*omega^2).
 USE_MLD_ITERATION = True        !   [Boolean] default = False
                                 ! A logical that specifies whether or not to use the
-                                ! distance to the bottom of the actively turblent boundary
+                                ! distance to the bottom of the actively turbulent boundary
                                 ! layer to help set the EPBL length scale.
 ORIG_MLD_ITERATION = False      !   [Boolean] default = True
                                 ! A logical that specifies whether or not to use the

--- a/ice_ocean_SIS2/OM4_05/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/OM4_05/MOM_parameter_doc.short
@@ -140,7 +140,8 @@ MINIMUM_DEPTH = 9.5             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 MASKING_DEPTH = 0.0             !   [m] default = -9999.0
                                 ! The depth below which to mask points as land points, for which all
                                 ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.

--- a/ice_ocean_SIS2/OM4_05/SIS_parameter_doc.all
+++ b/ice_ocean_SIS2/OM4_05/SIS_parameter_doc.all
@@ -451,7 +451,8 @@ STATISTICS_FILE = "seaice.stats" ! default = "seaice.stats"
 ! This module handles sea-ice state diagnostics.
 
 ! === module SIS_fast_thermo ===
-! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.
+! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature
+! calculation.
 REORDER_0C_HEATFLUX = False     !   [Boolean] default = False
                                 ! If true, rearrange the calculation of the heat fluxes
                                 ! projected back to 0C to work on each contribution

--- a/ice_ocean_SIS2/OM4_05/SIS_parameter_doc.short
+++ b/ice_ocean_SIS2/OM4_05/SIS_parameter_doc.short
@@ -133,7 +133,8 @@ SIS_TRACER_ADVECTION_SCHEME = "PPM:H3" ! default = "UPWIND_2D"
 ! This module handles sea-ice state diagnostics.
 
 ! === module SIS_fast_thermo ===
-! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.
+! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature
+! calculation.
 
 ! === module SIS2_ice_thm (updates) ===
 ! This sub-module does updates of the sea-ice due to thermodynamic changes.

--- a/ice_ocean_SIS2/SIS2/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/SIS2/MOM_parameter_doc.all
@@ -250,7 +250,8 @@ MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -906,7 +907,8 @@ RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -994,7 +996,8 @@ HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
                                 ! stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
@@ -1234,7 +1237,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of
@@ -1886,7 +1890,8 @@ FLUXCONST = 0.5                 !   [m day-1]
 SALT_RESTORE_FILE = "salt_restore.nc" ! default = "salt_restore.nc"
                                 ! A file in which to find the surface salinity to use for restoring.
 SALT_RESTORE_VARIABLE = "salt"  ! default = "salt"
-                                ! The name of the surface salinity variable to read from SALT_RESTORE_FILE for restoring salinity.
+                                ! The name of the surface salinity variable to read from SALT_RESTORE_FILE for
+                                ! restoring salinity.
 SRESTORE_AS_SFLUX = False       !   [Boolean] default = False
                                 ! If true, the restoring of salinity is applied as a salt
                                 ! flux instead of as a freshwater flux.

--- a/ice_ocean_SIS2/SIS2/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/SIS2/MOM_parameter_doc.all
@@ -109,6 +109,10 @@ BOUND_SALINITY = True           !   [Boolean] default = False
                                 ! If true, limit salinity to being positive. (The sea-ice
                                 ! model may ask for more salt than is available and
                                 ! drive the salinity negative otherwise.)
+MIN_SALINITY = 0.01             !   [PPT] default = 0.01
+                                ! The minimum value of salinity when BOUND_SALINITY=True.
+                                ! The default is 0.01 for backward compatibility but ideally
+                                ! should be 0.
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
                                 ! The heat capacity of sea water, approximated as a
                                 ! constant. This is only used if ENABLE_THERMODYNAMICS is
@@ -180,7 +184,7 @@ RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -455,8 +459,8 @@ COORD_VAR = "Layer"             ! default = "Layer"
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 THICKNESS_CONFIG = "file"       !
                                 ! A string that determines how the initial layer
@@ -540,7 +544,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 SPONGE = False                  !   [Boolean] default = False
                                 ! If true, sponges may be applied anywhere in the domain.
@@ -559,7 +563,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -663,7 +667,8 @@ GILL_EQUATORIAL_LD = False      !   [Boolean] default = False
                                 ! If true, uses Gill's definition of the baroclinic
                                 ! equatorial deformation radius, otherwise, if false, use
                                 ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 infront of the beta term in the denominator. Gill'sis the more appropriate definition.
+                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
@@ -680,8 +685,8 @@ LINEAR_DRAG = False             !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 0.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -742,7 +747,7 @@ KV = 1.0E-04                    !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -796,7 +801,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -923,7 +928,7 @@ KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
                                 ! The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latidutinally-dependent background
+                                ! The amplitude of a latitudinally-dependent background
                                 ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
@@ -1017,7 +1022,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -1042,7 +1047,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
                                 ! If true, and BOUND_BT_CORRECTION is true, use the
                                 ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocites
+                                ! MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
                                 ! If true, adjust the curve fit to the BT_cont type
@@ -1070,7 +1075,7 @@ NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
                                 ! USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -1105,7 +1110,7 @@ BT_STRONG_DRAG = False          !   [Boolean] default = False
                                 ! barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
                                 ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _vdivided by the depth of
+                                ! using rates set by lin_drag_u & _v divided by the depth of
                                 ! the ocean.  This was introduced to facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
                                 ! If true, limit any velocity components that exceed
@@ -1161,7 +1166,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1259,6 +1264,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1283,7 +1291,7 @@ INT_TIDE_PROFILE = "STLAURENT_02" ! default = "STLAURENT_02"
                                 ! dissipation with INT_TIDE_DISSIPATION. Valid values are:
                                 !    STLAURENT_02 - Use the St. Laurent et al exponential
                                 !                   decay profile.
-                                !    POLZIN_09 - Use the Polzin WKB-streched algebraic
+                                !    POLZIN_09 - Use the Polzin WKB-stretched algebraic
                                 !                   decay profile.
 LEE_WAVE_DISSIPATION = False    !   [Boolean] default = False
                                 ! If true, use an lee wave driven dissipation scheme to
@@ -1315,9 +1323,10 @@ KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
 UTIDE = 0.0                     !   [m s-1] default = 0.0
                                 ! The constant tidal amplitude used with INT_TIDE_DISSIPATION.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with nINT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with
+                                ! INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source availble to mix
+                                ! The maximum internal tide energy source available to mix
                                 ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
                                 ! If true, read a file (given by TIDEAMP_FILE) containing
@@ -1411,7 +1420,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1419,7 +1428,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1641,7 +1651,7 @@ CORRECT_ABSORPTION_DEPTH = True !   [Boolean] default = False
                                 ! heating depth of an exponential profile by moving some
                                 ! of the heating upward in the water column.
 DO_RIVERMIX = True              !   [Boolean] default = False
-                                ! If true, apply additional mixing whereever there is
+                                ! If true, apply additional mixing wherever there is
                                 ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
                                 ! if the ocean is that deep.
 RIVERMIX_DEPTH = 40.0           !   [m] default = 0.0
@@ -1722,12 +1732,12 @@ KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 3.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = True   !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1831,7 +1841,7 @@ RESTORE_SALINITY = True         !   [Boolean] default = False
                                 ! toward specified values.
 RESTORE_TEMPERATURE = False     !   [Boolean] default = False
                                 ! If true, the coupled driver will add a
-                                ! heat flux that drives sea-surface temperauture
+                                ! heat flux that drives sea-surface temperature
                                 ! toward specified values.
 ADJUST_NET_SRESTORE_TO_ZERO = True !   [Boolean] default = True
                                 ! If true, adjusts the salinity restoring seen to zero
@@ -1918,7 +1928,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_file_parser ===
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False

--- a/ice_ocean_SIS2/SIS2/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/SIS2/MOM_parameter_doc.short
@@ -369,7 +369,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
                                 ! less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -442,9 +442,10 @@ KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
                                 ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
                                 ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with nINT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with
+                                ! INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source availble to mix
+                                ! The maximum internal tide energy source available to mix
                                 ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
                                 ! If true, read a file (given by TIDEAMP_FILE) containing
@@ -491,7 +492,7 @@ TKE_DECAY = 10.0                !   [nondim] default = 2.5
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -561,7 +562,7 @@ CORRECT_ABSORPTION_DEPTH = True !   [Boolean] default = False
                                 ! heating depth of an exponential profile by moving some
                                 ! of the heating upward in the water column.
 DO_RIVERMIX = True              !   [Boolean] default = False
-                                ! If true, apply additional mixing whereever there is
+                                ! If true, apply additional mixing wherever there is
                                 ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
                                 ! if the ocean is that deep.
 RIVERMIX_DEPTH = 40.0           !   [m] default = 0.0
@@ -597,8 +598,8 @@ KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 3.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 DIFFUSE_ML_TO_INTERIOR = True   !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface

--- a/ice_ocean_SIS2/SIS2/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/SIS2/MOM_parameter_doc.short
@@ -126,7 +126,8 @@ MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 CHANNEL_CONFIG = "global_1deg"  ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:

--- a/ice_ocean_SIS2/SIS2/SIS_parameter_doc.all
+++ b/ice_ocean_SIS2/SIS2/SIS_parameter_doc.all
@@ -418,7 +418,8 @@ STATISTICS_FILE = "seaice.stats" ! default = "seaice.stats"
 ! This module handles sea-ice state diagnostics.
 
 ! === module SIS_fast_thermo ===
-! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.
+! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature
+! calculation.
 REORDER_0C_HEATFLUX = False     !   [Boolean] default = False
                                 ! If true, rearrange the calculation of the heat fluxes
                                 ! projected back to 0C to work on each contribution

--- a/ice_ocean_SIS2/SIS2/SIS_parameter_doc.short
+++ b/ice_ocean_SIS2/SIS2/SIS_parameter_doc.short
@@ -105,7 +105,8 @@ RECATEGORIZE_ICE = False        !   [Boolean] default = True
 ! This module handles sea-ice state diagnostics.
 
 ! === module SIS_fast_thermo ===
-! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.
+! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature
+! calculation.
 
 ! === module SIS2_ice_thm (updates) ===
 ! This sub-module does updates of the sea-ice due to thermodynamic changes.

--- a/ice_ocean_SIS2/SIS2_bergs_cgrid/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/SIS2_bergs_cgrid/MOM_parameter_doc.all
@@ -250,7 +250,8 @@ MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -906,7 +907,8 @@ RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -994,7 +996,8 @@ HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
                                 ! stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
@@ -1234,7 +1237,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of
@@ -1886,7 +1890,8 @@ FLUXCONST = 0.5                 !   [m day-1]
 SALT_RESTORE_FILE = "salt_restore.nc" ! default = "salt_restore.nc"
                                 ! A file in which to find the surface salinity to use for restoring.
 SALT_RESTORE_VARIABLE = "salt"  ! default = "salt"
-                                ! The name of the surface salinity variable to read from SALT_RESTORE_FILE for restoring salinity.
+                                ! The name of the surface salinity variable to read from SALT_RESTORE_FILE for
+                                ! restoring salinity.
 SRESTORE_AS_SFLUX = False       !   [Boolean] default = False
                                 ! If true, the restoring of salinity is applied as a salt
                                 ! flux instead of as a freshwater flux.

--- a/ice_ocean_SIS2/SIS2_bergs_cgrid/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/SIS2_bergs_cgrid/MOM_parameter_doc.all
@@ -109,6 +109,10 @@ BOUND_SALINITY = True           !   [Boolean] default = False
                                 ! If true, limit salinity to being positive. (The sea-ice
                                 ! model may ask for more salt than is available and
                                 ! drive the salinity negative otherwise.)
+MIN_SALINITY = 0.01             !   [PPT] default = 0.01
+                                ! The minimum value of salinity when BOUND_SALINITY=True.
+                                ! The default is 0.01 for backward compatibility but ideally
+                                ! should be 0.
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
                                 ! The heat capacity of sea water, approximated as a
                                 ! constant. This is only used if ENABLE_THERMODYNAMICS is
@@ -180,7 +184,7 @@ RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -455,8 +459,8 @@ COORD_VAR = "Layer"             ! default = "Layer"
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 THICKNESS_CONFIG = "file"       !
                                 ! A string that determines how the initial layer
@@ -540,7 +544,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 SPONGE = False                  !   [Boolean] default = False
                                 ! If true, sponges may be applied anywhere in the domain.
@@ -559,7 +563,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -663,7 +667,8 @@ GILL_EQUATORIAL_LD = False      !   [Boolean] default = False
                                 ! If true, uses Gill's definition of the baroclinic
                                 ! equatorial deformation radius, otherwise, if false, use
                                 ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 infront of the beta term in the denominator. Gill'sis the more appropriate definition.
+                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
@@ -680,8 +685,8 @@ LINEAR_DRAG = False             !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 0.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -742,7 +747,7 @@ KV = 1.0E-04                    !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -796,7 +801,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -923,7 +928,7 @@ KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
                                 ! The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latidutinally-dependent background
+                                ! The amplitude of a latitudinally-dependent background
                                 ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
@@ -1017,7 +1022,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -1042,7 +1047,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
                                 ! If true, and BOUND_BT_CORRECTION is true, use the
                                 ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocites
+                                ! MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
                                 ! If true, adjust the curve fit to the BT_cont type
@@ -1070,7 +1075,7 @@ NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
                                 ! USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -1105,7 +1110,7 @@ BT_STRONG_DRAG = False          !   [Boolean] default = False
                                 ! barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
                                 ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _vdivided by the depth of
+                                ! using rates set by lin_drag_u & _v divided by the depth of
                                 ! the ocean.  This was introduced to facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
                                 ! If true, limit any velocity components that exceed
@@ -1161,7 +1166,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1259,6 +1264,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1283,7 +1291,7 @@ INT_TIDE_PROFILE = "STLAURENT_02" ! default = "STLAURENT_02"
                                 ! dissipation with INT_TIDE_DISSIPATION. Valid values are:
                                 !    STLAURENT_02 - Use the St. Laurent et al exponential
                                 !                   decay profile.
-                                !    POLZIN_09 - Use the Polzin WKB-streched algebraic
+                                !    POLZIN_09 - Use the Polzin WKB-stretched algebraic
                                 !                   decay profile.
 LEE_WAVE_DISSIPATION = False    !   [Boolean] default = False
                                 ! If true, use an lee wave driven dissipation scheme to
@@ -1315,9 +1323,10 @@ KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
 UTIDE = 0.0                     !   [m s-1] default = 0.0
                                 ! The constant tidal amplitude used with INT_TIDE_DISSIPATION.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with nINT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with
+                                ! INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source availble to mix
+                                ! The maximum internal tide energy source available to mix
                                 ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
                                 ! If true, read a file (given by TIDEAMP_FILE) containing
@@ -1411,7 +1420,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1419,7 +1428,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1641,7 +1651,7 @@ CORRECT_ABSORPTION_DEPTH = True !   [Boolean] default = False
                                 ! heating depth of an exponential profile by moving some
                                 ! of the heating upward in the water column.
 DO_RIVERMIX = True              !   [Boolean] default = False
-                                ! If true, apply additional mixing whereever there is
+                                ! If true, apply additional mixing wherever there is
                                 ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
                                 ! if the ocean is that deep.
 RIVERMIX_DEPTH = 40.0           !   [m] default = 0.0
@@ -1722,12 +1732,12 @@ KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 3.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = True   !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1831,7 +1841,7 @@ RESTORE_SALINITY = True         !   [Boolean] default = False
                                 ! toward specified values.
 RESTORE_TEMPERATURE = False     !   [Boolean] default = False
                                 ! If true, the coupled driver will add a
-                                ! heat flux that drives sea-surface temperauture
+                                ! heat flux that drives sea-surface temperature
                                 ! toward specified values.
 ADJUST_NET_SRESTORE_TO_ZERO = True !   [Boolean] default = True
                                 ! If true, adjusts the salinity restoring seen to zero
@@ -1918,7 +1928,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_file_parser ===
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False

--- a/ice_ocean_SIS2/SIS2_bergs_cgrid/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/SIS2_bergs_cgrid/MOM_parameter_doc.short
@@ -369,7 +369,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
                                 ! less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -442,9 +442,10 @@ KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
                                 ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
                                 ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with nINT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with
+                                ! INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source availble to mix
+                                ! The maximum internal tide energy source available to mix
                                 ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
                                 ! If true, read a file (given by TIDEAMP_FILE) containing
@@ -491,7 +492,7 @@ TKE_DECAY = 10.0                !   [nondim] default = 2.5
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -561,7 +562,7 @@ CORRECT_ABSORPTION_DEPTH = True !   [Boolean] default = False
                                 ! heating depth of an exponential profile by moving some
                                 ! of the heating upward in the water column.
 DO_RIVERMIX = True              !   [Boolean] default = False
-                                ! If true, apply additional mixing whereever there is
+                                ! If true, apply additional mixing wherever there is
                                 ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
                                 ! if the ocean is that deep.
 RIVERMIX_DEPTH = 40.0           !   [m] default = 0.0
@@ -597,8 +598,8 @@ KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 3.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 DIFFUSE_ML_TO_INTERIOR = True   !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface

--- a/ice_ocean_SIS2/SIS2_bergs_cgrid/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/SIS2_bergs_cgrid/MOM_parameter_doc.short
@@ -126,7 +126,8 @@ MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 CHANNEL_CONFIG = "global_1deg"  ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:

--- a/ice_ocean_SIS2/SIS2_bergs_cgrid/SIS_parameter_doc.all
+++ b/ice_ocean_SIS2/SIS2_bergs_cgrid/SIS_parameter_doc.all
@@ -455,7 +455,8 @@ STATISTICS_FILE = "seaice.stats" ! default = "seaice.stats"
 ! This module handles sea-ice state diagnostics.
 
 ! === module SIS_fast_thermo ===
-! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.
+! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature
+! calculation.
 REORDER_0C_HEATFLUX = False     !   [Boolean] default = False
                                 ! If true, rearrange the calculation of the heat fluxes
                                 ! projected back to 0C to work on each contribution

--- a/ice_ocean_SIS2/SIS2_bergs_cgrid/SIS_parameter_doc.short
+++ b/ice_ocean_SIS2/SIS2_bergs_cgrid/SIS_parameter_doc.short
@@ -103,7 +103,8 @@ ICE_TDAMP_ELASTIC = 1000.0      !   [s or nondim] default = -0.2
 ! This module handles sea-ice state diagnostics.
 
 ! === module SIS_fast_thermo ===
-! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.
+! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature
+! calculation.
 
 ! === module SIS2_ice_thm (updates) ===
 ! This sub-module does updates of the sea-ice due to thermodynamic changes.

--- a/ice_ocean_SIS2/SIS2_cgrid/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/SIS2_cgrid/MOM_parameter_doc.all
@@ -250,7 +250,8 @@ MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -906,7 +907,8 @@ RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -994,7 +996,8 @@ HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
                                 ! stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
@@ -1234,7 +1237,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of
@@ -1886,7 +1890,8 @@ FLUXCONST = 0.5                 !   [m day-1]
 SALT_RESTORE_FILE = "salt_restore.nc" ! default = "salt_restore.nc"
                                 ! A file in which to find the surface salinity to use for restoring.
 SALT_RESTORE_VARIABLE = "salt"  ! default = "salt"
-                                ! The name of the surface salinity variable to read from SALT_RESTORE_FILE for restoring salinity.
+                                ! The name of the surface salinity variable to read from SALT_RESTORE_FILE for
+                                ! restoring salinity.
 SRESTORE_AS_SFLUX = False       !   [Boolean] default = False
                                 ! If true, the restoring of salinity is applied as a salt
                                 ! flux instead of as a freshwater flux.

--- a/ice_ocean_SIS2/SIS2_cgrid/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/SIS2_cgrid/MOM_parameter_doc.all
@@ -109,6 +109,10 @@ BOUND_SALINITY = True           !   [Boolean] default = False
                                 ! If true, limit salinity to being positive. (The sea-ice
                                 ! model may ask for more salt than is available and
                                 ! drive the salinity negative otherwise.)
+MIN_SALINITY = 0.01             !   [PPT] default = 0.01
+                                ! The minimum value of salinity when BOUND_SALINITY=True.
+                                ! The default is 0.01 for backward compatibility but ideally
+                                ! should be 0.
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
                                 ! The heat capacity of sea water, approximated as a
                                 ! constant. This is only used if ENABLE_THERMODYNAMICS is
@@ -180,7 +184,7 @@ RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -455,8 +459,8 @@ COORD_VAR = "Layer"             ! default = "Layer"
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 THICKNESS_CONFIG = "file"       !
                                 ! A string that determines how the initial layer
@@ -540,7 +544,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 SPONGE = False                  !   [Boolean] default = False
                                 ! If true, sponges may be applied anywhere in the domain.
@@ -559,7 +563,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -663,7 +667,8 @@ GILL_EQUATORIAL_LD = False      !   [Boolean] default = False
                                 ! If true, uses Gill's definition of the baroclinic
                                 ! equatorial deformation radius, otherwise, if false, use
                                 ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 infront of the beta term in the denominator. Gill'sis the more appropriate definition.
+                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
@@ -680,8 +685,8 @@ LINEAR_DRAG = False             !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 0.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -742,7 +747,7 @@ KV = 1.0E-04                    !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -796,7 +801,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -923,7 +928,7 @@ KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
                                 ! The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latidutinally-dependent background
+                                ! The amplitude of a latitudinally-dependent background
                                 ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
@@ -1017,7 +1022,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -1042,7 +1047,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
                                 ! If true, and BOUND_BT_CORRECTION is true, use the
                                 ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocites
+                                ! MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
                                 ! If true, adjust the curve fit to the BT_cont type
@@ -1070,7 +1075,7 @@ NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
                                 ! USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -1105,7 +1110,7 @@ BT_STRONG_DRAG = False          !   [Boolean] default = False
                                 ! barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
                                 ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _vdivided by the depth of
+                                ! using rates set by lin_drag_u & _v divided by the depth of
                                 ! the ocean.  This was introduced to facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
                                 ! If true, limit any velocity components that exceed
@@ -1161,7 +1166,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1259,6 +1264,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1283,7 +1291,7 @@ INT_TIDE_PROFILE = "STLAURENT_02" ! default = "STLAURENT_02"
                                 ! dissipation with INT_TIDE_DISSIPATION. Valid values are:
                                 !    STLAURENT_02 - Use the St. Laurent et al exponential
                                 !                   decay profile.
-                                !    POLZIN_09 - Use the Polzin WKB-streched algebraic
+                                !    POLZIN_09 - Use the Polzin WKB-stretched algebraic
                                 !                   decay profile.
 LEE_WAVE_DISSIPATION = False    !   [Boolean] default = False
                                 ! If true, use an lee wave driven dissipation scheme to
@@ -1315,9 +1323,10 @@ KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
 UTIDE = 0.0                     !   [m s-1] default = 0.0
                                 ! The constant tidal amplitude used with INT_TIDE_DISSIPATION.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with nINT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with
+                                ! INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source availble to mix
+                                ! The maximum internal tide energy source available to mix
                                 ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
                                 ! If true, read a file (given by TIDEAMP_FILE) containing
@@ -1411,7 +1420,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1419,7 +1428,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1641,7 +1651,7 @@ CORRECT_ABSORPTION_DEPTH = True !   [Boolean] default = False
                                 ! heating depth of an exponential profile by moving some
                                 ! of the heating upward in the water column.
 DO_RIVERMIX = True              !   [Boolean] default = False
-                                ! If true, apply additional mixing whereever there is
+                                ! If true, apply additional mixing wherever there is
                                 ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
                                 ! if the ocean is that deep.
 RIVERMIX_DEPTH = 40.0           !   [m] default = 0.0
@@ -1722,12 +1732,12 @@ KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 3.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = True   !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1831,7 +1841,7 @@ RESTORE_SALINITY = True         !   [Boolean] default = False
                                 ! toward specified values.
 RESTORE_TEMPERATURE = False     !   [Boolean] default = False
                                 ! If true, the coupled driver will add a
-                                ! heat flux that drives sea-surface temperauture
+                                ! heat flux that drives sea-surface temperature
                                 ! toward specified values.
 ADJUST_NET_SRESTORE_TO_ZERO = True !   [Boolean] default = True
                                 ! If true, adjusts the salinity restoring seen to zero
@@ -1918,7 +1928,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_file_parser ===
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False

--- a/ice_ocean_SIS2/SIS2_cgrid/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/SIS2_cgrid/MOM_parameter_doc.short
@@ -369,7 +369,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
                                 ! less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -442,9 +442,10 @@ KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
                                 ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
                                 ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with nINT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with
+                                ! INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source availble to mix
+                                ! The maximum internal tide energy source available to mix
                                 ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
                                 ! If true, read a file (given by TIDEAMP_FILE) containing
@@ -491,7 +492,7 @@ TKE_DECAY = 10.0                !   [nondim] default = 2.5
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -561,7 +562,7 @@ CORRECT_ABSORPTION_DEPTH = True !   [Boolean] default = False
                                 ! heating depth of an exponential profile by moving some
                                 ! of the heating upward in the water column.
 DO_RIVERMIX = True              !   [Boolean] default = False
-                                ! If true, apply additional mixing whereever there is
+                                ! If true, apply additional mixing wherever there is
                                 ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
                                 ! if the ocean is that deep.
 RIVERMIX_DEPTH = 40.0           !   [m] default = 0.0
@@ -597,8 +598,8 @@ KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 3.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 DIFFUSE_ML_TO_INTERIOR = True   !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface

--- a/ice_ocean_SIS2/SIS2_cgrid/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/SIS2_cgrid/MOM_parameter_doc.short
@@ -126,7 +126,8 @@ MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 CHANNEL_CONFIG = "global_1deg"  ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:

--- a/ice_ocean_SIS2/SIS2_cgrid/SIS_parameter_doc.all
+++ b/ice_ocean_SIS2/SIS2_cgrid/SIS_parameter_doc.all
@@ -453,7 +453,8 @@ STATISTICS_FILE = "seaice.stats" ! default = "seaice.stats"
 ! This module handles sea-ice state diagnostics.
 
 ! === module SIS_fast_thermo ===
-! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.
+! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature
+! calculation.
 REORDER_0C_HEATFLUX = False     !   [Boolean] default = False
                                 ! If true, rearrange the calculation of the heat fluxes
                                 ! projected back to 0C to work on each contribution

--- a/ice_ocean_SIS2/SIS2_cgrid/SIS_parameter_doc.short
+++ b/ice_ocean_SIS2/SIS2_cgrid/SIS_parameter_doc.short
@@ -106,7 +106,8 @@ ICE_TDAMP_ELASTIC = 1000.0      !   [s or nondim] default = -0.2
 ! This module handles sea-ice state diagnostics.
 
 ! === module SIS_fast_thermo ===
-! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.
+! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature
+! calculation.
 
 ! === module SIS2_ice_thm (updates) ===
 ! This sub-module does updates of the sea-ice due to thermodynamic changes.

--- a/land_ice_ocean_LM3_SIS2/OM_360x320_C180/MOM_parameter_doc.all
+++ b/land_ice_ocean_LM3_SIS2/OM_360x320_C180/MOM_parameter_doc.all
@@ -117,6 +117,10 @@ BOUND_SALINITY = True           !   [Boolean] default = False
                                 ! If true, limit salinity to being positive. (The sea-ice
                                 ! model may ask for more salt than is available and
                                 ! drive the salinity negative otherwise.)
+MIN_SALINITY = 0.01             !   [PPT] default = 0.01
+                                ! The minimum value of salinity when BOUND_SALINITY=True.
+                                ! The default is 0.01 for backward compatibility but ideally
+                                ! should be 0.
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
                                 ! The heat capacity of sea water, approximated as a
                                 ! constant. This is only used if ENABLE_THERMODYNAMICS is
@@ -197,7 +201,7 @@ RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -416,15 +420,15 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
-                                ! Units of the regridding coordinuate.
+                                ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "FILE:vgrid_75_2m.nc,dz" ! default = "UNIFORM"
                                 ! Determines how to specify the coordinate
                                 ! resolution. Valid options are:
@@ -461,7 +465,7 @@ REMAPPING_SCHEME = "PPM_H4"     ! default = "PLM"
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
                                 ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicty or an inconsistency is
+                                ! consistency and if non-monotonicity or an inconsistency is
                                 ! detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
                                 ! If true, the results of remapping are checked for
@@ -490,15 +494,15 @@ REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
-                                ! REGRID_FILTER_SHALLOW_DEPTH the filter wieghts adopt a cubic profile.
+                                ! REGRID_FILTER_SHALLOW_DEPTH the filter weights adopt a cubic profile.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
@@ -557,7 +561,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
@@ -580,7 +584,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000144" ! default = "available_diags.000144"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -605,7 +609,7 @@ USE_MEKE = True                 !   [Boolean] default = False
                                 ! If true, turns on the MEKE scheme which calculates
                                 ! a sub-grid mesoscale eddy kinetic energy budget.
 MEKE_DAMPING = 0.0              !   [s-1] default = 0.0
-                                ! The local depth-indepented MEKE dissipation rate.
+                                ! The local depth-independent MEKE dissipation rate.
 MEKE_CD_SCALE = 0.0             !   [nondim] default = 0.0
                                 ! The ratio of the bottom eddy velocity to the column mean
                                 ! eddy velocity, i.e. sqrt(2*MEKE). This should be less than 1
@@ -669,34 +673,34 @@ MEKE_VISCOSITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! represent backscatter from the unresolved eddies.
 MEKE_FIXED_MIXING_LENGTH = 0.0  !   [m] default = 0.0
                                 ! If positive, is a fixed length contribution to the expression
-                                ! for mixing length used in MEKE-derived diffusiviity.
+                                ! for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_DEFORM = 0.0         !   [nondim] default = 0.0
                                 ! If positive, is a coefficient weighting the deformation scale
-                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+                                ! in the expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_RHINES = 0.05        !   [nondim] default = 0.05
                                 ! If positive, is a coefficient weighting the Rhines scale
-                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+                                ! in the expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_EADY = 0.05          !   [nondim] default = 0.05
                                 ! If positive, is a coefficient weighting the Eady length scale
-                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+                                ! in the expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_FRICT = 0.0          !   [nondim] default = 0.0
                                 ! If positive, is a coefficient weighting the frictional arrest scale
-                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+                                ! in the expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_GRID = 0.0           !   [nondim] default = 0.0
                                 ! If positive, is a coefficient weighting the grid-spacing as a scale
-                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+                                ! in the expression for mixing length used in MEKE-derived diffusivity.
 MEKE_COLD_START = False         !   [Boolean] default = False
                                 ! If true, initialize EKE to zero. Otherwise a local equilibrium solution
                                 ! is used as an initial condition for EKE.
 MEKE_BACKSCAT_RO_C = 0.0        !   [nondim] default = 0.0
-                                ! The coefficient in the Rossby number function for scaling the buharmonic
+                                ! The coefficient in the Rossby number function for scaling the biharmonic
                                 ! frictional energy source. Setting to non-zero enables the Rossby number function.
 MEKE_BACKSCAT_RO_POW = 0.0      !   [nondim] default = 0.0
-                                ! The power in the Rossby number function for scaling the biharmomnic
+                                ! The power in the Rossby number function for scaling the biharmonic
                                 ! frictional energy source.
 MEKE_ADVECTION_FACTOR = 0.0     !   [nondim] default = 0.0
                                 ! A scale factor in front of advection of eddy energy. Zero turns advection off.
-                                ! Using unity would be normal but other values could accomodate a mismatch
+                                ! Using unity would be normal but other values could accommodate a mismatch
                                 ! between the advecting barotropic flow and the vertical structure of MEKE.
 MEKE_TOPOGRAPHIC_BETA = 0.0     !   [nondim] default = 0.0
                                 ! A scale factor to determine how much topographic beta is weighed in
@@ -788,7 +792,8 @@ GILL_EQUATORIAL_LD = True       !   [Boolean] default = False
                                 ! If true, uses Gill's definition of the baroclinic
                                 ! equatorial deformation radius, otherwise, if false, use
                                 ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 infront of the beta term in the denominator. Gill'sis the more appropriate definition.
+                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
@@ -805,8 +810,8 @@ LINEAR_DRAG = False             !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -848,7 +853,7 @@ KV = 1.0E-04                    !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -902,7 +907,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -1029,7 +1034,7 @@ KH_VEL_SCALE = 0.0              !   [m s-1] default = 0.0
                                 ! The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latidutinally-dependent background
+                                ! The amplitude of a latitudinally-dependent background
                                 ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = True           !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
@@ -1134,7 +1139,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -1159,7 +1164,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
                                 ! If true, and BOUND_BT_CORRECTION is true, use the
                                 ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocites
+                                ! MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
                                 ! If true, adjust the curve fit to the BT_cont type
@@ -1187,7 +1192,7 @@ NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
                                 ! USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -1222,7 +1227,7 @@ BT_STRONG_DRAG = True           !   [Boolean] default = False
                                 ! barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
                                 ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _vdivided by the depth of
+                                ! using rates set by lin_drag_u & _v divided by the depth of
                                 ! the ocean.  This was introduced to facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
                                 ! If true, limit any velocity components that exceed
@@ -1278,7 +1283,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1406,6 +1411,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1430,7 +1438,7 @@ INT_TIDE_PROFILE = "POLZIN_09"  ! default = "STLAURENT_02"
                                 ! dissipation with INT_TIDE_DISSIPATION. Valid values are:
                                 !    STLAURENT_02 - Use the St. Laurent et al exponential
                                 !                   decay profile.
-                                !    POLZIN_09 - Use the Polzin WKB-streched algebraic
+                                !    POLZIN_09 - Use the Polzin WKB-stretched algebraic
                                 !                   decay profile.
 LEE_WAVE_DISSIPATION = False    !   [Boolean] default = False
                                 ! If true, use an lee wave driven dissipation scheme to
@@ -1449,7 +1457,7 @@ NU_POLZIN = 0.0697              !   [nondim] default = 0.0697
                                 ! vertical scale of decay for the tidal energy dissipation.
 NBOTREF_POLZIN = 9.61E-04       !   [s-1] default = 9.61E-04
                                 ! When the Polzin decay profile is used, this is the
-                                ! Rreference value of the buoyancy frequency at the ocean
+                                ! reference value of the buoyancy frequency at the ocean
                                 ! bottom in the Polzin formulation for the vertical
                                 ! scale of decay for the tidal energy dissipation.
 POLZIN_DECAY_SCALE_FACTOR = 1.0 !   [nondim] default = 1.0
@@ -1484,9 +1492,10 @@ KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
 UTIDE = 0.0                     !   [m s-1] default = 0.0
                                 ! The constant tidal amplitude used with INT_TIDE_DISSIPATION.
 KAPPA_H2_FACTOR = 0.84          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with nINT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with
+                                ! INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source availble to mix
+                                ! The maximum internal tide energy source available to mix
                                 ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
                                 ! If true, read a file (given by TIDEAMP_FILE) containing
@@ -1541,7 +1550,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = True !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1552,7 +1561,8 @@ LOTW_BBL_USE_OMEGA = True       !   [Boolean] default = True
 SIMPLE_TKE_TO_KD = True         !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1709,7 +1719,7 @@ IGNORE_FLUXES_OVER_LAND = False !   [Boolean] default = False
                                 ! be different than the ocean mask to avoid sea ice formation
                                 ! under ice shelves. This flag only works when use_ePBL = True.
 DO_RIVERMIX = False             !   [Boolean] default = False
-                                ! If true, apply additional mixing whereever there is
+                                ! If true, apply additional mixing wherever there is
                                 ! runoff, so that it is mixed down to RIVERMIX_DEPTH
                                 ! if the ocean is that deep.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
@@ -1785,7 +1795,7 @@ EKMAN_SCALE_COEF = 1.0          !   [nondim] default = 1.0
                                 ! decreases the PBL diffusivity.
 USE_MLD_ITERATION = False       !   [Boolean] default = False
                                 ! A logical that specifies whether or not to use the
-                                ! distance to the bottom of the actively turblent boundary
+                                ! distance to the bottom of the actively turbulent boundary
                                 ! layer to help set the EPBL length scale.
 ORIG_MLD_ITERATION = True       !   [Boolean] default = True
                                 ! A logical that specifies whether or not to use the
@@ -1887,12 +1897,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1986,7 +1996,7 @@ RESTORE_SALINITY = False        !   [Boolean] default = False
                                 ! toward specified values.
 RESTORE_TEMPERATURE = False     !   [Boolean] default = False
                                 ! If true, the coupled driver will add a
-                                ! heat flux that drives sea-surface temperauture
+                                ! heat flux that drives sea-surface temperature
                                 ! toward specified values.
 ADJUST_NET_SRESTORE_TO_ZERO = False !   [Boolean] default = False
                                 ! If true, adjusts the salinity restoring seen to zero
@@ -2043,7 +2053,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_file_parser ===
 SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False

--- a/land_ice_ocean_LM3_SIS2/OM_360x320_C180/MOM_parameter_doc.all
+++ b/land_ice_ocean_LM3_SIS2/OM_360x320_C180/MOM_parameter_doc.all
@@ -267,7 +267,8 @@ MINIMUM_DEPTH = 9.5             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = 0.0             !   [m] default = -9999.0
@@ -694,7 +695,8 @@ MEKE_COLD_START = False         !   [Boolean] default = False
                                 ! is used as an initial condition for EKE.
 MEKE_BACKSCAT_RO_C = 0.0        !   [nondim] default = 0.0
                                 ! The coefficient in the Rossby number function for scaling the biharmonic
-                                ! frictional energy source. Setting to non-zero enables the Rossby number function.
+                                ! frictional energy source. Setting to non-zero enables the Rossby number
+                                ! function.
 MEKE_BACKSCAT_RO_POW = 0.0      !   [nondim] default = 0.0
                                 ! The power in the Rossby number function for scaling the biharmonic
                                 ! frictional energy source.
@@ -1012,7 +1014,8 @@ RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -1103,7 +1106,8 @@ HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
                                 ! stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
@@ -1381,7 +1385,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of

--- a/land_ice_ocean_LM3_SIS2/OM_360x320_C180/MOM_parameter_doc.short
+++ b/land_ice_ocean_LM3_SIS2/OM_360x320_C180/MOM_parameter_doc.short
@@ -207,8 +207,8 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
@@ -251,8 +251,8 @@ REMAPPING_SCHEME = "PPM_H4"     ! default = "PLM"
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
@@ -315,7 +315,8 @@ GILL_EQUATORIAL_LD = True       !   [Boolean] default = False
                                 ! If true, uses Gill's definition of the baroclinic
                                 ! equatorial deformation radius, otherwise, if false, use
                                 ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 infront of the beta term in the denominator. Gill'sis the more appropriate definition.
+                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 CHANNEL_DRAG = True             !   [Boolean] default = False
@@ -431,7 +432,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
                                 ! less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -508,15 +509,16 @@ INT_TIDE_PROFILE = "POLZIN_09"  ! default = "STLAURENT_02"
                                 ! dissipation with INT_TIDE_DISSIPATION. Valid values are:
                                 !    STLAURENT_02 - Use the St. Laurent et al exponential
                                 !                   decay profile.
-                                !    POLZIN_09 - Use the Polzin WKB-streched algebraic
+                                !    POLZIN_09 - Use the Polzin WKB-stretched algebraic
                                 !                   decay profile.
 KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
                                 ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
                                 ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
 KAPPA_H2_FACTOR = 0.84          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with nINT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with
+                                ! INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source availble to mix
+                                ! The maximum internal tide energy source available to mix
                                 ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
                                 ! If true, read a file (given by TIDEAMP_FILE) containing
@@ -537,7 +539,7 @@ H2_FILE = "topog.nc"            !
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = True !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -545,7 +547,8 @@ USE_LOTW_BBL_DIFFUSIVITY = True !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = True         !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients

--- a/land_ice_ocean_LM3_SIS2/OM_360x320_C180/MOM_parameter_doc.short
+++ b/land_ice_ocean_LM3_SIS2/OM_360x320_C180/MOM_parameter_doc.short
@@ -145,7 +145,8 @@ MINIMUM_DEPTH = 9.5             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 MASKING_DEPTH = 0.0             !   [m] default = -9999.0
                                 ! The depth below which to mask points as land points, for which all
                                 ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.

--- a/land_ice_ocean_LM3_SIS2/OM_360x320_C180/SIS_parameter_doc.all
+++ b/land_ice_ocean_LM3_SIS2/OM_360x320_C180/SIS_parameter_doc.all
@@ -449,7 +449,8 @@ STATISTICS_FILE = "seaice.stats" ! default = "seaice.stats"
 ! This module handles sea-ice state diagnostics.
 
 ! === module SIS_fast_thermo ===
-! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.
+! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature
+! calculation.
 REORDER_0C_HEATFLUX = False     !   [Boolean] default = False
                                 ! If true, rearrange the calculation of the heat fluxes
                                 ! projected back to 0C to work on each contribution

--- a/land_ice_ocean_LM3_SIS2/OM_360x320_C180/SIS_parameter_doc.short
+++ b/land_ice_ocean_LM3_SIS2/OM_360x320_C180/SIS_parameter_doc.short
@@ -103,7 +103,8 @@ ICE_TDAMP_ELASTIC = 1000.0      !   [s or nondim] default = -0.2
 ! This module handles sea-ice state diagnostics.
 
 ! === module SIS_fast_thermo ===
-! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature calculation.
+! This module applies rapidly varying heat fluxes to the ice and does an implicit surface temperature
+! calculation.
 
 ! === module SIS2_ice_thm (updates) ===
 ! This sub-module does updates of the sea-ice due to thermodynamic changes.

--- a/ocean_only/CVmix_SCM_tests/cooling_only/BML/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/BML/MOM_parameter_doc.all
@@ -245,7 +245,8 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -758,7 +759,8 @@ RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -781,7 +783,8 @@ USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
                                 ! for new experiments.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
@@ -900,7 +903,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of

--- a/ocean_only/CVmix_SCM_tests/cooling_only/BML/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/BML/MOM_parameter_doc.all
@@ -176,7 +176,7 @@ RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -394,8 +394,8 @@ COORD_VAR = "Layer"             ! default = "Layer"
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 THICKNESS_CONFIG = "uniform"    !
                                 ! A string that determines how the initial layer
@@ -483,7 +483,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 SPONGE = False                  !   [Boolean] default = False
                                 ! If true, sponges may be applied anywhere in the domain.
@@ -502,7 +502,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -578,8 +578,8 @@ LINEAR_DRAG = False             !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -627,7 +627,7 @@ KV = 0.0                        !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -653,7 +653,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -809,7 +809,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -841,7 +841,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -930,6 +930,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -993,7 +996,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1001,7 +1004,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1227,7 +1231,7 @@ CORRECT_ABSORPTION_DEPTH = False !   [Boolean] default = False
                                 ! heating depth of an exponential profile by moving some
                                 ! of the heating upward in the water column.
 DO_RIVERMIX = False             !   [Boolean] default = False
-                                ! If true, apply additional mixing whereever there is
+                                ! If true, apply additional mixing wherever there is
                                 ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
                                 ! if the ocean is that deep.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
@@ -1289,12 +1293,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1393,7 +1397,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1200.0             !   [s] default = 1200.0

--- a/ocean_only/CVmix_SCM_tests/cooling_only/BML/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/BML/MOM_parameter_doc.short
@@ -97,7 +97,8 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate

--- a/ocean_only/CVmix_SCM_tests/cooling_only/EPBL/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/EPBL/MOM_parameter_doc.all
@@ -178,7 +178,7 @@ RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -393,15 +393,15 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
-                                ! Units of the regridding coordinuate.
+                                ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
                                 ! Determines how to specify the coordinate
                                 ! resolution. Valid options are:
@@ -438,7 +438,7 @@ REMAPPING_SCHEME = "PLM"        ! default = "PLM"
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
                                 ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicty or an inconsistency is
+                                ! consistency and if non-monotonicity or an inconsistency is
                                 ! detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
                                 ! If true, the results of remapping are checked for
@@ -467,15 +467,15 @@ REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
-                                ! REGRID_FILTER_SHALLOW_DEPTH the filter wieghts adopt a cubic profile.
+                                ! REGRID_FILTER_SHALLOW_DEPTH the filter weights adopt a cubic profile.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 THICKNESS_CONFIG = "coord"      !
                                 ! A string that determines how the initial layer
@@ -563,7 +563,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
@@ -586,7 +586,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -662,8 +662,8 @@ LINEAR_DRAG = False             !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -711,7 +711,7 @@ KV = 0.0                        !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -737,7 +737,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -901,7 +901,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -933,7 +933,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1019,6 +1019,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1082,7 +1085,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1090,7 +1093,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1243,7 +1247,7 @@ IGNORE_FLUXES_OVER_LAND = False !   [Boolean] default = False
                                 ! be different than the ocean mask to avoid sea ice formation
                                 ! under ice shelves. This flag only works when use_ePBL = True.
 DO_RIVERMIX = False             !   [Boolean] default = False
-                                ! If true, apply additional mixing whereever there is
+                                ! If true, apply additional mixing wherever there is
                                 ! runoff, so that it is mixed down to RIVERMIX_DEPTH
                                 ! if the ocean is that deep.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
@@ -1319,7 +1323,7 @@ EKMAN_SCALE_COEF = 1.0          !   [nondim] default = 1.0
                                 ! decreases the PBL diffusivity.
 USE_MLD_ITERATION = False       !   [Boolean] default = False
                                 ! A logical that specifies whether or not to use the
-                                ! distance to the bottom of the actively turblent boundary
+                                ! distance to the bottom of the actively turbulent boundary
                                 ! layer to help set the EPBL length scale.
 ORIG_MLD_ITERATION = True       !   [Boolean] default = True
                                 ! A logical that specifies whether or not to use the
@@ -1416,12 +1420,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1520,7 +1524,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1200.0             !   [s] default = 1200.0

--- a/ocean_only/CVmix_SCM_tests/cooling_only/EPBL/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/EPBL/MOM_parameter_doc.all
@@ -247,7 +247,8 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -842,7 +843,8 @@ RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -865,7 +867,8 @@ USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
                                 ! for new experiments.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
@@ -989,7 +992,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of

--- a/ocean_only/CVmix_SCM_tests/cooling_only/EPBL/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/EPBL/MOM_parameter_doc.short
@@ -155,8 +155,8 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate

--- a/ocean_only/CVmix_SCM_tests/cooling_only/EPBL/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/EPBL/MOM_parameter_doc.short
@@ -100,7 +100,8 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate

--- a/ocean_only/CVmix_SCM_tests/cooling_only/KPP/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/KPP/MOM_parameter_doc.all
@@ -178,7 +178,7 @@ RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -393,15 +393,15 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
-                                ! Units of the regridding coordinuate.
+                                ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
                                 ! Determines how to specify the coordinate
                                 ! resolution. Valid options are:
@@ -438,7 +438,7 @@ REMAPPING_SCHEME = "PLM"        ! default = "PLM"
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
                                 ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicty or an inconsistency is
+                                ! consistency and if non-monotonicity or an inconsistency is
                                 ! detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
                                 ! If true, the results of remapping are checked for
@@ -467,15 +467,15 @@ REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
-                                ! REGRID_FILTER_SHALLOW_DEPTH the filter wieghts adopt a cubic profile.
+                                ! REGRID_FILTER_SHALLOW_DEPTH the filter weights adopt a cubic profile.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 THICKNESS_CONFIG = "coord"      !
                                 ! A string that determines how the initial layer
@@ -563,7 +563,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
@@ -586,7 +586,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -662,8 +662,8 @@ LINEAR_DRAG = False             !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -711,7 +711,7 @@ KV = 0.0                        !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -737,7 +737,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -901,7 +901,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -933,7 +933,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1019,6 +1019,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1175,7 +1178,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1183,7 +1186,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1391,12 +1395,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1495,7 +1499,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1200.0             !   [s] default = 1200.0

--- a/ocean_only/CVmix_SCM_tests/cooling_only/KPP/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/KPP/MOM_parameter_doc.all
@@ -247,7 +247,8 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -842,7 +843,8 @@ RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -865,7 +867,8 @@ USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
                                 ! for new experiments.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
@@ -989,7 +992,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of
@@ -1100,21 +1104,25 @@ MATCH_TECHNIQUE = "SimpleShapes" ! default = "SimpleShapes"
                                 ! CVMix method to set profile function for diffusivity and NLT,
                                 ! as well as matching across OBL base. Allowed values are:
                                 !    SimpleShapes      = sigma*(1-sigma)^2 for both diffusivity and NLT
-                                !    MatchGradient     = sigma*(1-sigma)^2 for NLT; diffusivity profile from matching
+                                !    MatchGradient     = sigma*(1-sigma)^2 for NLT; diffusivity profile from
+                                !      matching
                                 !    MatchBoth         = match gradient for both diffusivity and NLT
                                 !    ParabolicNonLocal = sigma*(1-sigma)^2 for diffusivity; (1-sigma)^2 for NLT
 KPP_ZERO_DIFFUSIVITY = False    !   [Boolean] default = False
                                 ! If True, zeroes the KPP diffusivity and viscosity; for testing purpose.
 KPP_IS_ADDITIVE = True          !   [Boolean] default = True
-                                ! If true, adds KPP diffusivity to diffusivity from other schemes.If false, KPP is the only diffusivity wherever KPP is non-zero.
+                                ! If true, adds KPP diffusivity to diffusivity from other schemes.
+                                ! If false, KPP is the only diffusivity wherever KPP is non-zero.
 KPP_SHORTWAVE_METHOD = "MXL_SW" ! default = "MXL_SW"
-                                ! Determines contribution of shortwave radiation to KPP surface buoyancy flux.  Options include:
+                                ! Determines contribution of shortwave radiation to KPP surface
+                                ! buoyancy flux.  Options include:
                                 !   ALL_SW: use total shortwave radiation
-                                !   MXL_SW:  use shortwave radiation absorbed by mixing layer
-                                !   LV1_SW:  use shortwave radiation absorbed by top model layer
+                                !   MXL_SW: use shortwave radiation absorbed by mixing layer
+                                !   LV1_SW: use shortwave radiation absorbed by top model layer
 CVMix_ZERO_H_WORK_AROUND = 0.0  !   [m] default = 0.0
                                 ! A minimum thickness used to avoid division by small numbers in the vicinity
-                                ! of vanished layers. This is independent of MIN_THICKNESS used in other parts of MOM.
+                                ! of vanished layers. This is independent of MIN_THICKNESS used in other parts
+                                ! of MOM.
 USE_KPP_LT_K = False            ! default = False
                                 ! Flag for Langmuir turbulence enhancement of turbulentmixing coefficient.
 STOKES_MIXING = False           ! default = False

--- a/ocean_only/CVmix_SCM_tests/cooling_only/KPP/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/KPP/MOM_parameter_doc.short
@@ -155,8 +155,8 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate

--- a/ocean_only/CVmix_SCM_tests/cooling_only/KPP/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/KPP/MOM_parameter_doc.short
@@ -100,7 +100,8 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate

--- a/ocean_only/CVmix_SCM_tests/mech_only/BML/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/mech_only/BML/MOM_parameter_doc.all
@@ -176,7 +176,7 @@ RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -394,8 +394,8 @@ COORD_VAR = "Layer"             ! default = "Layer"
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 THICKNESS_CONFIG = "uniform"    !
                                 ! A string that determines how the initial layer
@@ -483,7 +483,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 SPONGE = False                  !   [Boolean] default = False
                                 ! If true, sponges may be applied anywhere in the domain.
@@ -502,7 +502,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -578,8 +578,8 @@ LINEAR_DRAG = False             !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -627,7 +627,7 @@ KV = 0.0                        !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -653,7 +653,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -809,7 +809,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -841,7 +841,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -930,6 +930,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -993,7 +996,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1001,7 +1004,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1227,7 +1231,7 @@ CORRECT_ABSORPTION_DEPTH = False !   [Boolean] default = False
                                 ! heating depth of an exponential profile by moving some
                                 ! of the heating upward in the water column.
 DO_RIVERMIX = False             !   [Boolean] default = False
-                                ! If true, apply additional mixing whereever there is
+                                ! If true, apply additional mixing wherever there is
                                 ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
                                 ! if the ocean is that deep.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
@@ -1289,12 +1293,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1390,7 +1394,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1200.0             !   [s] default = 1200.0

--- a/ocean_only/CVmix_SCM_tests/mech_only/BML/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/mech_only/BML/MOM_parameter_doc.all
@@ -245,7 +245,8 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -758,7 +759,8 @@ RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -781,7 +783,8 @@ USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
                                 ! for new experiments.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
@@ -900,7 +903,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of

--- a/ocean_only/CVmix_SCM_tests/mech_only/BML/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/mech_only/BML/MOM_parameter_doc.short
@@ -97,7 +97,8 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate

--- a/ocean_only/CVmix_SCM_tests/mech_only/EPBL/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/mech_only/EPBL/MOM_parameter_doc.all
@@ -178,7 +178,7 @@ RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -393,15 +393,15 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
-                                ! Units of the regridding coordinuate.
+                                ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
                                 ! Determines how to specify the coordinate
                                 ! resolution. Valid options are:
@@ -438,7 +438,7 @@ REMAPPING_SCHEME = "PLM"        ! default = "PLM"
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
                                 ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicty or an inconsistency is
+                                ! consistency and if non-monotonicity or an inconsistency is
                                 ! detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
                                 ! If true, the results of remapping are checked for
@@ -467,15 +467,15 @@ REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
-                                ! REGRID_FILTER_SHALLOW_DEPTH the filter wieghts adopt a cubic profile.
+                                ! REGRID_FILTER_SHALLOW_DEPTH the filter weights adopt a cubic profile.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 THICKNESS_CONFIG = "coord"      !
                                 ! A string that determines how the initial layer
@@ -563,7 +563,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
@@ -586,7 +586,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -662,8 +662,8 @@ LINEAR_DRAG = False             !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -711,7 +711,7 @@ KV = 0.0                        !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -737,7 +737,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -901,7 +901,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -933,7 +933,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1019,6 +1019,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1082,7 +1085,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1090,7 +1093,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1243,7 +1247,7 @@ IGNORE_FLUXES_OVER_LAND = False !   [Boolean] default = False
                                 ! be different than the ocean mask to avoid sea ice formation
                                 ! under ice shelves. This flag only works when use_ePBL = True.
 DO_RIVERMIX = False             !   [Boolean] default = False
-                                ! If true, apply additional mixing whereever there is
+                                ! If true, apply additional mixing wherever there is
                                 ! runoff, so that it is mixed down to RIVERMIX_DEPTH
                                 ! if the ocean is that deep.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
@@ -1319,7 +1323,7 @@ EKMAN_SCALE_COEF = 1.0          !   [nondim] default = 1.0
                                 ! decreases the PBL diffusivity.
 USE_MLD_ITERATION = False       !   [Boolean] default = False
                                 ! A logical that specifies whether or not to use the
-                                ! distance to the bottom of the actively turblent boundary
+                                ! distance to the bottom of the actively turbulent boundary
                                 ! layer to help set the EPBL length scale.
 ORIG_MLD_ITERATION = True       !   [Boolean] default = True
                                 ! A logical that specifies whether or not to use the
@@ -1416,12 +1420,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1517,7 +1521,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1200.0             !   [s] default = 1200.0

--- a/ocean_only/CVmix_SCM_tests/mech_only/EPBL/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/mech_only/EPBL/MOM_parameter_doc.all
@@ -247,7 +247,8 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -842,7 +843,8 @@ RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -865,7 +867,8 @@ USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
                                 ! for new experiments.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
@@ -989,7 +992,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of

--- a/ocean_only/CVmix_SCM_tests/mech_only/EPBL/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/mech_only/EPBL/MOM_parameter_doc.short
@@ -155,8 +155,8 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate

--- a/ocean_only/CVmix_SCM_tests/mech_only/EPBL/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/mech_only/EPBL/MOM_parameter_doc.short
@@ -100,7 +100,8 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate

--- a/ocean_only/CVmix_SCM_tests/mech_only/KPP/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/mech_only/KPP/MOM_parameter_doc.all
@@ -178,7 +178,7 @@ RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -393,15 +393,15 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
-                                ! Units of the regridding coordinuate.
+                                ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
                                 ! Determines how to specify the coordinate
                                 ! resolution. Valid options are:
@@ -438,7 +438,7 @@ REMAPPING_SCHEME = "PLM"        ! default = "PLM"
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
                                 ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicty or an inconsistency is
+                                ! consistency and if non-monotonicity or an inconsistency is
                                 ! detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
                                 ! If true, the results of remapping are checked for
@@ -467,15 +467,15 @@ REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
-                                ! REGRID_FILTER_SHALLOW_DEPTH the filter wieghts adopt a cubic profile.
+                                ! REGRID_FILTER_SHALLOW_DEPTH the filter weights adopt a cubic profile.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 THICKNESS_CONFIG = "coord"      !
                                 ! A string that determines how the initial layer
@@ -563,7 +563,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
@@ -586,7 +586,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -662,8 +662,8 @@ LINEAR_DRAG = False             !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -711,7 +711,7 @@ KV = 0.0                        !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -737,7 +737,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -901,7 +901,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -933,7 +933,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1019,6 +1019,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1175,7 +1178,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1183,7 +1186,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1391,12 +1395,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1492,7 +1496,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1200.0             !   [s] default = 1200.0

--- a/ocean_only/CVmix_SCM_tests/mech_only/KPP/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/mech_only/KPP/MOM_parameter_doc.all
@@ -247,7 +247,8 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -842,7 +843,8 @@ RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -865,7 +867,8 @@ USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
                                 ! for new experiments.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
@@ -989,7 +992,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of
@@ -1100,21 +1104,25 @@ MATCH_TECHNIQUE = "SimpleShapes" ! default = "SimpleShapes"
                                 ! CVMix method to set profile function for diffusivity and NLT,
                                 ! as well as matching across OBL base. Allowed values are:
                                 !    SimpleShapes      = sigma*(1-sigma)^2 for both diffusivity and NLT
-                                !    MatchGradient     = sigma*(1-sigma)^2 for NLT; diffusivity profile from matching
+                                !    MatchGradient     = sigma*(1-sigma)^2 for NLT; diffusivity profile from
+                                !      matching
                                 !    MatchBoth         = match gradient for both diffusivity and NLT
                                 !    ParabolicNonLocal = sigma*(1-sigma)^2 for diffusivity; (1-sigma)^2 for NLT
 KPP_ZERO_DIFFUSIVITY = False    !   [Boolean] default = False
                                 ! If True, zeroes the KPP diffusivity and viscosity; for testing purpose.
 KPP_IS_ADDITIVE = True          !   [Boolean] default = True
-                                ! If true, adds KPP diffusivity to diffusivity from other schemes.If false, KPP is the only diffusivity wherever KPP is non-zero.
+                                ! If true, adds KPP diffusivity to diffusivity from other schemes.
+                                ! If false, KPP is the only diffusivity wherever KPP is non-zero.
 KPP_SHORTWAVE_METHOD = "MXL_SW" ! default = "MXL_SW"
-                                ! Determines contribution of shortwave radiation to KPP surface buoyancy flux.  Options include:
+                                ! Determines contribution of shortwave radiation to KPP surface
+                                ! buoyancy flux.  Options include:
                                 !   ALL_SW: use total shortwave radiation
-                                !   MXL_SW:  use shortwave radiation absorbed by mixing layer
-                                !   LV1_SW:  use shortwave radiation absorbed by top model layer
+                                !   MXL_SW: use shortwave radiation absorbed by mixing layer
+                                !   LV1_SW: use shortwave radiation absorbed by top model layer
 CVMix_ZERO_H_WORK_AROUND = 0.0  !   [m] default = 0.0
                                 ! A minimum thickness used to avoid division by small numbers in the vicinity
-                                ! of vanished layers. This is independent of MIN_THICKNESS used in other parts of MOM.
+                                ! of vanished layers. This is independent of MIN_THICKNESS used in other parts
+                                ! of MOM.
 USE_KPP_LT_K = False            ! default = False
                                 ! Flag for Langmuir turbulence enhancement of turbulentmixing coefficient.
 STOKES_MIXING = False           ! default = False

--- a/ocean_only/CVmix_SCM_tests/mech_only/KPP/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/mech_only/KPP/MOM_parameter_doc.short
@@ -155,8 +155,8 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate

--- a/ocean_only/CVmix_SCM_tests/mech_only/KPP/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/mech_only/KPP/MOM_parameter_doc.short
@@ -100,7 +100,8 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/BML/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/BML/MOM_parameter_doc.all
@@ -176,7 +176,7 @@ RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -394,8 +394,8 @@ COORD_VAR = "Layer"             ! default = "Layer"
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 THICKNESS_CONFIG = "uniform"    !
                                 ! A string that determines how the initial layer
@@ -483,7 +483,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 SPONGE = False                  !   [Boolean] default = False
                                 ! If true, sponges may be applied anywhere in the domain.
@@ -502,7 +502,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -578,8 +578,8 @@ LINEAR_DRAG = False             !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -627,7 +627,7 @@ KV = 0.0                        !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -653,7 +653,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -809,7 +809,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -841,7 +841,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -930,6 +930,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -993,7 +996,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1001,7 +1004,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1227,7 +1231,7 @@ CORRECT_ABSORPTION_DEPTH = False !   [Boolean] default = False
                                 ! heating depth of an exponential profile by moving some
                                 ! of the heating upward in the water column.
 DO_RIVERMIX = False             !   [Boolean] default = False
-                                ! If true, apply additional mixing whereever there is
+                                ! If true, apply additional mixing wherever there is
                                 ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
                                 ! if the ocean is that deep.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
@@ -1289,12 +1293,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1399,7 +1403,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1200.0             !   [s] default = 1200.0

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/BML/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/BML/MOM_parameter_doc.all
@@ -245,7 +245,8 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -758,7 +759,8 @@ RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -781,7 +783,8 @@ USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
                                 ! for new experiments.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
@@ -900,7 +903,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/BML/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/BML/MOM_parameter_doc.short
@@ -97,7 +97,8 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/EPBL/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/EPBL/MOM_parameter_doc.all
@@ -178,7 +178,7 @@ RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -393,15 +393,15 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
-                                ! Units of the regridding coordinuate.
+                                ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
                                 ! Determines how to specify the coordinate
                                 ! resolution. Valid options are:
@@ -438,7 +438,7 @@ REMAPPING_SCHEME = "PLM"        ! default = "PLM"
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
                                 ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicty or an inconsistency is
+                                ! consistency and if non-monotonicity or an inconsistency is
                                 ! detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
                                 ! If true, the results of remapping are checked for
@@ -467,15 +467,15 @@ REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
-                                ! REGRID_FILTER_SHALLOW_DEPTH the filter wieghts adopt a cubic profile.
+                                ! REGRID_FILTER_SHALLOW_DEPTH the filter weights adopt a cubic profile.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 THICKNESS_CONFIG = "coord"      !
                                 ! A string that determines how the initial layer
@@ -563,7 +563,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
@@ -586,7 +586,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -662,8 +662,8 @@ LINEAR_DRAG = False             !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -711,7 +711,7 @@ KV = 0.0                        !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -737,7 +737,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -901,7 +901,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -933,7 +933,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1019,6 +1019,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1082,7 +1085,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1090,7 +1093,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1243,7 +1247,7 @@ IGNORE_FLUXES_OVER_LAND = False !   [Boolean] default = False
                                 ! be different than the ocean mask to avoid sea ice formation
                                 ! under ice shelves. This flag only works when use_ePBL = True.
 DO_RIVERMIX = False             !   [Boolean] default = False
-                                ! If true, apply additional mixing whereever there is
+                                ! If true, apply additional mixing wherever there is
                                 ! runoff, so that it is mixed down to RIVERMIX_DEPTH
                                 ! if the ocean is that deep.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
@@ -1319,7 +1323,7 @@ EKMAN_SCALE_COEF = 1.0          !   [nondim] default = 1.0
                                 ! decreases the PBL diffusivity.
 USE_MLD_ITERATION = False       !   [Boolean] default = False
                                 ! A logical that specifies whether or not to use the
-                                ! distance to the bottom of the actively turblent boundary
+                                ! distance to the bottom of the actively turbulent boundary
                                 ! layer to help set the EPBL length scale.
 ORIG_MLD_ITERATION = True       !   [Boolean] default = True
                                 ! A logical that specifies whether or not to use the
@@ -1416,12 +1420,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1526,7 +1530,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1200.0             !   [s] default = 1200.0

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/EPBL/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/EPBL/MOM_parameter_doc.all
@@ -247,7 +247,8 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -842,7 +843,8 @@ RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -865,7 +867,8 @@ USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
                                 ! for new experiments.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
@@ -989,7 +992,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/EPBL/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/EPBL/MOM_parameter_doc.short
@@ -155,8 +155,8 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/EPBL/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/EPBL/MOM_parameter_doc.short
@@ -100,7 +100,8 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/KPP/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/KPP/MOM_parameter_doc.all
@@ -178,7 +178,7 @@ RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -393,15 +393,15 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
-                                ! Units of the regridding coordinuate.
+                                ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
                                 ! Determines how to specify the coordinate
                                 ! resolution. Valid options are:
@@ -438,7 +438,7 @@ REMAPPING_SCHEME = "PLM"        ! default = "PLM"
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
                                 ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicty or an inconsistency is
+                                ! consistency and if non-monotonicity or an inconsistency is
                                 ! detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
                                 ! If true, the results of remapping are checked for
@@ -467,15 +467,15 @@ REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
-                                ! REGRID_FILTER_SHALLOW_DEPTH the filter wieghts adopt a cubic profile.
+                                ! REGRID_FILTER_SHALLOW_DEPTH the filter weights adopt a cubic profile.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 THICKNESS_CONFIG = "coord"      !
                                 ! A string that determines how the initial layer
@@ -563,7 +563,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
@@ -586,7 +586,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -662,8 +662,8 @@ LINEAR_DRAG = False             !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -711,7 +711,7 @@ KV = 0.0                        !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -737,7 +737,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -901,7 +901,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -933,7 +933,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1019,6 +1019,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1175,7 +1178,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1183,7 +1186,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1391,12 +1395,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1501,7 +1505,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1200.0             !   [s] default = 1200.0

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/KPP/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/KPP/MOM_parameter_doc.all
@@ -247,7 +247,8 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -842,7 +843,8 @@ RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -865,7 +867,8 @@ USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
                                 ! for new experiments.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
@@ -989,7 +992,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of
@@ -1100,21 +1104,25 @@ MATCH_TECHNIQUE = "SimpleShapes" ! default = "SimpleShapes"
                                 ! CVMix method to set profile function for diffusivity and NLT,
                                 ! as well as matching across OBL base. Allowed values are:
                                 !    SimpleShapes      = sigma*(1-sigma)^2 for both diffusivity and NLT
-                                !    MatchGradient     = sigma*(1-sigma)^2 for NLT; diffusivity profile from matching
+                                !    MatchGradient     = sigma*(1-sigma)^2 for NLT; diffusivity profile from
+                                !      matching
                                 !    MatchBoth         = match gradient for both diffusivity and NLT
                                 !    ParabolicNonLocal = sigma*(1-sigma)^2 for diffusivity; (1-sigma)^2 for NLT
 KPP_ZERO_DIFFUSIVITY = False    !   [Boolean] default = False
                                 ! If True, zeroes the KPP diffusivity and viscosity; for testing purpose.
 KPP_IS_ADDITIVE = True          !   [Boolean] default = True
-                                ! If true, adds KPP diffusivity to diffusivity from other schemes.If false, KPP is the only diffusivity wherever KPP is non-zero.
+                                ! If true, adds KPP diffusivity to diffusivity from other schemes.
+                                ! If false, KPP is the only diffusivity wherever KPP is non-zero.
 KPP_SHORTWAVE_METHOD = "MXL_SW" ! default = "MXL_SW"
-                                ! Determines contribution of shortwave radiation to KPP surface buoyancy flux.  Options include:
+                                ! Determines contribution of shortwave radiation to KPP surface
+                                ! buoyancy flux.  Options include:
                                 !   ALL_SW: use total shortwave radiation
-                                !   MXL_SW:  use shortwave radiation absorbed by mixing layer
-                                !   LV1_SW:  use shortwave radiation absorbed by top model layer
+                                !   MXL_SW: use shortwave radiation absorbed by mixing layer
+                                !   LV1_SW: use shortwave radiation absorbed by top model layer
 CVMix_ZERO_H_WORK_AROUND = 0.0  !   [m] default = 0.0
                                 ! A minimum thickness used to avoid division by small numbers in the vicinity
-                                ! of vanished layers. This is independent of MIN_THICKNESS used in other parts of MOM.
+                                ! of vanished layers. This is independent of MIN_THICKNESS used in other parts
+                                ! of MOM.
 USE_KPP_LT_K = False            ! default = False
                                 ! Flag for Langmuir turbulence enhancement of turbulentmixing coefficient.
 STOKES_MIXING = False           ! default = False

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/KPP/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/KPP/MOM_parameter_doc.short
@@ -155,8 +155,8 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/KPP/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/KPP/MOM_parameter_doc.short
@@ -100,7 +100,8 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate

--- a/ocean_only/CVmix_SCM_tests/wind_only/BML/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/wind_only/BML/MOM_parameter_doc.all
@@ -245,7 +245,8 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -758,7 +759,8 @@ RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -781,7 +783,8 @@ USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
                                 ! for new experiments.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
@@ -900,7 +903,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of

--- a/ocean_only/CVmix_SCM_tests/wind_only/BML/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/wind_only/BML/MOM_parameter_doc.all
@@ -176,7 +176,7 @@ RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -394,8 +394,8 @@ COORD_VAR = "Layer"             ! default = "Layer"
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 THICKNESS_CONFIG = "uniform"    !
                                 ! A string that determines how the initial layer
@@ -483,7 +483,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 SPONGE = False                  !   [Boolean] default = False
                                 ! If true, sponges may be applied anywhere in the domain.
@@ -502,7 +502,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -578,8 +578,8 @@ LINEAR_DRAG = False             !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -627,7 +627,7 @@ KV = 0.0                        !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -653,7 +653,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -809,7 +809,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -841,7 +841,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -930,6 +930,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -993,7 +996,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1001,7 +1004,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1227,7 +1231,7 @@ CORRECT_ABSORPTION_DEPTH = False !   [Boolean] default = False
                                 ! heating depth of an exponential profile by moving some
                                 ! of the heating upward in the water column.
 DO_RIVERMIX = False             !   [Boolean] default = False
-                                ! If true, apply additional mixing whereever there is
+                                ! If true, apply additional mixing wherever there is
                                 ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
                                 ! if the ocean is that deep.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
@@ -1289,12 +1293,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1396,7 +1400,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1200.0             !   [s] default = 1200.0

--- a/ocean_only/CVmix_SCM_tests/wind_only/BML/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/wind_only/BML/MOM_parameter_doc.short
@@ -97,7 +97,8 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate

--- a/ocean_only/CVmix_SCM_tests/wind_only/EPBL/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/wind_only/EPBL/MOM_parameter_doc.all
@@ -178,7 +178,7 @@ RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -393,15 +393,15 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
-                                ! Units of the regridding coordinuate.
+                                ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
                                 ! Determines how to specify the coordinate
                                 ! resolution. Valid options are:
@@ -438,7 +438,7 @@ REMAPPING_SCHEME = "PLM"        ! default = "PLM"
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
                                 ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicty or an inconsistency is
+                                ! consistency and if non-monotonicity or an inconsistency is
                                 ! detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
                                 ! If true, the results of remapping are checked for
@@ -467,15 +467,15 @@ REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
-                                ! REGRID_FILTER_SHALLOW_DEPTH the filter wieghts adopt a cubic profile.
+                                ! REGRID_FILTER_SHALLOW_DEPTH the filter weights adopt a cubic profile.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 THICKNESS_CONFIG = "coord"      !
                                 ! A string that determines how the initial layer
@@ -563,7 +563,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
@@ -586,7 +586,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -662,8 +662,8 @@ LINEAR_DRAG = False             !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -711,7 +711,7 @@ KV = 0.0                        !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -737,7 +737,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -901,7 +901,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -933,7 +933,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1019,6 +1019,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1082,7 +1085,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1090,7 +1093,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1243,7 +1247,7 @@ IGNORE_FLUXES_OVER_LAND = False !   [Boolean] default = False
                                 ! be different than the ocean mask to avoid sea ice formation
                                 ! under ice shelves. This flag only works when use_ePBL = True.
 DO_RIVERMIX = False             !   [Boolean] default = False
-                                ! If true, apply additional mixing whereever there is
+                                ! If true, apply additional mixing wherever there is
                                 ! runoff, so that it is mixed down to RIVERMIX_DEPTH
                                 ! if the ocean is that deep.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
@@ -1319,7 +1323,7 @@ EKMAN_SCALE_COEF = 1.0          !   [nondim] default = 1.0
                                 ! decreases the PBL diffusivity.
 USE_MLD_ITERATION = False       !   [Boolean] default = False
                                 ! A logical that specifies whether or not to use the
-                                ! distance to the bottom of the actively turblent boundary
+                                ! distance to the bottom of the actively turbulent boundary
                                 ! layer to help set the EPBL length scale.
 ORIG_MLD_ITERATION = True       !   [Boolean] default = True
                                 ! A logical that specifies whether or not to use the
@@ -1416,12 +1420,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1523,7 +1527,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1200.0             !   [s] default = 1200.0

--- a/ocean_only/CVmix_SCM_tests/wind_only/EPBL/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/wind_only/EPBL/MOM_parameter_doc.all
@@ -247,7 +247,8 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -842,7 +843,8 @@ RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -865,7 +867,8 @@ USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
                                 ! for new experiments.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
@@ -989,7 +992,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of

--- a/ocean_only/CVmix_SCM_tests/wind_only/EPBL/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/wind_only/EPBL/MOM_parameter_doc.short
@@ -155,8 +155,8 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate

--- a/ocean_only/CVmix_SCM_tests/wind_only/EPBL/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/wind_only/EPBL/MOM_parameter_doc.short
@@ -100,7 +100,8 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate

--- a/ocean_only/CVmix_SCM_tests/wind_only/KPP/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/wind_only/KPP/MOM_parameter_doc.all
@@ -178,7 +178,7 @@ RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -393,15 +393,15 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
-                                ! Units of the regridding coordinuate.
+                                ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
                                 ! Determines how to specify the coordinate
                                 ! resolution. Valid options are:
@@ -438,7 +438,7 @@ REMAPPING_SCHEME = "PLM"        ! default = "PLM"
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
                                 ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicty or an inconsistency is
+                                ! consistency and if non-monotonicity or an inconsistency is
                                 ! detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
                                 ! If true, the results of remapping are checked for
@@ -467,15 +467,15 @@ REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
-                                ! REGRID_FILTER_SHALLOW_DEPTH the filter wieghts adopt a cubic profile.
+                                ! REGRID_FILTER_SHALLOW_DEPTH the filter weights adopt a cubic profile.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 THICKNESS_CONFIG = "coord"      !
                                 ! A string that determines how the initial layer
@@ -563,7 +563,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
@@ -586,7 +586,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -662,8 +662,8 @@ LINEAR_DRAG = False             !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -711,7 +711,7 @@ KV = 0.0                        !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -737,7 +737,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -901,7 +901,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -933,7 +933,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1019,6 +1019,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1175,7 +1178,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1183,7 +1186,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1391,12 +1395,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1498,7 +1502,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1200.0             !   [s] default = 1200.0

--- a/ocean_only/CVmix_SCM_tests/wind_only/KPP/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/wind_only/KPP/MOM_parameter_doc.all
@@ -247,7 +247,8 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -842,7 +843,8 @@ RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -865,7 +867,8 @@ USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
                                 ! for new experiments.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
@@ -989,7 +992,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of
@@ -1100,21 +1104,25 @@ MATCH_TECHNIQUE = "SimpleShapes" ! default = "SimpleShapes"
                                 ! CVMix method to set profile function for diffusivity and NLT,
                                 ! as well as matching across OBL base. Allowed values are:
                                 !    SimpleShapes      = sigma*(1-sigma)^2 for both diffusivity and NLT
-                                !    MatchGradient     = sigma*(1-sigma)^2 for NLT; diffusivity profile from matching
+                                !    MatchGradient     = sigma*(1-sigma)^2 for NLT; diffusivity profile from
+                                !      matching
                                 !    MatchBoth         = match gradient for both diffusivity and NLT
                                 !    ParabolicNonLocal = sigma*(1-sigma)^2 for diffusivity; (1-sigma)^2 for NLT
 KPP_ZERO_DIFFUSIVITY = False    !   [Boolean] default = False
                                 ! If True, zeroes the KPP diffusivity and viscosity; for testing purpose.
 KPP_IS_ADDITIVE = True          !   [Boolean] default = True
-                                ! If true, adds KPP diffusivity to diffusivity from other schemes.If false, KPP is the only diffusivity wherever KPP is non-zero.
+                                ! If true, adds KPP diffusivity to diffusivity from other schemes.
+                                ! If false, KPP is the only diffusivity wherever KPP is non-zero.
 KPP_SHORTWAVE_METHOD = "MXL_SW" ! default = "MXL_SW"
-                                ! Determines contribution of shortwave radiation to KPP surface buoyancy flux.  Options include:
+                                ! Determines contribution of shortwave radiation to KPP surface
+                                ! buoyancy flux.  Options include:
                                 !   ALL_SW: use total shortwave radiation
-                                !   MXL_SW:  use shortwave radiation absorbed by mixing layer
-                                !   LV1_SW:  use shortwave radiation absorbed by top model layer
+                                !   MXL_SW: use shortwave radiation absorbed by mixing layer
+                                !   LV1_SW: use shortwave radiation absorbed by top model layer
 CVMix_ZERO_H_WORK_AROUND = 0.0  !   [m] default = 0.0
                                 ! A minimum thickness used to avoid division by small numbers in the vicinity
-                                ! of vanished layers. This is independent of MIN_THICKNESS used in other parts of MOM.
+                                ! of vanished layers. This is independent of MIN_THICKNESS used in other parts
+                                ! of MOM.
 USE_KPP_LT_K = False            ! default = False
                                 ! Flag for Langmuir turbulence enhancement of turbulentmixing coefficient.
 STOKES_MIXING = False           ! default = False

--- a/ocean_only/CVmix_SCM_tests/wind_only/KPP/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/wind_only/KPP/MOM_parameter_doc.short
@@ -155,8 +155,8 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate

--- a/ocean_only/CVmix_SCM_tests/wind_only/KPP/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/wind_only/KPP/MOM_parameter_doc.short
@@ -100,7 +100,8 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate

--- a/ocean_only/DOME/MOM_parameter_doc.all
+++ b/ocean_only/DOME/MOM_parameter_doc.all
@@ -232,7 +232,8 @@ MAXIMUM_DEPTH = 3600.0          !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 1      ! default = 0
                                 ! The number of open boundary segments.
 OBC_ZERO_VORTICITY = True       !   [Boolean] default = False
@@ -810,7 +811,8 @@ HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
                                 ! stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
@@ -1044,7 +1046,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of

--- a/ocean_only/DOME/MOM_parameter_doc.all
+++ b/ocean_only/DOME/MOM_parameter_doc.all
@@ -161,7 +161,7 @@ RHO_0 = 1031.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -402,8 +402,8 @@ DENSITY_RANGE = 2.0             !   [kg m-3] default = 2.0
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 THICKNESS_CONFIG = "DOME"       !
                                 ! A string that determines how the initial layer
@@ -453,7 +453,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 SPONGE_CONFIG = "DOME"          ! default = "file"
                                 ! A string that sets how the sponges are configured:
@@ -491,7 +491,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -567,8 +567,8 @@ LINEAR_DRAG = False             !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 0.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -616,7 +616,7 @@ KV = 1.0E-04                    !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -664,7 +664,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -849,7 +849,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -872,7 +872,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
                                 ! If true, and BOUND_BT_CORRECTION is true, use the
                                 ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocites
+                                ! MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
                                 ! If true, adjust the curve fit to the BT_cont type
@@ -900,7 +900,7 @@ NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
                                 ! USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -935,7 +935,7 @@ BT_STRONG_DRAG = False          !   [Boolean] default = False
                                 ! barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
                                 ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _vdivided by the depth of
+                                ! using rates set by lin_drag_u & _v divided by the depth of
                                 ! the ocean.  This was introduced to facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
                                 ! If true, limit any velocity components that exceed
@@ -991,7 +991,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1074,6 +1074,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1137,7 +1140,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1145,7 +1148,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1330,12 +1334,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1431,7 +1435,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 8.64E+04           !   [s] default = 1200.0

--- a/ocean_only/DOME/MOM_parameter_doc.short
+++ b/ocean_only/DOME/MOM_parameter_doc.short
@@ -113,7 +113,8 @@ MAXIMUM_DEPTH = 3600.0          !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 1      ! default = 0
                                 ! The number of open boundary segments.
 OBC_ZERO_VORTICITY = True       !   [Boolean] default = False

--- a/ocean_only/DOME/MOM_parameter_doc.short
+++ b/ocean_only/DOME/MOM_parameter_doc.short
@@ -330,7 +330,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
                                 ! less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted

--- a/ocean_only/Phillips_2layer/MOM_parameter_doc.all
+++ b/ocean_only/Phillips_2layer/MOM_parameter_doc.all
@@ -230,7 +230,8 @@ MAXIMUM_DEPTH = 2000.0          !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -788,7 +789,8 @@ HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
                                 ! stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
@@ -1022,7 +1024,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of

--- a/ocean_only/Phillips_2layer/MOM_parameter_doc.all
+++ b/ocean_only/Phillips_2layer/MOM_parameter_doc.all
@@ -161,7 +161,7 @@ RHO_0 = 1031.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -339,8 +339,8 @@ GINT = 0.0196                   !   [m s-2]
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 THICKNESS_CONFIG = "phillips"   !
                                 ! A string that determines how the initial layer
@@ -370,7 +370,7 @@ THICKNESS_CONFIG = "phillips"   !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 HALF_STRAT_DEPTH = 0.25         !   [nondim] default = 0.5
-                                ! The maximum depth of the ocean.
+                                ! The fractional depth where the stratification is centered.
 JET_WIDTH = 200.0               !   [km]
                                 ! The width of the zonal-mean jet.
 JET_HEIGHT = 300.0              !   [m]
@@ -399,7 +399,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 SPONGE = True                   !   [Boolean] default = False
                                 ! If true, sponges may be applied anywhere in the domain.
@@ -432,7 +432,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -527,7 +527,8 @@ GILL_EQUATORIAL_LD = True       !   [Boolean] default = False
                                 ! If true, uses Gill's definition of the baroclinic
                                 ! equatorial deformation radius, otherwise, if false, use
                                 ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 infront of the beta term in the denominator. Gill'sis the more appropriate definition.
+                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
@@ -544,8 +545,8 @@ LINEAR_DRAG = False             !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -593,7 +594,7 @@ KV = 1.0E-04                    !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -641,7 +642,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -826,7 +827,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -849,7 +850,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
                                 ! If true, and BOUND_BT_CORRECTION is true, use the
                                 ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocites
+                                ! MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
                                 ! If true, adjust the curve fit to the BT_cont type
@@ -877,7 +878,7 @@ NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
                                 ! USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -912,7 +913,7 @@ BT_STRONG_DRAG = False          !   [Boolean] default = False
                                 ! barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
                                 ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _vdivided by the depth of
+                                ! using rates set by lin_drag_u & _v divided by the depth of
                                 ! the ocean.  This was introduced to facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
                                 ! If true, limit any velocity components that exceed
@@ -968,7 +969,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1051,6 +1052,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1114,7 +1118,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1122,7 +1126,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1307,12 +1312,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1408,7 +1413,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 3600.0             !   [s] default = 600.0

--- a/ocean_only/Phillips_2layer/MOM_parameter_doc.short
+++ b/ocean_only/Phillips_2layer/MOM_parameter_doc.short
@@ -188,7 +188,7 @@ THICKNESS_CONFIG = "phillips"   !
                                 !     rossby_front - a mixed layer front in thermal wind balance.
                                 !     USER - call a user modified routine.
 HALF_STRAT_DEPTH = 0.25         !   [nondim] default = 0.5
-                                ! The maximum depth of the ocean.
+                                ! The fractional depth where the stratification is centered.
 JET_WIDTH = 200.0               !   [km]
                                 ! The width of the zonal-mean jet.
 JET_HEIGHT = 300.0              !   [m]
@@ -255,7 +255,8 @@ GILL_EQUATORIAL_LD = True       !   [Boolean] default = False
                                 ! If true, uses Gill's definition of the baroclinic
                                 ! equatorial deformation radius, otherwise, if false, use
                                 ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 infront of the beta term in the denominator. Gill'sis the more appropriate definition.
+                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 HBBL = 10.0                     !   [m]
@@ -345,7 +346,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
                                 ! less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted

--- a/ocean_only/Phillips_2layer/MOM_parameter_doc.short
+++ b/ocean_only/Phillips_2layer/MOM_parameter_doc.short
@@ -112,7 +112,8 @@ MAXIMUM_DEPTH = 2000.0          !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 ROTATION = "beta"               ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate

--- a/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.all
+++ b/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.all
@@ -247,7 +247,8 @@ MAXIMUM_DEPTH = 300.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -842,7 +843,8 @@ RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -865,7 +867,8 @@ USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
                                 ! for new experiments.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
@@ -986,7 +989,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of
@@ -1097,21 +1101,25 @@ MATCH_TECHNIQUE = "SimpleShapes" ! default = "SimpleShapes"
                                 ! CVMix method to set profile function for diffusivity and NLT,
                                 ! as well as matching across OBL base. Allowed values are:
                                 !    SimpleShapes      = sigma*(1-sigma)^2 for both diffusivity and NLT
-                                !    MatchGradient     = sigma*(1-sigma)^2 for NLT; diffusivity profile from matching
+                                !    MatchGradient     = sigma*(1-sigma)^2 for NLT; diffusivity profile from
+                                !      matching
                                 !    MatchBoth         = match gradient for both diffusivity and NLT
                                 !    ParabolicNonLocal = sigma*(1-sigma)^2 for diffusivity; (1-sigma)^2 for NLT
 KPP_ZERO_DIFFUSIVITY = False    !   [Boolean] default = False
                                 ! If True, zeroes the KPP diffusivity and viscosity; for testing purpose.
 KPP_IS_ADDITIVE = True          !   [Boolean] default = True
-                                ! If true, adds KPP diffusivity to diffusivity from other schemes.If false, KPP is the only diffusivity wherever KPP is non-zero.
+                                ! If true, adds KPP diffusivity to diffusivity from other schemes.
+                                ! If false, KPP is the only diffusivity wherever KPP is non-zero.
 KPP_SHORTWAVE_METHOD = "MXL_SW" ! default = "MXL_SW"
-                                ! Determines contribution of shortwave radiation to KPP surface buoyancy flux.  Options include:
+                                ! Determines contribution of shortwave radiation to KPP surface
+                                ! buoyancy flux.  Options include:
                                 !   ALL_SW: use total shortwave radiation
-                                !   MXL_SW:  use shortwave radiation absorbed by mixing layer
-                                !   LV1_SW:  use shortwave radiation absorbed by top model layer
+                                !   MXL_SW: use shortwave radiation absorbed by mixing layer
+                                !   LV1_SW: use shortwave radiation absorbed by top model layer
 CVMix_ZERO_H_WORK_AROUND = 0.0  !   [m] default = 0.0
                                 ! A minimum thickness used to avoid division by small numbers in the vicinity
-                                ! of vanished layers. This is independent of MIN_THICKNESS used in other parts of MOM.
+                                ! of vanished layers. This is independent of MIN_THICKNESS used in other parts
+                                ! of MOM.
 USE_KPP_LT_K = False            ! default = False
                                 ! Flag for Langmuir turbulence enhancement of turbulentmixing coefficient.
 STOKES_MIXING = False           ! default = False
@@ -1503,7 +1511,8 @@ IDL_HURR_MAX_WIND = 65.0        !   [m/s] default = 65.0
 IDL_HURR_TRAN_SPEED = 5.0       !   [m/s] default = 5.0
                                 ! Translation speed of hurricane used in the idealizedhurricane wind profile.
 IDL_HURR_TRAN_DIR = 180.0       !   [degrees] default = 180.0
-                                ! Translation direction (towards) of hurricane used in the idealized hurricane wind profile.
+                                ! Translation direction (towards) of hurricane used in the idealized hurricane
+                                ! wind profile.
 IDL_HURR_X0 = 0.0               !   [m] default = 0.0
                                 ! Idealized Hurricane initial X position
 IDL_HURR_Y0 = 0.0               !   [m] default = 0.0
@@ -1511,7 +1520,8 @@ IDL_HURR_Y0 = 0.0               !   [m] default = 0.0
 IDL_HURR_TAU_CURR_REL = False   ! default = False
                                 ! Current relative stress switchused in the idealized hurricane wind profile.
 IDL_HURR_SCM_BR_BENCH = False   ! default = False
-                                ! Single column mode benchmark case switch, which is invoking a modification (bug) in the wind profile meant to reproduce a previous implementation.
+                                ! Single column mode benchmark case switch, which is invoking a modification
+                                ! (bug) in the wind profile meant to reproduce a previous implementation.
 IDL_HURR_SCM = False            ! default = False
                                 ! Single Column mode switchused in the SCM idealized hurricane wind profile.
 IDL_HURR_SCM_LOCY = 5.0E+04     !   [m] default = 5.0E+04

--- a/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.all
+++ b/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.all
@@ -178,7 +178,7 @@ RHO_0 = 1027.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -393,15 +393,15 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
-                                ! Units of the regridding coordinuate.
+                                ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
                                 ! Determines how to specify the coordinate
                                 ! resolution. Valid options are:
@@ -438,7 +438,7 @@ REMAPPING_SCHEME = "PLM"        ! default = "PLM"
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
                                 ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicty or an inconsistency is
+                                ! consistency and if non-monotonicity or an inconsistency is
                                 ! detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
                                 ! If true, the results of remapping are checked for
@@ -467,15 +467,15 @@ REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
-                                ! REGRID_FILTER_SHALLOW_DEPTH the filter wieghts adopt a cubic profile.
+                                ! REGRID_FILTER_SHALLOW_DEPTH the filter weights adopt a cubic profile.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 THICKNESS_CONFIG = "uniform"    !
                                 ! A string that determines how the initial layer
@@ -563,7 +563,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
@@ -586,7 +586,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -662,8 +662,8 @@ LINEAR_DRAG = False             !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -711,7 +711,7 @@ KV = 1.0E-04                    !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -737,7 +737,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -901,7 +901,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -933,7 +933,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1016,6 +1016,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1172,7 +1175,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1180,7 +1183,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1388,12 +1392,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1520,7 +1524,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1200.0             !   [s] default = 1200.0

--- a/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.short
+++ b/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.short
@@ -161,8 +161,8 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate

--- a/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.short
+++ b/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.short
@@ -110,7 +110,8 @@ MAXIMUM_DEPTH = 300.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate

--- a/ocean_only/adjustment2d/layer/MOM_parameter_doc.all
+++ b/ocean_only/adjustment2d/layer/MOM_parameter_doc.all
@@ -182,7 +182,7 @@ RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-15              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -401,8 +401,8 @@ GFS = 10.0                      !   [m s-2] default = 10.0
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 THICKNESS_CONFIG = "adjustment2d" !
                                 ! A string that determines how the initial layer
@@ -496,7 +496,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 SPONGE = False                  !   [Boolean] default = False
                                 ! If true, sponges may be applied anywhere in the domain.
@@ -515,7 +515,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -591,8 +591,8 @@ LINEAR_DRAG = False             !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -640,7 +640,7 @@ KV = 1.0E-06                    !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -688,7 +688,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -815,7 +815,7 @@ KH_VEL_SCALE = 0.0              !   [m s-1] default = 0.0
                                 ! The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latidutinally-dependent background
+                                ! The amplitude of a latitudinally-dependent background
                                 ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = True           !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
@@ -890,7 +890,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -915,7 +915,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
                                 ! If true, and BOUND_BT_CORRECTION is true, use the
                                 ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocites
+                                ! MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
                                 ! If true, adjust the curve fit to the BT_cont type
@@ -943,7 +943,7 @@ NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
                                 ! USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -978,7 +978,7 @@ BT_STRONG_DRAG = False          !   [Boolean] default = False
                                 ! barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
                                 ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _vdivided by the depth of
+                                ! using rates set by lin_drag_u & _v divided by the depth of
                                 ! the ocean.  This was introduced to facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
                                 ! If true, limit any velocity components that exceed
@@ -1034,7 +1034,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1117,6 +1117,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1180,7 +1183,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1188,7 +1191,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1396,12 +1400,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1497,7 +1501,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 600.0              !   [s] default = 150.0

--- a/ocean_only/adjustment2d/layer/MOM_parameter_doc.all
+++ b/ocean_only/adjustment2d/layer/MOM_parameter_doc.all
@@ -251,7 +251,8 @@ MAXIMUM_DEPTH = 20.0            !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -793,7 +794,8 @@ RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -851,7 +853,8 @@ HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
                                 ! stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
@@ -1087,7 +1090,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of

--- a/ocean_only/adjustment2d/layer/MOM_parameter_doc.short
+++ b/ocean_only/adjustment2d/layer/MOM_parameter_doc.short
@@ -122,7 +122,8 @@ MAXIMUM_DEPTH = 20.0            !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 ROTATION = "beta"               ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate

--- a/ocean_only/adjustment2d/layer/MOM_parameter_doc.short
+++ b/ocean_only/adjustment2d/layer/MOM_parameter_doc.short
@@ -61,7 +61,7 @@ RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
                                 ! properties, or with BOUSSINSEQ false to convert some
                                 ! parameters from vertical units of m to kg m-2.
 ANGSTROM = 1.0E-15              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 NK = 25                         !   [nondim]
                                 ! The number of model layers.
 
@@ -333,7 +333,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
                                 ! less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted

--- a/ocean_only/adjustment2d/rho/MOM_parameter_doc.all
+++ b/ocean_only/adjustment2d/rho/MOM_parameter_doc.all
@@ -182,7 +182,7 @@ RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-15              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -403,15 +403,15 @@ REGRIDDING_COORDINATE_MODE = "RHO" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 REGRIDDING_COORDINATE_UNITS = "kg m^-3" ! default = "kg m^-3"
-                                ! Units of the regridding coordinuate.
+                                ! Units of the regridding coordinate.
 INTERPOLATION_SCHEME = "P3M_IH4IH3" ! default = "P1M_H2"
                                 ! This sets the interpolation scheme to use to
                                 ! determine the new grid. These parameters are
@@ -459,7 +459,7 @@ ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
                                 ! RHO target densities for interfaces
 REGRID_COMPRESSIBILITY_FRACTION = 0.0 !   [not defined] default = 0.0
                                 ! When interpolating potential density profiles we can add
-                                ! some artificial compressibility solely to make homogenous
+                                ! some artificial compressibility solely to make homogeneous
                                 ! regions appear stratified.
 MIN_THICKNESS = 1.0E-04         !   [m] default = 0.001
                                 ! When regridding, this is the minimum layer
@@ -494,7 +494,7 @@ REMAPPING_SCHEME = "PPM_IH4"    ! default = "PLM"
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
                                 ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicty or an inconsistency is
+                                ! consistency and if non-monotonicity or an inconsistency is
                                 ! detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
                                 ! If true, the results of remapping are checked for
@@ -523,15 +523,15 @@ REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
-                                ! REGRID_FILTER_SHALLOW_DEPTH the filter wieghts adopt a cubic profile.
+                                ! REGRID_FILTER_SHALLOW_DEPTH the filter weights adopt a cubic profile.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 THICKNESS_CONFIG = "adjustment2d" !
                                 ! A string that determines how the initial layer
@@ -623,7 +623,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
@@ -646,7 +646,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -722,8 +722,8 @@ LINEAR_DRAG = False             !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -771,7 +771,7 @@ KV = 1.0E-06                    !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -819,7 +819,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -946,7 +946,7 @@ KH_VEL_SCALE = 0.0              !   [m s-1] default = 0.0
                                 ! The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latidutinally-dependent background
+                                ! The amplitude of a latitudinally-dependent background
                                 ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = True           !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
@@ -1021,7 +1021,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -1046,7 +1046,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
                                 ! If true, and BOUND_BT_CORRECTION is true, use the
                                 ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocites
+                                ! MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
                                 ! If true, adjust the curve fit to the BT_cont type
@@ -1074,7 +1074,7 @@ NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
                                 ! USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -1109,7 +1109,7 @@ BT_STRONG_DRAG = False          !   [Boolean] default = False
                                 ! barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
                                 ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _vdivided by the depth of
+                                ! using rates set by lin_drag_u & _v divided by the depth of
                                 ! the ocean.  This was introduced to facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
                                 ! If true, limit any velocity components that exceed
@@ -1165,7 +1165,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1248,6 +1248,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1311,7 +1314,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1319,7 +1322,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1527,12 +1531,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1628,7 +1632,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 600.0              !   [s] default = 150.0

--- a/ocean_only/adjustment2d/rho/MOM_parameter_doc.all
+++ b/ocean_only/adjustment2d/rho/MOM_parameter_doc.all
@@ -251,7 +251,8 @@ MAXIMUM_DEPTH = 20.0            !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -924,7 +925,8 @@ RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -982,7 +984,8 @@ HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
                                 ! stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
@@ -1218,7 +1221,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of

--- a/ocean_only/adjustment2d/rho/MOM_parameter_doc.short
+++ b/ocean_only/adjustment2d/rho/MOM_parameter_doc.short
@@ -57,7 +57,7 @@ RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
                                 ! properties, or with BOUSSINSEQ false to convert some
                                 ! parameters from vertical units of m to kg m-2.
 ANGSTROM = 1.0E-15              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 NK = 25                         !   [nondim]
                                 ! The number of model layers.
 
@@ -173,8 +173,8 @@ REGRIDDING_COORDINATE_MODE = "RHO" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
@@ -381,7 +381,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
                                 ! less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted

--- a/ocean_only/adjustment2d/rho/MOM_parameter_doc.short
+++ b/ocean_only/adjustment2d/rho/MOM_parameter_doc.short
@@ -118,7 +118,8 @@ MAXIMUM_DEPTH = 20.0            !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 ROTATION = "beta"               ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate

--- a/ocean_only/adjustment2d/z/MOM_parameter_doc.all
+++ b/ocean_only/adjustment2d/z/MOM_parameter_doc.all
@@ -182,7 +182,7 @@ RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-15              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -403,15 +403,15 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
-                                ! Units of the regridding coordinuate.
+                                ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
                                 ! Determines how to specify the coordinate
                                 ! resolution. Valid options are:
@@ -448,7 +448,7 @@ REMAPPING_SCHEME = "PPM_IH4"    ! default = "PLM"
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
                                 ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicty or an inconsistency is
+                                ! consistency and if non-monotonicity or an inconsistency is
                                 ! detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
                                 ! If true, the results of remapping are checked for
@@ -477,15 +477,15 @@ REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
-                                ! REGRID_FILTER_SHALLOW_DEPTH the filter wieghts adopt a cubic profile.
+                                ! REGRID_FILTER_SHALLOW_DEPTH the filter weights adopt a cubic profile.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 THICKNESS_CONFIG = "adjustment2d" !
                                 ! A string that determines how the initial layer
@@ -577,7 +577,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
@@ -600,7 +600,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -676,8 +676,8 @@ LINEAR_DRAG = False             !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -725,7 +725,7 @@ KV = 1.0E-06                    !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -773,7 +773,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -900,7 +900,7 @@ KH_VEL_SCALE = 0.0              !   [m s-1] default = 0.0
                                 ! The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latidutinally-dependent background
+                                ! The amplitude of a latitudinally-dependent background
                                 ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = True           !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
@@ -975,7 +975,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -1000,7 +1000,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
                                 ! If true, and BOUND_BT_CORRECTION is true, use the
                                 ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocites
+                                ! MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
                                 ! If true, adjust the curve fit to the BT_cont type
@@ -1028,7 +1028,7 @@ NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
                                 ! USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -1063,7 +1063,7 @@ BT_STRONG_DRAG = False          !   [Boolean] default = False
                                 ! barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
                                 ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _vdivided by the depth of
+                                ! using rates set by lin_drag_u & _v divided by the depth of
                                 ! the ocean.  This was introduced to facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
                                 ! If true, limit any velocity components that exceed
@@ -1119,7 +1119,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1202,6 +1202,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1265,7 +1268,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1273,7 +1276,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1481,12 +1485,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1582,7 +1586,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 600.0              !   [s] default = 150.0

--- a/ocean_only/adjustment2d/z/MOM_parameter_doc.all
+++ b/ocean_only/adjustment2d/z/MOM_parameter_doc.all
@@ -251,7 +251,8 @@ MAXIMUM_DEPTH = 20.0            !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -878,7 +879,8 @@ RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -936,7 +938,8 @@ HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
                                 ! stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
@@ -1172,7 +1175,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of

--- a/ocean_only/adjustment2d/z/MOM_parameter_doc.short
+++ b/ocean_only/adjustment2d/z/MOM_parameter_doc.short
@@ -57,7 +57,7 @@ RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
                                 ! properties, or with BOUSSINSEQ false to convert some
                                 ! parameters from vertical units of m to kg m-2.
 ANGSTROM = 1.0E-15              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 NK = 25                         !   [nondim]
                                 ! The number of model layers.
 
@@ -173,8 +173,8 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
@@ -357,7 +357,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
                                 ! less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted

--- a/ocean_only/adjustment2d/z/MOM_parameter_doc.short
+++ b/ocean_only/adjustment2d/z/MOM_parameter_doc.short
@@ -118,7 +118,8 @@ MAXIMUM_DEPTH = 20.0            !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 ROTATION = "beta"               ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate

--- a/ocean_only/benchmark/MOM_parameter_doc.all
+++ b/ocean_only/benchmark/MOM_parameter_doc.all
@@ -180,7 +180,7 @@ RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -435,8 +435,8 @@ GFS = 9.8                       !   [m s-2] default = 9.8
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 THICKNESS_CONFIG = "benchmark"  !
                                 ! A string that determines how the initial layer
@@ -512,7 +512,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 SPONGE = False                  !   [Boolean] default = False
                                 ! If true, sponges may be applied anywhere in the domain.
@@ -531,7 +531,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -635,7 +635,8 @@ GILL_EQUATORIAL_LD = False      !   [Boolean] default = False
                                 ! If true, uses Gill's definition of the baroclinic
                                 ! equatorial deformation radius, otherwise, if false, use
                                 ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 infront of the beta term in the denominator. Gill'sis the more appropriate definition.
+                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
@@ -652,8 +653,8 @@ LINEAR_DRAG = False             !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 0.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -714,7 +715,7 @@ KV = 1.0E-04                    !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -762,7 +763,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -955,7 +956,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -980,7 +981,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
                                 ! If true, and BOUND_BT_CORRECTION is true, use the
                                 ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocites
+                                ! MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
                                 ! If true, adjust the curve fit to the BT_cont type
@@ -1012,7 +1013,7 @@ NONLIN_BT_CONT_UPDATE_PERIOD = 1 !   [nondim] default = 1
                                 ! areas, or 0 to update only before the barotropic stepping.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -1047,7 +1048,7 @@ BT_STRONG_DRAG = False          !   [Boolean] default = False
                                 ! barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
                                 ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _vdivided by the depth of
+                                ! using rates set by lin_drag_u & _v divided by the depth of
                                 ! the ocean.  This was introduced to facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
                                 ! If true, limit any velocity components that exceed
@@ -1103,7 +1104,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1198,6 +1199,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1261,7 +1265,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1269,7 +1273,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1491,7 +1496,7 @@ CORRECT_ABSORPTION_DEPTH = True !   [Boolean] default = False
                                 ! heating depth of an exponential profile by moving some
                                 ! of the heating upward in the water column.
 DO_RIVERMIX = False             !   [Boolean] default = False
-                                ! If true, apply additional mixing whereever there is
+                                ! If true, apply additional mixing wherever there is
                                 ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
                                 ! if the ocean is that deep.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
@@ -1560,12 +1565,12 @@ KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = True   !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1709,7 +1714,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 3600.0             !   [s] default = 900.0

--- a/ocean_only/benchmark/MOM_parameter_doc.all
+++ b/ocean_only/benchmark/MOM_parameter_doc.all
@@ -261,7 +261,8 @@ MAXIMUM_DEPTH = 5500.0          !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -868,7 +869,8 @@ RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -928,7 +930,8 @@ HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
                                 ! stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
@@ -1169,7 +1172,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of

--- a/ocean_only/benchmark/MOM_parameter_doc.short
+++ b/ocean_only/benchmark/MOM_parameter_doc.short
@@ -347,7 +347,7 @@ NONLINEAR_BT_CONTINUITY = True  !   [Boolean] default = False
                                 ! USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted

--- a/ocean_only/benchmark/MOM_parameter_doc.short
+++ b/ocean_only/benchmark/MOM_parameter_doc.short
@@ -123,7 +123,8 @@ MAXIMUM_DEPTH = 5500.0          !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 
 ! === module MOM_tracer_registry ===
 

--- a/ocean_only/circle_obcs/MOM_parameter_doc.all
+++ b/ocean_only/circle_obcs/MOM_parameter_doc.all
@@ -230,7 +230,8 @@ MAXIMUM_DEPTH = 600.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 4      ! default = 0
                                 ! The number of open boundary segments.
 OBC_ZERO_VORTICITY = False      !   [Boolean] default = False
@@ -798,7 +799,8 @@ RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -889,7 +891,8 @@ HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
                                 ! stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
@@ -1129,7 +1132,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of

--- a/ocean_only/circle_obcs/MOM_parameter_doc.all
+++ b/ocean_only/circle_obcs/MOM_parameter_doc.all
@@ -161,7 +161,7 @@ RHO_0 = 1031.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -432,8 +432,8 @@ DENSITY_RANGE = 2.0             !   [kg m-3] default = 2.0
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 THICKNESS_CONFIG = "circle_obcs" !
                                 ! A string that determines how the initial layer
@@ -494,7 +494,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 OBC_USER_CONFIG = "none"        ! default = "none"
                                 ! A string that sets how the user code is invoked to set open
@@ -520,7 +520,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -596,8 +596,8 @@ LINEAR_DRAG = False             !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -645,7 +645,7 @@ KV = 1.0E-04                    !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -693,7 +693,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -820,7 +820,7 @@ KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
                                 ! The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latidutinally-dependent background
+                                ! The amplitude of a latitudinally-dependent background
                                 ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = True           !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
@@ -928,7 +928,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -953,7 +953,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
                                 ! If true, and BOUND_BT_CORRECTION is true, use the
                                 ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocites
+                                ! MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
                                 ! If true, adjust the curve fit to the BT_cont type
@@ -985,7 +985,7 @@ NONLIN_BT_CONT_UPDATE_PERIOD = 1 !   [nondim] default = 1
                                 ! areas, or 0 to update only before the barotropic stepping.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -1020,7 +1020,7 @@ BT_STRONG_DRAG = False          !   [Boolean] default = False
                                 ! barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
                                 ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _vdivided by the depth of
+                                ! using rates set by lin_drag_u & _v divided by the depth of
                                 ! the ocean.  This was introduced to facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
                                 ! If true, limit any velocity components that exceed
@@ -1076,7 +1076,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1159,6 +1159,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1222,7 +1225,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1230,7 +1233,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1415,12 +1419,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1516,7 +1520,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 600.0              !   [s] default = 120.0

--- a/ocean_only/circle_obcs/MOM_parameter_doc.short
+++ b/ocean_only/circle_obcs/MOM_parameter_doc.short
@@ -314,7 +314,7 @@ NONLINEAR_BT_CONTINUITY = True  !   [Boolean] default = False
                                 ! USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted

--- a/ocean_only/circle_obcs/MOM_parameter_doc.short
+++ b/ocean_only/circle_obcs/MOM_parameter_doc.short
@@ -106,7 +106,8 @@ MAXIMUM_DEPTH = 600.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 4      ! default = 0
                                 ! The number of open boundary segments.
 OBC_ZERO_BIHARMONIC = True      !   [Boolean] default = False

--- a/ocean_only/double_gyre/MOM_parameter_doc.all
+++ b/ocean_only/double_gyre/MOM_parameter_doc.all
@@ -228,7 +228,8 @@ MAXIMUM_DEPTH = 2000.0          !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -676,7 +677,8 @@ RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -734,7 +736,8 @@ HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
                                 ! stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False

--- a/ocean_only/double_gyre/MOM_parameter_doc.all
+++ b/ocean_only/double_gyre/MOM_parameter_doc.all
@@ -161,7 +161,7 @@ RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -333,8 +333,8 @@ GINT = 0.0098                   !   [m s-2]
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 THICKNESS_CONFIG = "uniform"    !
                                 ! A string that determines how the initial layer
@@ -384,7 +384,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 SPONGE = False                  !   [Boolean] default = False
                                 ! If true, sponges may be applied anywhere in the domain.
@@ -403,7 +403,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -523,7 +523,7 @@ KV = 1.0E-04                    !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -571,7 +571,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -698,7 +698,7 @@ KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
                                 ! The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latidutinally-dependent background
+                                ! The amplitude of a latitudinally-dependent background
                                 ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = True           !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
@@ -773,7 +773,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -796,7 +796,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
                                 ! If true, and BOUND_BT_CORRECTION is true, use the
                                 ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocites
+                                ! MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
                                 ! If true, adjust the curve fit to the BT_cont type
@@ -824,7 +824,7 @@ NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
                                 ! USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -859,7 +859,7 @@ BT_STRONG_DRAG = False          !   [Boolean] default = False
                                 ! barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
                                 ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _vdivided by the depth of
+                                ! using rates set by lin_drag_u & _v divided by the depth of
                                 ! the ocean.  This was introduced to facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
                                 ! If true, limit any velocity components that exceed
@@ -915,7 +915,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -965,12 +965,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1071,7 +1071,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 2400.0             !   [s] default = 1200.0

--- a/ocean_only/double_gyre/MOM_parameter_doc.short
+++ b/ocean_only/double_gyre/MOM_parameter_doc.short
@@ -266,7 +266,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
                                 ! less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted

--- a/ocean_only/double_gyre/MOM_parameter_doc.short
+++ b/ocean_only/double_gyre/MOM_parameter_doc.short
@@ -102,7 +102,8 @@ MAXIMUM_DEPTH = 2000.0          !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 
 ! === module MOM_tracer_registry ===
 

--- a/ocean_only/external_gwave/MOM_parameter_doc.all
+++ b/ocean_only/external_gwave/MOM_parameter_doc.all
@@ -182,7 +182,7 @@ RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-15              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -399,8 +399,8 @@ DENSITY_RANGE = 5.0             !   [kg m-3] default = 2.0
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 THICKNESS_CONFIG = "external_gwave" !
                                 ! A string that determines how the initial layer
@@ -483,7 +483,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 SPONGE = False                  !   [Boolean] default = False
                                 ! If true, sponges may be applied anywhere in the domain.
@@ -502,7 +502,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -578,8 +578,8 @@ LINEAR_DRAG = False             !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -627,7 +627,7 @@ KV = 1.0E-04                    !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -675,7 +675,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -802,7 +802,7 @@ KH_VEL_SCALE = 0.0              !   [m s-1] default = 0.0
                                 ! The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latidutinally-dependent background
+                                ! The amplitude of a latitudinally-dependent background
                                 ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
@@ -867,7 +867,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -892,7 +892,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
                                 ! If true, and BOUND_BT_CORRECTION is true, use the
                                 ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocites
+                                ! MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
                                 ! If true, adjust the curve fit to the BT_cont type
@@ -924,7 +924,7 @@ NONLIN_BT_CONT_UPDATE_PERIOD = 1 !   [nondim] default = 1
                                 ! areas, or 0 to update only before the barotropic stepping.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -959,7 +959,7 @@ BT_STRONG_DRAG = False          !   [Boolean] default = False
                                 ! barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
                                 ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _vdivided by the depth of
+                                ! using rates set by lin_drag_u & _v divided by the depth of
                                 ! the ocean.  This was introduced to facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
                                 ! If true, limit any velocity components that exceed
@@ -1015,7 +1015,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1098,6 +1098,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1161,7 +1164,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1169,7 +1172,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1377,12 +1381,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1478,7 +1482,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 600.0              !   [s] default = 60.0

--- a/ocean_only/external_gwave/MOM_parameter_doc.all
+++ b/ocean_only/external_gwave/MOM_parameter_doc.all
@@ -251,7 +251,8 @@ MAXIMUM_DEPTH = 20.0            !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -780,7 +781,8 @@ RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -831,7 +833,8 @@ USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
                                 ! for new experiments.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
@@ -1068,7 +1071,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of

--- a/ocean_only/external_gwave/MOM_parameter_doc.short
+++ b/ocean_only/external_gwave/MOM_parameter_doc.short
@@ -59,7 +59,7 @@ RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
                                 ! properties, or with BOUSSINSEQ false to convert some
                                 ! parameters from vertical units of m to kg m-2.
 ANGSTROM = 1.0E-15              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 NK = 21                         !   [nondim]
                                 ! The number of model layers.
 
@@ -321,7 +321,7 @@ NONLINEAR_BT_CONTINUITY = True  !   [Boolean] default = False
                                 ! USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted

--- a/ocean_only/external_gwave/MOM_parameter_doc.short
+++ b/ocean_only/external_gwave/MOM_parameter_doc.short
@@ -123,7 +123,8 @@ MAXIMUM_DEPTH = 20.0            !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 ROTATION = "beta"               ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate

--- a/ocean_only/flow_downslope/layer/MOM_parameter_doc.all
+++ b/ocean_only/flow_downslope/layer/MOM_parameter_doc.all
@@ -182,7 +182,7 @@ RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -412,8 +412,8 @@ GFS = 0.98                      !   [m s-2] default = 9.8
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 THICKNESS_CONFIG = "DOME2D"     !
                                 ! A string that determines how the initial layer
@@ -491,7 +491,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 SPONGE = False                  !   [Boolean] default = False
                                 ! If true, sponges may be applied anywhere in the domain.
@@ -510,7 +510,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -586,8 +586,8 @@ LINEAR_DRAG = True              !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -635,7 +635,7 @@ KV = 1.0E-04                    !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -683,7 +683,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -810,7 +810,7 @@ KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
                                 ! The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latidutinally-dependent background
+                                ! The amplitude of a latitudinally-dependent background
                                 ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
@@ -882,7 +882,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -907,7 +907,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
                                 ! If true, and BOUND_BT_CORRECTION is true, use the
                                 ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocites
+                                ! MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
                                 ! If true, adjust the curve fit to the BT_cont type
@@ -935,7 +935,7 @@ NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
                                 ! USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = False     !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -970,7 +970,7 @@ BT_STRONG_DRAG = False          !   [Boolean] default = False
                                 ! barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
                                 ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _vdivided by the depth of
+                                ! using rates set by lin_drag_u & _v divided by the depth of
                                 ! the ocean.  This was introduced to facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
                                 ! If true, limit any velocity components that exceed
@@ -1026,7 +1026,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1109,6 +1109,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1172,7 +1175,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1180,7 +1183,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1388,12 +1392,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1489,7 +1493,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1800.0             !   [s] default = 300.0

--- a/ocean_only/flow_downslope/layer/MOM_parameter_doc.all
+++ b/ocean_only/flow_downslope/layer/MOM_parameter_doc.all
@@ -262,7 +262,8 @@ MINIMUM_DEPTH = 1.0             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -788,7 +789,8 @@ RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -843,7 +845,8 @@ HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
                                 ! stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
@@ -1079,7 +1082,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of

--- a/ocean_only/flow_downslope/layer/MOM_parameter_doc.short
+++ b/ocean_only/flow_downslope/layer/MOM_parameter_doc.short
@@ -116,7 +116,8 @@ MINIMUM_DEPTH = 1.0             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate

--- a/ocean_only/flow_downslope/rho/MOM_parameter_doc.all
+++ b/ocean_only/flow_downslope/rho/MOM_parameter_doc.all
@@ -262,7 +262,8 @@ MINIMUM_DEPTH = 1.0             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -921,7 +922,8 @@ RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -976,7 +978,8 @@ HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
                                 ! stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
@@ -1212,7 +1215,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of

--- a/ocean_only/flow_downslope/rho/MOM_parameter_doc.all
+++ b/ocean_only/flow_downslope/rho/MOM_parameter_doc.all
@@ -182,7 +182,7 @@ RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -414,15 +414,15 @@ REGRIDDING_COORDINATE_MODE = "RHO" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 REGRIDDING_COORDINATE_UNITS = "kg m^-3" ! default = "kg m^-3"
-                                ! Units of the regridding coordinuate.
+                                ! Units of the regridding coordinate.
 INTERPOLATION_SCHEME = "PQM_IH4IH3" ! default = "P1M_H2"
                                 ! This sets the interpolation scheme to use to
                                 ! determine the new grid. These parameters are
@@ -470,7 +470,7 @@ ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
                                 ! RHO target densities for interfaces
 REGRID_COMPRESSIBILITY_FRACTION = 0.0 !   [not defined] default = 0.0
                                 ! When interpolating potential density profiles we can add
-                                ! some artificial compressibility solely to make homogenous
+                                ! some artificial compressibility solely to make homogeneous
                                 ! regions appear stratified.
 MIN_THICKNESS = 0.001           !   [m] default = 0.001
                                 ! When regridding, this is the minimum layer
@@ -505,7 +505,7 @@ REMAPPING_SCHEME = "PQM_IH4IH3" ! default = "PLM"
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
                                 ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicty or an inconsistency is
+                                ! consistency and if non-monotonicity or an inconsistency is
                                 ! detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
                                 ! If true, the results of remapping are checked for
@@ -534,15 +534,15 @@ REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
-                                ! REGRID_FILTER_SHALLOW_DEPTH the filter wieghts adopt a cubic profile.
+                                ! REGRID_FILTER_SHALLOW_DEPTH the filter weights adopt a cubic profile.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 THICKNESS_CONFIG = "DOME2D"     !
                                 ! A string that determines how the initial layer
@@ -620,7 +620,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
@@ -643,7 +643,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -719,8 +719,8 @@ LINEAR_DRAG = True              !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -768,7 +768,7 @@ KV = 1.0E-04                    !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -816,7 +816,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -943,7 +943,7 @@ KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
                                 ! The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latidutinally-dependent background
+                                ! The amplitude of a latitudinally-dependent background
                                 ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
@@ -1015,7 +1015,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -1040,7 +1040,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
                                 ! If true, and BOUND_BT_CORRECTION is true, use the
                                 ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocites
+                                ! MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
                                 ! If true, adjust the curve fit to the BT_cont type
@@ -1068,7 +1068,7 @@ NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
                                 ! USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = False     !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -1103,7 +1103,7 @@ BT_STRONG_DRAG = False          !   [Boolean] default = False
                                 ! barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
                                 ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _vdivided by the depth of
+                                ! using rates set by lin_drag_u & _v divided by the depth of
                                 ! the ocean.  This was introduced to facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
                                 ! If true, limit any velocity components that exceed
@@ -1159,7 +1159,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1242,6 +1242,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1305,7 +1308,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1313,7 +1316,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1521,12 +1525,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1622,7 +1626,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1800.0             !   [s] default = 300.0

--- a/ocean_only/flow_downslope/rho/MOM_parameter_doc.short
+++ b/ocean_only/flow_downslope/rho/MOM_parameter_doc.short
@@ -112,7 +112,8 @@ MINIMUM_DEPTH = 1.0             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate

--- a/ocean_only/flow_downslope/rho/MOM_parameter_doc.short
+++ b/ocean_only/flow_downslope/rho/MOM_parameter_doc.short
@@ -172,8 +172,8 @@ REGRIDDING_COORDINATE_MODE = "RHO" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate

--- a/ocean_only/flow_downslope/sigma/MOM_parameter_doc.all
+++ b/ocean_only/flow_downslope/sigma/MOM_parameter_doc.all
@@ -262,7 +262,8 @@ MINIMUM_DEPTH = 1.0             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -875,7 +876,8 @@ RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -930,7 +932,8 @@ HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
                                 ! stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
@@ -1166,7 +1169,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of

--- a/ocean_only/flow_downslope/sigma/MOM_parameter_doc.all
+++ b/ocean_only/flow_downslope/sigma/MOM_parameter_doc.all
@@ -182,7 +182,7 @@ RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -414,15 +414,15 @@ REGRIDDING_COORDINATE_MODE = "SIGMA" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 REGRIDDING_COORDINATE_UNITS = "Non-dimensional" ! default = "Non-dimensional"
-                                ! Units of the regridding coordinuate.
+                                ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
                                 ! Determines how to specify the coordinate
                                 ! resolution. Valid options are:
@@ -459,7 +459,7 @@ REMAPPING_SCHEME = "PQM_IH4IH3" ! default = "PLM"
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
                                 ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicty or an inconsistency is
+                                ! consistency and if non-monotonicity or an inconsistency is
                                 ! detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
                                 ! If true, the results of remapping are checked for
@@ -488,15 +488,15 @@ REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
-                                ! REGRID_FILTER_SHALLOW_DEPTH the filter wieghts adopt a cubic profile.
+                                ! REGRID_FILTER_SHALLOW_DEPTH the filter weights adopt a cubic profile.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 THICKNESS_CONFIG = "DOME2D"     !
                                 ! A string that determines how the initial layer
@@ -574,7 +574,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
@@ -597,7 +597,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -673,8 +673,8 @@ LINEAR_DRAG = True              !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -722,7 +722,7 @@ KV = 1.0E-04                    !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -770,7 +770,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -897,7 +897,7 @@ KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
                                 ! The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latidutinally-dependent background
+                                ! The amplitude of a latitudinally-dependent background
                                 ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
@@ -969,7 +969,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -994,7 +994,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
                                 ! If true, and BOUND_BT_CORRECTION is true, use the
                                 ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocites
+                                ! MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
                                 ! If true, adjust the curve fit to the BT_cont type
@@ -1022,7 +1022,7 @@ NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
                                 ! USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = False     !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -1057,7 +1057,7 @@ BT_STRONG_DRAG = False          !   [Boolean] default = False
                                 ! barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
                                 ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _vdivided by the depth of
+                                ! using rates set by lin_drag_u & _v divided by the depth of
                                 ! the ocean.  This was introduced to facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
                                 ! If true, limit any velocity components that exceed
@@ -1113,7 +1113,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1196,6 +1196,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1259,7 +1262,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1267,7 +1270,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1475,12 +1479,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1576,7 +1580,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1800.0             !   [s] default = 300.0

--- a/ocean_only/flow_downslope/sigma/MOM_parameter_doc.short
+++ b/ocean_only/flow_downslope/sigma/MOM_parameter_doc.short
@@ -112,7 +112,8 @@ MINIMUM_DEPTH = 1.0             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate

--- a/ocean_only/flow_downslope/sigma/MOM_parameter_doc.short
+++ b/ocean_only/flow_downslope/sigma/MOM_parameter_doc.short
@@ -169,8 +169,8 @@ REGRIDDING_COORDINATE_MODE = "SIGMA" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate

--- a/ocean_only/flow_downslope/z/MOM_parameter_doc.all
+++ b/ocean_only/flow_downslope/z/MOM_parameter_doc.all
@@ -262,7 +262,8 @@ MINIMUM_DEPTH = 1.0             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -875,7 +876,8 @@ RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -930,7 +932,8 @@ HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
                                 ! stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
@@ -1166,7 +1169,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of

--- a/ocean_only/flow_downslope/z/MOM_parameter_doc.all
+++ b/ocean_only/flow_downslope/z/MOM_parameter_doc.all
@@ -182,7 +182,7 @@ RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -414,15 +414,15 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
-                                ! Units of the regridding coordinuate.
+                                ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
                                 ! Determines how to specify the coordinate
                                 ! resolution. Valid options are:
@@ -459,7 +459,7 @@ REMAPPING_SCHEME = "PQM_IH4IH3" ! default = "PLM"
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
                                 ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicty or an inconsistency is
+                                ! consistency and if non-monotonicity or an inconsistency is
                                 ! detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
                                 ! If true, the results of remapping are checked for
@@ -488,15 +488,15 @@ REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
-                                ! REGRID_FILTER_SHALLOW_DEPTH the filter wieghts adopt a cubic profile.
+                                ! REGRID_FILTER_SHALLOW_DEPTH the filter weights adopt a cubic profile.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 THICKNESS_CONFIG = "DOME2D"     !
                                 ! A string that determines how the initial layer
@@ -574,7 +574,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
@@ -597,7 +597,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -673,8 +673,8 @@ LINEAR_DRAG = True              !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -722,7 +722,7 @@ KV = 1.0E-04                    !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -770,7 +770,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -897,7 +897,7 @@ KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
                                 ! The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latidutinally-dependent background
+                                ! The amplitude of a latitudinally-dependent background
                                 ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
@@ -969,7 +969,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -994,7 +994,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
                                 ! If true, and BOUND_BT_CORRECTION is true, use the
                                 ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocites
+                                ! MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
                                 ! If true, adjust the curve fit to the BT_cont type
@@ -1022,7 +1022,7 @@ NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
                                 ! USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = False     !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -1057,7 +1057,7 @@ BT_STRONG_DRAG = False          !   [Boolean] default = False
                                 ! barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
                                 ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _vdivided by the depth of
+                                ! using rates set by lin_drag_u & _v divided by the depth of
                                 ! the ocean.  This was introduced to facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
                                 ! If true, limit any velocity components that exceed
@@ -1113,7 +1113,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1196,6 +1196,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1259,7 +1262,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1267,7 +1270,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1475,12 +1479,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1576,7 +1580,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1800.0             !   [s] default = 300.0

--- a/ocean_only/flow_downslope/z/MOM_parameter_doc.short
+++ b/ocean_only/flow_downslope/z/MOM_parameter_doc.short
@@ -112,7 +112,8 @@ MINIMUM_DEPTH = 1.0             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate

--- a/ocean_only/flow_downslope/z/MOM_parameter_doc.short
+++ b/ocean_only/flow_downslope/z/MOM_parameter_doc.short
@@ -169,8 +169,8 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate

--- a/ocean_only/global_ALE/hycom/MOM_parameter_doc.all
+++ b/ocean_only/global_ALE/hycom/MOM_parameter_doc.all
@@ -117,6 +117,10 @@ BOUND_SALINITY = True           !   [Boolean] default = False
                                 ! If true, limit salinity to being positive. (The sea-ice
                                 ! model may ask for more salt than is available and
                                 ! drive the salinity negative otherwise.)
+MIN_SALINITY = 0.01             !   [PPT] default = 0.01
+                                ! The minimum value of salinity when BOUND_SALINITY=True.
+                                ! The default is 0.01 for backward compatibility but ideally
+                                ! should be 0.
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
                                 ! The heat capacity of sea water, approximated as a
                                 ! constant. This is only used if ENABLE_THERMODYNAMICS is
@@ -197,7 +201,7 @@ RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -423,15 +427,15 @@ REGRIDDING_COORDINATE_MODE = "HYCOM1" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
-                                ! Units of the regridding coordinuate.
+                                ! Units of the regridding coordinate.
 INTERPOLATION_SCHEME = "P1M_H2" ! default = "P1M_H2"
                                 ! This sets the interpolation scheme to use to
                                 ! determine the new grid. These parameters are
@@ -476,10 +480,10 @@ ALE_COORDINATE_CONFIG = "HYBRID:hycom1_50.nc,sigma2,dz" ! default = "UNIFORM"
                                 ! thicknesses (in m). In sigma-coordinate mode, the list
                                 ! is of non-dimensional fractions of the water column.
 !TARGET_DENSITIES = 1010.0, 1016.1289, 1020.843, 1024.821, 1027.0275, 1028.2911, 1029.2795, 1030.1194, 1030.8626, 1031.5364, 1032.1572, 1032.7358, 1033.2798, 1033.7948, 1034.2519, 1034.5828, 1034.8508, 1035.0821, 1035.2886, 1035.4769, 1035.6511, 1035.814, 1035.9675, 1036.1107, 1036.2411, 1036.3615, 1036.4739, 1036.5797, 1036.68, 1036.7755, 1036.8526, 1036.9024, 1036.9418, 1036.9754, 1037.0052, 1037.0323, 1037.0574, 1037.082, 1037.1066, 1037.1312, 1037.1558, 1037.1804, 1037.206, 1037.2337, 1037.2642, 1037.2986, 1037.3389, 1037.3901, 1037.475, 1037.7204, 1038.0 !   [m]
-                                ! HYBRID target densities for itnerfaces
+                                ! HYBRID target densities for interfaces
 REGRID_COMPRESSIBILITY_FRACTION = 0.0 !   [not defined] default = 0.0
                                 ! When interpolating potential density profiles we can add
-                                ! some artificial compressibility solely to make homogenous
+                                ! some artificial compressibility solely to make homogeneous
                                 ! regions appear stratified.
 MIN_THICKNESS = 0.001           !   [m] default = 0.001
                                 ! When regridding, this is the minimum layer
@@ -516,7 +520,7 @@ REMAPPING_SCHEME = "PPM_H4"     ! default = "PLM"
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
                                 ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicty or an inconsistency is
+                                ! consistency and if non-monotonicity or an inconsistency is
                                 ! detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
                                 ! If true, the results of remapping are checked for
@@ -545,15 +549,15 @@ REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
-                                ! REGRID_FILTER_SHALLOW_DEPTH the filter wieghts adopt a cubic profile.
+                                ! REGRID_FILTER_SHALLOW_DEPTH the filter weights adopt a cubic profile.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
@@ -612,7 +616,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
@@ -635,7 +639,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -660,7 +664,7 @@ USE_MEKE = True                 !   [Boolean] default = False
                                 ! If true, turns on the MEKE scheme which calculates
                                 ! a sub-grid mesoscale eddy kinetic energy budget.
 MEKE_DAMPING = 0.0              !   [s-1] default = 0.0
-                                ! The local depth-indepented MEKE dissipation rate.
+                                ! The local depth-independent MEKE dissipation rate.
 MEKE_CD_SCALE = 0.0             !   [nondim] default = 0.0
                                 ! The ratio of the bottom eddy velocity to the column mean
                                 ! eddy velocity, i.e. sqrt(2*MEKE). This should be less than 1
@@ -724,34 +728,34 @@ MEKE_VISCOSITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! represent backscatter from the unresolved eddies.
 MEKE_FIXED_MIXING_LENGTH = 0.0  !   [m] default = 0.0
                                 ! If positive, is a fixed length contribution to the expression
-                                ! for mixing length used in MEKE-derived diffusiviity.
+                                ! for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_DEFORM = 0.0         !   [nondim] default = 0.0
                                 ! If positive, is a coefficient weighting the deformation scale
-                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+                                ! in the expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_RHINES = 0.05        !   [nondim] default = 0.05
                                 ! If positive, is a coefficient weighting the Rhines scale
-                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+                                ! in the expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_EADY = 0.05          !   [nondim] default = 0.05
                                 ! If positive, is a coefficient weighting the Eady length scale
-                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+                                ! in the expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_FRICT = 0.0          !   [nondim] default = 0.0
                                 ! If positive, is a coefficient weighting the frictional arrest scale
-                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+                                ! in the expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_GRID = 0.0           !   [nondim] default = 0.0
                                 ! If positive, is a coefficient weighting the grid-spacing as a scale
-                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+                                ! in the expression for mixing length used in MEKE-derived diffusivity.
 MEKE_COLD_START = False         !   [Boolean] default = False
                                 ! If true, initialize EKE to zero. Otherwise a local equilibrium solution
                                 ! is used as an initial condition for EKE.
 MEKE_BACKSCAT_RO_C = 0.0        !   [nondim] default = 0.0
-                                ! The coefficient in the Rossby number function for scaling the buharmonic
+                                ! The coefficient in the Rossby number function for scaling the biharmonic
                                 ! frictional energy source. Setting to non-zero enables the Rossby number function.
 MEKE_BACKSCAT_RO_POW = 0.0      !   [nondim] default = 0.0
-                                ! The power in the Rossby number function for scaling the biharmomnic
+                                ! The power in the Rossby number function for scaling the biharmonic
                                 ! frictional energy source.
 MEKE_ADVECTION_FACTOR = 0.0     !   [nondim] default = 0.0
                                 ! A scale factor in front of advection of eddy energy. Zero turns advection off.
-                                ! Using unity would be normal but other values could accomodate a mismatch
+                                ! Using unity would be normal but other values could accommodate a mismatch
                                 ! between the advecting barotropic flow and the vertical structure of MEKE.
 MEKE_TOPOGRAPHIC_BETA = 0.0     !   [nondim] default = 0.0
                                 ! A scale factor to determine how much topographic beta is weighed in
@@ -837,7 +841,8 @@ GILL_EQUATORIAL_LD = True       !   [Boolean] default = False
                                 ! If true, uses Gill's definition of the baroclinic
                                 ! equatorial deformation radius, otherwise, if false, use
                                 ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 infront of the beta term in the denominator. Gill'sis the more appropriate definition.
+                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
@@ -854,8 +859,8 @@ LINEAR_DRAG = False             !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -897,7 +902,7 @@ KV = 1.0E-04                    !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -951,7 +956,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -1135,7 +1140,7 @@ KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
                                 ! The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latidutinally-dependent background
+                                ! The amplitude of a latitudinally-dependent background
                                 ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
@@ -1237,7 +1242,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 7200.0 !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -1262,7 +1267,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
                                 ! If true, and BOUND_BT_CORRECTION is true, use the
                                 ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocites
+                                ! MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
                                 ! If true, adjust the curve fit to the BT_cont type
@@ -1290,7 +1295,7 @@ NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
                                 ! USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -1325,7 +1330,7 @@ BT_STRONG_DRAG = False          !   [Boolean] default = False
                                 ! barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
                                 ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _vdivided by the depth of
+                                ! using rates set by lin_drag_u & _v divided by the depth of
                                 ! the ocean.  This was introduced to facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
                                 ! If true, limit any velocity components that exceed
@@ -1381,7 +1386,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1519,6 +1524,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1543,7 +1551,7 @@ INT_TIDE_PROFILE = "STLAURENT_02" ! default = "STLAURENT_02"
                                 ! dissipation with INT_TIDE_DISSIPATION. Valid values are:
                                 !    STLAURENT_02 - Use the St. Laurent et al exponential
                                 !                   decay profile.
-                                !    POLZIN_09 - Use the Polzin WKB-streched algebraic
+                                !    POLZIN_09 - Use the Polzin WKB-stretched algebraic
                                 !                   decay profile.
 LEE_WAVE_DISSIPATION = False    !   [Boolean] default = False
                                 ! If true, use an lee wave driven dissipation scheme to
@@ -1575,9 +1583,10 @@ KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
 UTIDE = 0.0                     !   [m s-1] default = 0.0
                                 ! The constant tidal amplitude used with INT_TIDE_DISSIPATION.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with nINT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with
+                                ! INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source availble to mix
+                                ! The maximum internal tide energy source available to mix
                                 ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
                                 ! If true, read a file (given by TIDEAMP_FILE) containing
@@ -1650,7 +1659,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = True !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1661,7 +1670,8 @@ LOTW_BBL_USE_OMEGA = True       !   [Boolean] default = True
 SIMPLE_TKE_TO_KD = True         !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1818,7 +1828,7 @@ IGNORE_FLUXES_OVER_LAND = False !   [Boolean] default = False
                                 ! be different than the ocean mask to avoid sea ice formation
                                 ! under ice shelves. This flag only works when use_ePBL = True.
 DO_RIVERMIX = False             !   [Boolean] default = False
-                                ! If true, apply additional mixing whereever there is
+                                ! If true, apply additional mixing wherever there is
                                 ! runoff, so that it is mixed down to RIVERMIX_DEPTH
                                 ! if the ocean is that deep.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
@@ -1894,7 +1904,7 @@ EKMAN_SCALE_COEF = 1.0          !   [nondim] default = 1.0
                                 ! decreases the PBL diffusivity.
 USE_MLD_ITERATION = False       !   [Boolean] default = False
                                 ! A logical that specifies whether or not to use the
-                                ! distance to the bottom of the actively turblent boundary
+                                ! distance to the bottom of the actively turbulent boundary
                                 ! layer to help set the EPBL length scale.
 ORIG_MLD_ITERATION = True       !   [Boolean] default = True
                                 ! A logical that specifies whether or not to use the
@@ -1996,12 +2006,12 @@ KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -2196,7 +2206,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 7200.0             !   [s] default = 3600.0

--- a/ocean_only/global_ALE/hycom/MOM_parameter_doc.all
+++ b/ocean_only/global_ALE/hycom/MOM_parameter_doc.all
@@ -267,7 +267,8 @@ MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -749,7 +750,8 @@ MEKE_COLD_START = False         !   [Boolean] default = False
                                 ! is used as an initial condition for EKE.
 MEKE_BACKSCAT_RO_C = 0.0        !   [nondim] default = 0.0
                                 ! The coefficient in the Rossby number function for scaling the biharmonic
-                                ! frictional energy source. Setting to non-zero enables the Rossby number function.
+                                ! frictional energy source. Setting to non-zero enables the Rossby number
+                                ! function.
 MEKE_BACKSCAT_RO_POW = 0.0      !   [nondim] default = 0.0
                                 ! The power in the Rossby number function for scaling the biharmonic
                                 ! frictional energy source.
@@ -1118,7 +1120,8 @@ RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -1206,7 +1209,8 @@ HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
                                 ! stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
@@ -1494,7 +1498,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of

--- a/ocean_only/global_ALE/hycom/MOM_parameter_doc.short
+++ b/ocean_only/global_ALE/hycom/MOM_parameter_doc.short
@@ -186,8 +186,8 @@ REGRIDDING_COORDINATE_MODE = "HYCOM1" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
@@ -215,7 +215,7 @@ ALE_COORDINATE_CONFIG = "HYBRID:hycom1_50.nc,sigma2,dz" ! default = "UNIFORM"
                                 ! thicknesses (in m). In sigma-coordinate mode, the list
                                 ! is of non-dimensional fractions of the water column.
 !TARGET_DENSITIES = 1010.0, 1016.1289, 1020.843, 1024.821, 1027.0275, 1028.2911, 1029.2795, 1030.1194, 1030.8626, 1031.5364, 1032.1572, 1032.7358, 1033.2798, 1033.7948, 1034.2519, 1034.5828, 1034.8508, 1035.0821, 1035.2886, 1035.4769, 1035.6511, 1035.814, 1035.9675, 1036.1107, 1036.2411, 1036.3615, 1036.4739, 1036.5797, 1036.68, 1036.7755, 1036.8526, 1036.9024, 1036.9418, 1036.9754, 1037.0052, 1037.0323, 1037.0574, 1037.082, 1037.1066, 1037.1312, 1037.1558, 1037.1804, 1037.206, 1037.2337, 1037.2642, 1037.2986, 1037.3389, 1037.3901, 1037.475, 1037.7204, 1038.0 !   [m]
-                                ! HYBRID target densities for itnerfaces
+                                ! HYBRID target densities for interfaces
 MAXIMUM_INT_DEPTH_CONFIG = "FNC1:5,12000,1.0,.125" ! default = "NONE"
                                 ! Determines how to specify the maximum interface depths.
                                 ! Valid options are:
@@ -253,8 +253,8 @@ REGRID_TIME_SCALE = 8.64E+04    !   [s] default = 0.0
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
@@ -315,7 +315,8 @@ GILL_EQUATORIAL_LD = True       !   [Boolean] default = False
                                 ! If true, uses Gill's definition of the baroclinic
                                 ! equatorial deformation radius, otherwise, if false, use
                                 ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 infront of the beta term in the denominator. Gill'sis the more appropriate definition.
+                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 CHANNEL_DRAG = True             !   [Boolean] default = False
@@ -419,7 +420,7 @@ MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity
                                 ! components are truncated.
 CFL_TRUNCATE_RAMP_TIME = 7200.0 !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 
 ! === module MOM_PointAccel ===
@@ -431,7 +432,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
                                 ! less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -515,9 +516,10 @@ KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
                                 ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
                                 ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with nINT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with
+                                ! INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source availble to mix
+                                ! The maximum internal tide energy source available to mix
                                 ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
                                 ! If true, read a file (given by TIDEAMP_FILE) containing
@@ -549,7 +551,7 @@ GEOTHERMAL_FILE = "geothermal_heating_cm2g.nc" ! default = ""
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = True !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -557,7 +559,8 @@ USE_LOTW_BBL_DIFFUSIVITY = True !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = True         !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients

--- a/ocean_only/global_ALE/hycom/MOM_parameter_doc.short
+++ b/ocean_only/global_ALE/hycom/MOM_parameter_doc.short
@@ -133,7 +133,8 @@ MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 CHANNEL_CONFIG = "global_1deg"  ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:

--- a/ocean_only/global_ALE/layer/MOM_parameter_doc.all
+++ b/ocean_only/global_ALE/layer/MOM_parameter_doc.all
@@ -265,7 +265,8 @@ MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -621,7 +622,8 @@ MEKE_COLD_START = False         !   [Boolean] default = False
                                 ! is used as an initial condition for EKE.
 MEKE_BACKSCAT_RO_C = 0.0        !   [nondim] default = 0.0
                                 ! The coefficient in the Rossby number function for scaling the biharmonic
-                                ! frictional energy source. Setting to non-zero enables the Rossby number function.
+                                ! frictional energy source. Setting to non-zero enables the Rossby number
+                                ! function.
 MEKE_BACKSCAT_RO_POW = 0.0      !   [nondim] default = 0.0
                                 ! The power in the Rossby number function for scaling the biharmonic
                                 ! frictional energy source.
@@ -987,7 +989,8 @@ RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -1075,7 +1078,8 @@ HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
                                 ! stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
@@ -1325,7 +1329,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of

--- a/ocean_only/global_ALE/layer/MOM_parameter_doc.all
+++ b/ocean_only/global_ALE/layer/MOM_parameter_doc.all
@@ -109,6 +109,10 @@ BOUND_SALINITY = True           !   [Boolean] default = False
                                 ! If true, limit salinity to being positive. (The sea-ice
                                 ! model may ask for more salt than is available and
                                 ! drive the salinity negative otherwise.)
+MIN_SALINITY = 0.01             !   [PPT] default = 0.01
+                                ! The minimum value of salinity when BOUND_SALINITY=True.
+                                ! The default is 0.01 for backward compatibility but ideally
+                                ! should be 0.
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
                                 ! The heat capacity of sea water, approximated as a
                                 ! constant. This is only used if ENABLE_THERMODYNAMICS is
@@ -195,7 +199,7 @@ RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -419,8 +423,8 @@ COORD_VAR = "Layer"             ! default = "Layer"
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
@@ -488,7 +492,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 SPONGE = False                  !   [Boolean] default = False
                                 ! If true, sponges may be applied anywhere in the domain.
@@ -507,7 +511,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -532,7 +536,7 @@ USE_MEKE = True                 !   [Boolean] default = False
                                 ! If true, turns on the MEKE scheme which calculates
                                 ! a sub-grid mesoscale eddy kinetic energy budget.
 MEKE_DAMPING = 0.0              !   [s-1] default = 0.0
-                                ! The local depth-indepented MEKE dissipation rate.
+                                ! The local depth-independent MEKE dissipation rate.
 MEKE_CD_SCALE = 0.0             !   [nondim] default = 0.0
                                 ! The ratio of the bottom eddy velocity to the column mean
                                 ! eddy velocity, i.e. sqrt(2*MEKE). This should be less than 1
@@ -596,34 +600,34 @@ MEKE_VISCOSITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! represent backscatter from the unresolved eddies.
 MEKE_FIXED_MIXING_LENGTH = 0.0  !   [m] default = 0.0
                                 ! If positive, is a fixed length contribution to the expression
-                                ! for mixing length used in MEKE-derived diffusiviity.
+                                ! for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_DEFORM = 0.0         !   [nondim] default = 0.0
                                 ! If positive, is a coefficient weighting the deformation scale
-                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+                                ! in the expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_RHINES = 0.05        !   [nondim] default = 0.05
                                 ! If positive, is a coefficient weighting the Rhines scale
-                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+                                ! in the expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_EADY = 0.05          !   [nondim] default = 0.05
                                 ! If positive, is a coefficient weighting the Eady length scale
-                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+                                ! in the expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_FRICT = 0.0          !   [nondim] default = 0.0
                                 ! If positive, is a coefficient weighting the frictional arrest scale
-                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+                                ! in the expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_GRID = 0.0           !   [nondim] default = 0.0
                                 ! If positive, is a coefficient weighting the grid-spacing as a scale
-                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+                                ! in the expression for mixing length used in MEKE-derived diffusivity.
 MEKE_COLD_START = False         !   [Boolean] default = False
                                 ! If true, initialize EKE to zero. Otherwise a local equilibrium solution
                                 ! is used as an initial condition for EKE.
 MEKE_BACKSCAT_RO_C = 0.0        !   [nondim] default = 0.0
-                                ! The coefficient in the Rossby number function for scaling the buharmonic
+                                ! The coefficient in the Rossby number function for scaling the biharmonic
                                 ! frictional energy source. Setting to non-zero enables the Rossby number function.
 MEKE_BACKSCAT_RO_POW = 0.0      !   [nondim] default = 0.0
-                                ! The power in the Rossby number function for scaling the biharmomnic
+                                ! The power in the Rossby number function for scaling the biharmonic
                                 ! frictional energy source.
 MEKE_ADVECTION_FACTOR = 0.0     !   [nondim] default = 0.0
                                 ! A scale factor in front of advection of eddy energy. Zero turns advection off.
-                                ! Using unity would be normal but other values could accomodate a mismatch
+                                ! Using unity would be normal but other values could accommodate a mismatch
                                 ! between the advecting barotropic flow and the vertical structure of MEKE.
 MEKE_TOPOGRAPHIC_BETA = 0.0     !   [nondim] default = 0.0
                                 ! A scale factor to determine how much topographic beta is weighed in
@@ -706,7 +710,8 @@ GILL_EQUATORIAL_LD = True       !   [Boolean] default = False
                                 ! If true, uses Gill's definition of the baroclinic
                                 ! equatorial deformation radius, otherwise, if false, use
                                 ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 infront of the beta term in the denominator. Gill'sis the more appropriate definition.
+                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
@@ -723,8 +728,8 @@ LINEAR_DRAG = False             !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -766,7 +771,7 @@ KV = 1.0E-04                    !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -820,7 +825,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -1004,7 +1009,7 @@ KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
                                 ! The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latidutinally-dependent background
+                                ! The amplitude of a latitudinally-dependent background
                                 ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
@@ -1098,7 +1103,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -1123,7 +1128,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
                                 ! If true, and BOUND_BT_CORRECTION is true, use the
                                 ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocites
+                                ! MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
                                 ! If true, adjust the curve fit to the BT_cont type
@@ -1151,7 +1156,7 @@ NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
                                 ! USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -1186,7 +1191,7 @@ BT_STRONG_DRAG = False          !   [Boolean] default = False
                                 ! barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
                                 ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _vdivided by the depth of
+                                ! using rates set by lin_drag_u & _v divided by the depth of
                                 ! the ocean.  This was introduced to facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
                                 ! If true, limit any velocity components that exceed
@@ -1242,7 +1247,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1350,6 +1355,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1374,7 +1382,7 @@ INT_TIDE_PROFILE = "STLAURENT_02" ! default = "STLAURENT_02"
                                 ! dissipation with INT_TIDE_DISSIPATION. Valid values are:
                                 !    STLAURENT_02 - Use the St. Laurent et al exponential
                                 !                   decay profile.
-                                !    POLZIN_09 - Use the Polzin WKB-streched algebraic
+                                !    POLZIN_09 - Use the Polzin WKB-stretched algebraic
                                 !                   decay profile.
 LEE_WAVE_DISSIPATION = False    !   [Boolean] default = False
                                 ! If true, use an lee wave driven dissipation scheme to
@@ -1406,9 +1414,10 @@ KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
 UTIDE = 0.0                     !   [m s-1] default = 0.0
                                 ! The constant tidal amplitude used with INT_TIDE_DISSIPATION.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with nINT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with
+                                ! INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source availble to mix
+                                ! The maximum internal tide energy source available to mix
                                 ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
                                 ! If true, read a file (given by TIDEAMP_FILE) containing
@@ -1481,7 +1490,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = True !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1492,7 +1501,8 @@ LOTW_BBL_USE_OMEGA = True       !   [Boolean] default = True
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1725,7 +1735,7 @@ CORRECT_ABSORPTION_DEPTH = True !   [Boolean] default = False
                                 ! heating depth of an exponential profile by moving some
                                 ! of the heating upward in the water column.
 DO_RIVERMIX = True              !   [Boolean] default = False
-                                ! If true, apply additional mixing whereever there is
+                                ! If true, apply additional mixing wherever there is
                                 ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
                                 ! if the ocean is that deep.
 RIVERMIX_DEPTH = 40.0           !   [m] default = 0.0
@@ -1802,12 +1812,12 @@ KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1992,7 +2002,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 7200.0             !   [s] default = 3600.0

--- a/ocean_only/global_ALE/layer/MOM_parameter_doc.short
+++ b/ocean_only/global_ALE/layer/MOM_parameter_doc.short
@@ -130,7 +130,8 @@ MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 CHANNEL_CONFIG = "global_1deg"  ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:

--- a/ocean_only/global_ALE/layer/MOM_parameter_doc.short
+++ b/ocean_only/global_ALE/layer/MOM_parameter_doc.short
@@ -185,8 +185,8 @@ COORD_FILE = "Layer_coord.nc"   !
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
@@ -242,7 +242,8 @@ GILL_EQUATORIAL_LD = True       !   [Boolean] default = False
                                 ! If true, uses Gill's definition of the baroclinic
                                 ! equatorial deformation radius, otherwise, if false, use
                                 ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 infront of the beta term in the denominator. Gill'sis the more appropriate definition.
+                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 CHANNEL_DRAG = True             !   [Boolean] default = False
@@ -347,7 +348,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
                                 ! less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -427,9 +428,10 @@ KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
                                 ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
                                 ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with nINT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with
+                                ! INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source availble to mix
+                                ! The maximum internal tide energy source available to mix
                                 ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
                                 ! If true, read a file (given by TIDEAMP_FILE) containing
@@ -461,7 +463,7 @@ GEOTHERMAL_FILE = "geothermal_heating_cm2g.nc" ! default = ""
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = True !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -531,7 +533,7 @@ CORRECT_ABSORPTION_DEPTH = True !   [Boolean] default = False
                                 ! heating depth of an exponential profile by moving some
                                 ! of the heating upward in the water column.
 DO_RIVERMIX = True              !   [Boolean] default = False
-                                ! If true, apply additional mixing whereever there is
+                                ! If true, apply additional mixing wherever there is
                                 ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
                                 ! if the ocean is that deep.
 RIVERMIX_DEPTH = 40.0           !   [m] default = 0.0

--- a/ocean_only/global_ALE/z/MOM_parameter_doc.all
+++ b/ocean_only/global_ALE/z/MOM_parameter_doc.all
@@ -117,6 +117,10 @@ BOUND_SALINITY = True           !   [Boolean] default = False
                                 ! If true, limit salinity to being positive. (The sea-ice
                                 ! model may ask for more salt than is available and
                                 ! drive the salinity negative otherwise.)
+MIN_SALINITY = 0.01             !   [PPT] default = 0.01
+                                ! The minimum value of salinity when BOUND_SALINITY=True.
+                                ! The default is 0.01 for backward compatibility but ideally
+                                ! should be 0.
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
                                 ! The heat capacity of sea water, approximated as a
                                 ! constant. This is only used if ENABLE_THERMODYNAMICS is
@@ -197,7 +201,7 @@ RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -423,15 +427,15 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
-                                ! Units of the regridding coordinuate.
+                                ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "FILE:vgrid.nc,dz" ! default = "UNIFORM"
                                 ! Determines how to specify the coordinate
                                 ! resolution. Valid options are:
@@ -468,7 +472,7 @@ REMAPPING_SCHEME = "PPM_H4"     ! default = "PLM"
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
                                 ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicty or an inconsistency is
+                                ! consistency and if non-monotonicity or an inconsistency is
                                 ! detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
                                 ! If true, the results of remapping are checked for
@@ -497,15 +501,15 @@ REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
-                                ! REGRID_FILTER_SHALLOW_DEPTH the filter wieghts adopt a cubic profile.
+                                ! REGRID_FILTER_SHALLOW_DEPTH the filter weights adopt a cubic profile.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
@@ -564,7 +568,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
@@ -587,7 +591,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -612,7 +616,7 @@ USE_MEKE = True                 !   [Boolean] default = False
                                 ! If true, turns on the MEKE scheme which calculates
                                 ! a sub-grid mesoscale eddy kinetic energy budget.
 MEKE_DAMPING = 0.0              !   [s-1] default = 0.0
-                                ! The local depth-indepented MEKE dissipation rate.
+                                ! The local depth-independent MEKE dissipation rate.
 MEKE_CD_SCALE = 0.0             !   [nondim] default = 0.0
                                 ! The ratio of the bottom eddy velocity to the column mean
                                 ! eddy velocity, i.e. sqrt(2*MEKE). This should be less than 1
@@ -676,34 +680,34 @@ MEKE_VISCOSITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! represent backscatter from the unresolved eddies.
 MEKE_FIXED_MIXING_LENGTH = 0.0  !   [m] default = 0.0
                                 ! If positive, is a fixed length contribution to the expression
-                                ! for mixing length used in MEKE-derived diffusiviity.
+                                ! for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_DEFORM = 0.0         !   [nondim] default = 0.0
                                 ! If positive, is a coefficient weighting the deformation scale
-                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+                                ! in the expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_RHINES = 0.05        !   [nondim] default = 0.05
                                 ! If positive, is a coefficient weighting the Rhines scale
-                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+                                ! in the expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_EADY = 0.05          !   [nondim] default = 0.05
                                 ! If positive, is a coefficient weighting the Eady length scale
-                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+                                ! in the expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_FRICT = 0.0          !   [nondim] default = 0.0
                                 ! If positive, is a coefficient weighting the frictional arrest scale
-                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+                                ! in the expression for mixing length used in MEKE-derived diffusivity.
 MEKE_ALPHA_GRID = 0.0           !   [nondim] default = 0.0
                                 ! If positive, is a coefficient weighting the grid-spacing as a scale
-                                ! in the expression for mixing length used in MEKE-derived diffusiviity.
+                                ! in the expression for mixing length used in MEKE-derived diffusivity.
 MEKE_COLD_START = False         !   [Boolean] default = False
                                 ! If true, initialize EKE to zero. Otherwise a local equilibrium solution
                                 ! is used as an initial condition for EKE.
 MEKE_BACKSCAT_RO_C = 0.0        !   [nondim] default = 0.0
-                                ! The coefficient in the Rossby number function for scaling the buharmonic
+                                ! The coefficient in the Rossby number function for scaling the biharmonic
                                 ! frictional energy source. Setting to non-zero enables the Rossby number function.
 MEKE_BACKSCAT_RO_POW = 0.0      !   [nondim] default = 0.0
-                                ! The power in the Rossby number function for scaling the biharmomnic
+                                ! The power in the Rossby number function for scaling the biharmonic
                                 ! frictional energy source.
 MEKE_ADVECTION_FACTOR = 0.0     !   [nondim] default = 0.0
                                 ! A scale factor in front of advection of eddy energy. Zero turns advection off.
-                                ! Using unity would be normal but other values could accomodate a mismatch
+                                ! Using unity would be normal but other values could accommodate a mismatch
                                 ! between the advecting barotropic flow and the vertical structure of MEKE.
 MEKE_TOPOGRAPHIC_BETA = 0.0     !   [nondim] default = 0.0
                                 ! A scale factor to determine how much topographic beta is weighed in
@@ -789,7 +793,8 @@ GILL_EQUATORIAL_LD = True       !   [Boolean] default = False
                                 ! If true, uses Gill's definition of the baroclinic
                                 ! equatorial deformation radius, otherwise, if false, use
                                 ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 infront of the beta term in the denominator. Gill'sis the more appropriate definition.
+                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
@@ -806,8 +811,8 @@ LINEAR_DRAG = False             !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -849,7 +854,7 @@ KV = 1.0E-04                    !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -903,7 +908,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -1087,7 +1092,7 @@ KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
                                 ! The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latidutinally-dependent background
+                                ! The amplitude of a latitudinally-dependent background
                                 ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
@@ -1189,7 +1194,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 7200.0 !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -1214,7 +1219,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
                                 ! If true, and BOUND_BT_CORRECTION is true, use the
                                 ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocites
+                                ! MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
                                 ! If true, adjust the curve fit to the BT_cont type
@@ -1242,7 +1247,7 @@ NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
                                 ! USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -1277,7 +1282,7 @@ BT_STRONG_DRAG = False          !   [Boolean] default = False
                                 ! barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
                                 ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _vdivided by the depth of
+                                ! using rates set by lin_drag_u & _v divided by the depth of
                                 ! the ocean.  This was introduced to facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
                                 ! If true, limit any velocity components that exceed
@@ -1333,7 +1338,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1471,6 +1476,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1495,7 +1503,7 @@ INT_TIDE_PROFILE = "STLAURENT_02" ! default = "STLAURENT_02"
                                 ! dissipation with INT_TIDE_DISSIPATION. Valid values are:
                                 !    STLAURENT_02 - Use the St. Laurent et al exponential
                                 !                   decay profile.
-                                !    POLZIN_09 - Use the Polzin WKB-streched algebraic
+                                !    POLZIN_09 - Use the Polzin WKB-stretched algebraic
                                 !                   decay profile.
 LEE_WAVE_DISSIPATION = False    !   [Boolean] default = False
                                 ! If true, use an lee wave driven dissipation scheme to
@@ -1527,9 +1535,10 @@ KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
 UTIDE = 0.0                     !   [m s-1] default = 0.0
                                 ! The constant tidal amplitude used with INT_TIDE_DISSIPATION.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with nINT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with
+                                ! INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source availble to mix
+                                ! The maximum internal tide energy source available to mix
                                 ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
                                 ! If true, read a file (given by TIDEAMP_FILE) containing
@@ -1602,7 +1611,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = True !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1613,7 +1622,8 @@ LOTW_BBL_USE_OMEGA = True       !   [Boolean] default = True
 SIMPLE_TKE_TO_KD = True         !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1770,7 +1780,7 @@ IGNORE_FLUXES_OVER_LAND = False !   [Boolean] default = False
                                 ! be different than the ocean mask to avoid sea ice formation
                                 ! under ice shelves. This flag only works when use_ePBL = True.
 DO_RIVERMIX = False             !   [Boolean] default = False
-                                ! If true, apply additional mixing whereever there is
+                                ! If true, apply additional mixing wherever there is
                                 ! runoff, so that it is mixed down to RIVERMIX_DEPTH
                                 ! if the ocean is that deep.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
@@ -1846,7 +1856,7 @@ EKMAN_SCALE_COEF = 1.0          !   [nondim] default = 1.0
                                 ! decreases the PBL diffusivity.
 USE_MLD_ITERATION = False       !   [Boolean] default = False
                                 ! A logical that specifies whether or not to use the
-                                ! distance to the bottom of the actively turblent boundary
+                                ! distance to the bottom of the actively turbulent boundary
                                 ! layer to help set the EPBL length scale.
 ORIG_MLD_ITERATION = True       !   [Boolean] default = True
                                 ! A logical that specifies whether or not to use the
@@ -1948,12 +1958,12 @@ KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -2148,7 +2158,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 7200.0             !   [s] default = 3600.0

--- a/ocean_only/global_ALE/z/MOM_parameter_doc.all
+++ b/ocean_only/global_ALE/z/MOM_parameter_doc.all
@@ -267,7 +267,8 @@ MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -701,7 +702,8 @@ MEKE_COLD_START = False         !   [Boolean] default = False
                                 ! is used as an initial condition for EKE.
 MEKE_BACKSCAT_RO_C = 0.0        !   [nondim] default = 0.0
                                 ! The coefficient in the Rossby number function for scaling the biharmonic
-                                ! frictional energy source. Setting to non-zero enables the Rossby number function.
+                                ! frictional energy source. Setting to non-zero enables the Rossby number
+                                ! function.
 MEKE_BACKSCAT_RO_POW = 0.0      !   [nondim] default = 0.0
                                 ! The power in the Rossby number function for scaling the biharmonic
                                 ! frictional energy source.
@@ -1070,7 +1072,8 @@ RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -1158,7 +1161,8 @@ HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
                                 ! stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
@@ -1446,7 +1450,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of

--- a/ocean_only/global_ALE/z/MOM_parameter_doc.short
+++ b/ocean_only/global_ALE/z/MOM_parameter_doc.short
@@ -186,8 +186,8 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
@@ -230,8 +230,8 @@ REMAPPING_SCHEME = "PPM_H4"     ! default = "PLM"
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
@@ -289,7 +289,8 @@ GILL_EQUATORIAL_LD = True       !   [Boolean] default = False
                                 ! If true, uses Gill's definition of the baroclinic
                                 ! equatorial deformation radius, otherwise, if false, use
                                 ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 infront of the beta term in the denominator. Gill'sis the more appropriate definition.
+                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 CHANNEL_DRAG = True             !   [Boolean] default = False
@@ -393,7 +394,7 @@ MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity
                                 ! components are truncated.
 CFL_TRUNCATE_RAMP_TIME = 7200.0 !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 
 ! === module MOM_PointAccel ===
@@ -405,7 +406,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
                                 ! less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -489,9 +490,10 @@ KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
                                 ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
                                 ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with nINT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with
+                                ! INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source availble to mix
+                                ! The maximum internal tide energy source available to mix
                                 ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
                                 ! If true, read a file (given by TIDEAMP_FILE) containing
@@ -523,7 +525,7 @@ GEOTHERMAL_FILE = "geothermal_heating_cm2g.nc" ! default = ""
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = True !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -531,7 +533,8 @@ USE_LOTW_BBL_DIFFUSIVITY = True !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = True         !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients

--- a/ocean_only/global_ALE/z/MOM_parameter_doc.short
+++ b/ocean_only/global_ALE/z/MOM_parameter_doc.short
@@ -133,7 +133,8 @@ MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 CHANNEL_CONFIG = "global_1deg"  ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:

--- a/ocean_only/lock_exchange/MOM_parameter_doc.all
+++ b/ocean_only/lock_exchange/MOM_parameter_doc.all
@@ -182,7 +182,7 @@ RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-15              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -399,8 +399,8 @@ DENSITY_RANGE = 5.0             !   [kg m-3] default = 2.0
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 THICKNESS_CONFIG = "lock_exchange" !
                                 ! A string that determines how the initial layer
@@ -486,7 +486,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 SPONGE = False                  !   [Boolean] default = False
                                 ! If true, sponges may be applied anywhere in the domain.
@@ -505,7 +505,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -581,8 +581,8 @@ LINEAR_DRAG = False             !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -630,7 +630,7 @@ KV = 1.0E-04                    !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -678,7 +678,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -805,7 +805,7 @@ KH_VEL_SCALE = 0.0              !   [m s-1] default = 0.0
                                 ! The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latidutinally-dependent background
+                                ! The amplitude of a latitudinally-dependent background
                                 ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
@@ -870,7 +870,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -895,7 +895,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
                                 ! If true, and BOUND_BT_CORRECTION is true, use the
                                 ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocites
+                                ! MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
                                 ! If true, adjust the curve fit to the BT_cont type
@@ -927,7 +927,7 @@ NONLIN_BT_CONT_UPDATE_PERIOD = 1 !   [nondim] default = 1
                                 ! areas, or 0 to update only before the barotropic stepping.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -962,7 +962,7 @@ BT_STRONG_DRAG = False          !   [Boolean] default = False
                                 ! barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
                                 ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _vdivided by the depth of
+                                ! using rates set by lin_drag_u & _v divided by the depth of
                                 ! the ocean.  This was introduced to facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
                                 ! If true, limit any velocity components that exceed
@@ -1018,7 +1018,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1101,6 +1101,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1164,7 +1167,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1172,7 +1175,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1380,12 +1384,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1481,7 +1485,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 5000.0             !   [s] default = 250.0

--- a/ocean_only/lock_exchange/MOM_parameter_doc.all
+++ b/ocean_only/lock_exchange/MOM_parameter_doc.all
@@ -251,7 +251,8 @@ MAXIMUM_DEPTH = 20.0            !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -783,7 +784,8 @@ RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -834,7 +836,8 @@ USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
                                 ! for new experiments.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
@@ -1071,7 +1074,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of

--- a/ocean_only/lock_exchange/MOM_parameter_doc.short
+++ b/ocean_only/lock_exchange/MOM_parameter_doc.short
@@ -116,7 +116,8 @@ MAXIMUM_DEPTH = 20.0            !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 ROTATION = "beta"               ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate

--- a/ocean_only/lock_exchange/MOM_parameter_doc.short
+++ b/ocean_only/lock_exchange/MOM_parameter_doc.short
@@ -52,7 +52,7 @@ RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
                                 ! properties, or with BOUSSINSEQ false to convert some
                                 ! parameters from vertical units of m to kg m-2.
 ANGSTROM = 1.0E-15              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 NK = 21                         !   [nondim]
                                 ! The number of model layers.
 
@@ -308,7 +308,7 @@ NONLINEAR_BT_CONTINUITY = True  !   [Boolean] default = False
                                 ! USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted

--- a/ocean_only/mixed_layer_restrat_2d/MOM_parameter_doc.all
+++ b/ocean_only/mixed_layer_restrat_2d/MOM_parameter_doc.all
@@ -251,7 +251,8 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -864,7 +865,8 @@ RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -919,7 +921,8 @@ HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
                                 ! stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
@@ -1200,7 +1203,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of

--- a/ocean_only/mixed_layer_restrat_2d/MOM_parameter_doc.all
+++ b/ocean_only/mixed_layer_restrat_2d/MOM_parameter_doc.all
@@ -182,7 +182,7 @@ RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -403,15 +403,15 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
-                                ! Units of the regridding coordinuate.
+                                ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
                                 ! Determines how to specify the coordinate
                                 ! resolution. Valid options are:
@@ -448,7 +448,7 @@ REMAPPING_SCHEME = "PPM_IH4"    ! default = "PLM"
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
                                 ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicty or an inconsistency is
+                                ! consistency and if non-monotonicity or an inconsistency is
                                 ! detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
                                 ! If true, the results of remapping are checked for
@@ -477,15 +477,15 @@ REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
-                                ! REGRID_FILTER_SHALLOW_DEPTH the filter wieghts adopt a cubic profile.
+                                ! REGRID_FILTER_SHALLOW_DEPTH the filter weights adopt a cubic profile.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 THICKNESS_CONFIG = "rossby_front" !
                                 ! A string that determines how the initial layer
@@ -563,7 +563,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
@@ -586,7 +586,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -662,8 +662,8 @@ LINEAR_DRAG = True              !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -711,7 +711,7 @@ KV = 1.0E-04                    !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -759,7 +759,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -886,7 +886,7 @@ KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
                                 ! The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latidutinally-dependent background
+                                ! The amplitude of a latitudinally-dependent background
                                 ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
@@ -958,7 +958,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -983,7 +983,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
                                 ! If true, and BOUND_BT_CORRECTION is true, use the
                                 ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocites
+                                ! MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
                                 ! If true, adjust the curve fit to the BT_cont type
@@ -1011,7 +1011,7 @@ NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
                                 ! USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = False     !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -1046,7 +1046,7 @@ BT_STRONG_DRAG = False          !   [Boolean] default = False
                                 ! barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
                                 ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _vdivided by the depth of
+                                ! using rates set by lin_drag_u & _v divided by the depth of
                                 ! the ocean.  This was introduced to facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
                                 ! If true, limit any velocity components that exceed
@@ -1102,7 +1102,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1230,6 +1230,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1293,7 +1296,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1301,7 +1304,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1509,12 +1513,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1610,7 +1614,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 3600.0             !   [s] default = 3600.0

--- a/ocean_only/mixed_layer_restrat_2d/MOM_parameter_doc.short
+++ b/ocean_only/mixed_layer_restrat_2d/MOM_parameter_doc.short
@@ -148,8 +148,8 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate

--- a/ocean_only/mixed_layer_restrat_2d/MOM_parameter_doc.short
+++ b/ocean_only/mixed_layer_restrat_2d/MOM_parameter_doc.short
@@ -98,7 +98,8 @@ MAXIMUM_DEPTH = 400.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate

--- a/ocean_only/nonBous_global/MOM_parameter_doc.all
+++ b/ocean_only/nonBous_global/MOM_parameter_doc.all
@@ -250,7 +250,8 @@ MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -912,7 +913,8 @@ RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -1000,7 +1002,8 @@ HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
                                 ! stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
@@ -1240,7 +1243,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of

--- a/ocean_only/nonBous_global/MOM_parameter_doc.all
+++ b/ocean_only/nonBous_global/MOM_parameter_doc.all
@@ -109,6 +109,10 @@ BOUND_SALINITY = True           !   [Boolean] default = False
                                 ! If true, limit salinity to being positive. (The sea-ice
                                 ! model may ask for more salt than is available and
                                 ! drive the salinity negative otherwise.)
+MIN_SALINITY = 0.01             !   [PPT] default = 0.01
+                                ! The minimum value of salinity when BOUND_SALINITY=True.
+                                ! The default is 0.01 for backward compatibility but ideally
+                                ! should be 0.
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
                                 ! The heat capacity of sea water, approximated as a
                                 ! constant. This is only used if ENABLE_THERMODYNAMICS is
@@ -180,7 +184,7 @@ RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = False              !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_KG_M2 = 1.0                !   [kg m-2 H-1] default = 1.0
                                 ! A constant that translates thicknesses from the model's
                                 ! internal units of thickness to kg m-2.
@@ -404,8 +408,8 @@ COORD_VAR = "Layer"             ! default = "Layer"
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 THICKNESS_CONFIG = "file"       !
                                 ! A string that determines how the initial layer
@@ -489,7 +493,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 SPONGE = False                  !   [Boolean] default = False
                                 ! If true, sponges may be applied anywhere in the domain.
@@ -508,7 +512,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -612,7 +616,8 @@ GILL_EQUATORIAL_LD = False      !   [Boolean] default = False
                                 ! If true, uses Gill's definition of the baroclinic
                                 ! equatorial deformation radius, otherwise, if false, use
                                 ! Pedlosky's definition. These definitions differ by a factor
-                                ! of 2 infront of the beta term in the denominator. Gill'sis the more appropriate definition.
+                                ! of 2 in front of the beta term in the denominator. Gill's
+                                ! is the more appropriate definition.
 
 ! === module MOM_set_visc ===
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
@@ -629,8 +634,8 @@ LINEAR_DRAG = False             !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 0.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -691,7 +696,7 @@ KV = 1.0E-04                    !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -745,7 +750,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -929,7 +934,7 @@ KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
                                 ! The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latidutinally-dependent background
+                                ! The amplitude of a latitudinally-dependent background
                                 ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
@@ -1023,7 +1028,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -1048,7 +1053,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
                                 ! If true, and BOUND_BT_CORRECTION is true, use the
                                 ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocites
+                                ! MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
                                 ! If true, adjust the curve fit to the BT_cont type
@@ -1076,7 +1081,7 @@ NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
                                 ! USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -1111,7 +1116,7 @@ BT_STRONG_DRAG = False          !   [Boolean] default = False
                                 ! barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
                                 ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _vdivided by the depth of
+                                ! using rates set by lin_drag_u & _v divided by the depth of
                                 ! the ocean.  This was introduced to facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
                                 ! If true, limit any velocity components that exceed
@@ -1167,7 +1172,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1265,6 +1270,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1289,7 +1297,7 @@ INT_TIDE_PROFILE = "STLAURENT_02" ! default = "STLAURENT_02"
                                 ! dissipation with INT_TIDE_DISSIPATION. Valid values are:
                                 !    STLAURENT_02 - Use the St. Laurent et al exponential
                                 !                   decay profile.
-                                !    POLZIN_09 - Use the Polzin WKB-streched algebraic
+                                !    POLZIN_09 - Use the Polzin WKB-stretched algebraic
                                 !                   decay profile.
 LEE_WAVE_DISSIPATION = False    !   [Boolean] default = False
                                 ! If true, use an lee wave driven dissipation scheme to
@@ -1321,9 +1329,10 @@ KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
 UTIDE = 0.0                     !   [m s-1] default = 0.0
                                 ! The constant tidal amplitude used with INT_TIDE_DISSIPATION.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with nINT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with
+                                ! INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source availble to mix
+                                ! The maximum internal tide energy source available to mix
                                 ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
                                 ! If true, read a file (given by TIDEAMP_FILE) containing
@@ -1417,7 +1426,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1425,7 +1434,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1647,7 +1657,7 @@ CORRECT_ABSORPTION_DEPTH = True !   [Boolean] default = False
                                 ! heating depth of an exponential profile by moving some
                                 ! of the heating upward in the water column.
 DO_RIVERMIX = True              !   [Boolean] default = False
-                                ! If true, apply additional mixing whereever there is
+                                ! If true, apply additional mixing wherever there is
                                 ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
                                 ! if the ocean is that deep.
 RIVERMIX_DEPTH = 40.0           !   [m] default = 0.0
@@ -1724,12 +1734,12 @@ KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 3.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = True   !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1918,7 +1928,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 7200.0             !   [s] default = 3600.0

--- a/ocean_only/nonBous_global/MOM_parameter_doc.short
+++ b/ocean_only/nonBous_global/MOM_parameter_doc.short
@@ -375,7 +375,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
                                 ! less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -448,9 +448,10 @@ KAPPA_ITIDES = 6.28319E-04      !   [m-1] default = 6.283185307179586E-04
                                 ! A topographic wavenumber used with INT_TIDE_DISSIPATION.
                                 ! The default is 2pi/10 km, as in St.Laurent et al. 2002.
 KAPPA_H2_FACTOR = 0.75          !   [nondim] default = 1.0
-                                ! A scaling factor for the roughness amplitude with nINT_TIDE_DISSIPATION.
+                                ! A scaling factor for the roughness amplitude with
+                                ! INT_TIDE_DISSIPATION.
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
-                                ! The maximum internal tide energy source availble to mix
+                                ! The maximum internal tide energy source available to mix
                                 ! above the bottom boundary layer with INT_TIDE_DISSIPATION.
 READ_TIDEAMP = True             !   [Boolean] default = False
                                 ! If true, read a file (given by TIDEAMP_FILE) containing
@@ -497,7 +498,7 @@ TKE_DECAY = 10.0                !   [nondim] default = 2.5
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -567,7 +568,7 @@ CORRECT_ABSORPTION_DEPTH = True !   [Boolean] default = False
                                 ! heating depth of an exponential profile by moving some
                                 ! of the heating upward in the water column.
 DO_RIVERMIX = True              !   [Boolean] default = False
-                                ! If true, apply additional mixing whereever there is
+                                ! If true, apply additional mixing wherever there is
                                 ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
                                 ! if the ocean is that deep.
 RIVERMIX_DEPTH = 40.0           !   [m] default = 0.0
@@ -599,8 +600,8 @@ KHTR_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 3.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 DIFFUSE_ML_TO_INTERIOR = True   !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface

--- a/ocean_only/nonBous_global/MOM_parameter_doc.short
+++ b/ocean_only/nonBous_global/MOM_parameter_doc.short
@@ -128,7 +128,8 @@ MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 CHANNEL_CONFIG = "global_1deg"  ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:

--- a/ocean_only/resting/layer/MOM_parameter_doc.all
+++ b/ocean_only/resting/layer/MOM_parameter_doc.all
@@ -251,7 +251,8 @@ MAXIMUM_DEPTH = 1000.0          !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -777,7 +778,8 @@ RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -832,7 +834,8 @@ HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
                                 ! stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
@@ -1068,7 +1071,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of

--- a/ocean_only/resting/layer/MOM_parameter_doc.all
+++ b/ocean_only/resting/layer/MOM_parameter_doc.all
@@ -182,7 +182,7 @@ RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -401,8 +401,8 @@ GFS = 0.98                      !   [m s-2] default = 9.8
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 THICKNESS_CONFIG = "uniform"    !
                                 ! A string that determines how the initial layer
@@ -480,7 +480,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 SPONGE = False                  !   [Boolean] default = False
                                 ! If true, sponges may be applied anywhere in the domain.
@@ -499,7 +499,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -575,8 +575,8 @@ LINEAR_DRAG = True              !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -624,7 +624,7 @@ KV = 0.0                        !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -672,7 +672,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -799,7 +799,7 @@ KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
                                 ! The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latidutinally-dependent background
+                                ! The amplitude of a latitudinally-dependent background
                                 ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
@@ -871,7 +871,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -896,7 +896,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
                                 ! If true, and BOUND_BT_CORRECTION is true, use the
                                 ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocites
+                                ! MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
                                 ! If true, adjust the curve fit to the BT_cont type
@@ -924,7 +924,7 @@ NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
                                 ! USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = False     !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -959,7 +959,7 @@ BT_STRONG_DRAG = False          !   [Boolean] default = False
                                 ! barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
                                 ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _vdivided by the depth of
+                                ! using rates set by lin_drag_u & _v divided by the depth of
                                 ! the ocean.  This was introduced to facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
                                 ! If true, limit any velocity components that exceed
@@ -1015,7 +1015,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1098,6 +1098,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1161,7 +1164,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1169,7 +1172,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1377,12 +1381,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1478,7 +1482,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1200.0             !   [s] default = 1200.0

--- a/ocean_only/resting/layer/MOM_parameter_doc.short
+++ b/ocean_only/resting/layer/MOM_parameter_doc.short
@@ -102,7 +102,8 @@ MAXIMUM_DEPTH = 1000.0          !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate

--- a/ocean_only/resting/z/MOM_parameter_doc.all
+++ b/ocean_only/resting/z/MOM_parameter_doc.all
@@ -251,7 +251,8 @@ MAXIMUM_DEPTH = 1000.0          !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -864,7 +865,8 @@ RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -919,7 +921,8 @@ HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
                                 ! stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
@@ -1155,7 +1158,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of

--- a/ocean_only/resting/z/MOM_parameter_doc.all
+++ b/ocean_only/resting/z/MOM_parameter_doc.all
@@ -182,7 +182,7 @@ RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -403,15 +403,15 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
-                                ! Units of the regridding coordinuate.
+                                ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
                                 ! Determines how to specify the coordinate
                                 ! resolution. Valid options are:
@@ -448,7 +448,7 @@ REMAPPING_SCHEME = "PLM"        ! default = "PLM"
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
                                 ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicty or an inconsistency is
+                                ! consistency and if non-monotonicity or an inconsistency is
                                 ! detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
                                 ! If true, the results of remapping are checked for
@@ -477,15 +477,15 @@ REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
-                                ! REGRID_FILTER_SHALLOW_DEPTH the filter wieghts adopt a cubic profile.
+                                ! REGRID_FILTER_SHALLOW_DEPTH the filter weights adopt a cubic profile.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 THICKNESS_CONFIG = "uniform"    !
                                 ! A string that determines how the initial layer
@@ -563,7 +563,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
@@ -586,7 +586,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -662,8 +662,8 @@ LINEAR_DRAG = True              !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -711,7 +711,7 @@ KV = 0.0                        !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -759,7 +759,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -886,7 +886,7 @@ KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
                                 ! The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latidutinally-dependent background
+                                ! The amplitude of a latitudinally-dependent background
                                 ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
@@ -958,7 +958,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -983,7 +983,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
                                 ! If true, and BOUND_BT_CORRECTION is true, use the
                                 ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocites
+                                ! MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
                                 ! If true, adjust the curve fit to the BT_cont type
@@ -1011,7 +1011,7 @@ NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
                                 ! USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = False     !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -1046,7 +1046,7 @@ BT_STRONG_DRAG = False          !   [Boolean] default = False
                                 ! barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
                                 ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _vdivided by the depth of
+                                ! using rates set by lin_drag_u & _v divided by the depth of
                                 ! the ocean.  This was introduced to facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
                                 ! If true, limit any velocity components that exceed
@@ -1102,7 +1102,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1185,6 +1185,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1248,7 +1251,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1256,7 +1259,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1464,12 +1468,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1565,7 +1569,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1200.0             !   [s] default = 1200.0

--- a/ocean_only/resting/z/MOM_parameter_doc.short
+++ b/ocean_only/resting/z/MOM_parameter_doc.short
@@ -155,8 +155,8 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate

--- a/ocean_only/resting/z/MOM_parameter_doc.short
+++ b/ocean_only/resting/z/MOM_parameter_doc.short
@@ -98,7 +98,8 @@ MAXIMUM_DEPTH = 1000.0          !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate

--- a/ocean_only/seamount/layer/MOM_parameter_doc.all
+++ b/ocean_only/seamount/layer/MOM_parameter_doc.all
@@ -262,7 +262,8 @@ MINIMUM_DEPTH = 1.0             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -811,7 +812,8 @@ RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -866,7 +868,8 @@ HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
                                 ! stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
@@ -1102,7 +1105,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of

--- a/ocean_only/seamount/layer/MOM_parameter_doc.all
+++ b/ocean_only/seamount/layer/MOM_parameter_doc.all
@@ -182,7 +182,7 @@ RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -427,8 +427,8 @@ GFS = 9.8                       !   [m s-2] default = 9.8
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 THICKNESS_CONFIG = "seamount"   !
                                 ! A string that determines how the initial layer
@@ -514,7 +514,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 SPONGE = False                  !   [Boolean] default = False
                                 ! If true, sponges may be applied anywhere in the domain.
@@ -533,7 +533,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -609,8 +609,8 @@ LINEAR_DRAG = True              !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -658,7 +658,7 @@ KV = 1.0E-04                    !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -706,7 +706,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -833,7 +833,7 @@ KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
                                 ! The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latidutinally-dependent background
+                                ! The amplitude of a latitudinally-dependent background
                                 ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
@@ -905,7 +905,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -930,7 +930,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
                                 ! If true, and BOUND_BT_CORRECTION is true, use the
                                 ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocites
+                                ! MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
                                 ! If true, adjust the curve fit to the BT_cont type
@@ -958,7 +958,7 @@ NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
                                 ! USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = False     !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -993,7 +993,7 @@ BT_STRONG_DRAG = False          !   [Boolean] default = False
                                 ! barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
                                 ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _vdivided by the depth of
+                                ! using rates set by lin_drag_u & _v divided by the depth of
                                 ! the ocean.  This was introduced to facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
                                 ! If true, limit any velocity components that exceed
@@ -1049,7 +1049,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1132,6 +1132,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1195,7 +1198,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1203,7 +1206,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1411,12 +1415,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1512,7 +1516,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1800.0             !   [s] default = 900.0

--- a/ocean_only/seamount/layer/MOM_parameter_doc.short
+++ b/ocean_only/seamount/layer/MOM_parameter_doc.short
@@ -107,7 +107,8 @@ MINIMUM_DEPTH = 1.0             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate

--- a/ocean_only/seamount/rho/MOM_parameter_doc.all
+++ b/ocean_only/seamount/rho/MOM_parameter_doc.all
@@ -182,7 +182,7 @@ RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -429,15 +429,15 @@ REGRIDDING_COORDINATE_MODE = "RHO" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 REGRIDDING_COORDINATE_UNITS = "kg m^-3" ! default = "kg m^-3"
-                                ! Units of the regridding coordinuate.
+                                ! Units of the regridding coordinate.
 INTERPOLATION_SCHEME = "P3M_IH4IH3" ! default = "P1M_H2"
                                 ! This sets the interpolation scheme to use to
                                 ! determine the new grid. These parameters are
@@ -485,7 +485,7 @@ ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
                                 ! RHO target densities for interfaces
 REGRID_COMPRESSIBILITY_FRACTION = 0.0 !   [not defined] default = 0.0
                                 ! When interpolating potential density profiles we can add
-                                ! some artificial compressibility solely to make homogenous
+                                ! some artificial compressibility solely to make homogeneous
                                 ! regions appear stratified.
 MIN_THICKNESS = 1.0E-09         !   [m] default = 0.001
                                 ! When regridding, this is the minimum layer
@@ -520,7 +520,7 @@ REMAPPING_SCHEME = "PPM_H4"     ! default = "PLM"
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
                                 ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicty or an inconsistency is
+                                ! consistency and if non-monotonicity or an inconsistency is
                                 ! detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
                                 ! If true, the results of remapping are checked for
@@ -549,15 +549,15 @@ REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
-                                ! REGRID_FILTER_SHALLOW_DEPTH the filter wieghts adopt a cubic profile.
+                                ! REGRID_FILTER_SHALLOW_DEPTH the filter weights adopt a cubic profile.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 THICKNESS_CONFIG = "seamount"   !
                                 ! A string that determines how the initial layer
@@ -641,7 +641,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
@@ -664,7 +664,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -740,8 +740,8 @@ LINEAR_DRAG = True              !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -789,7 +789,7 @@ KV = 1.0E-04                    !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -837,7 +837,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -964,7 +964,7 @@ KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
                                 ! The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latidutinally-dependent background
+                                ! The amplitude of a latitudinally-dependent background
                                 ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
@@ -1036,7 +1036,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -1061,7 +1061,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
                                 ! If true, and BOUND_BT_CORRECTION is true, use the
                                 ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocites
+                                ! MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
                                 ! If true, adjust the curve fit to the BT_cont type
@@ -1089,7 +1089,7 @@ NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
                                 ! USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = False     !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -1124,7 +1124,7 @@ BT_STRONG_DRAG = False          !   [Boolean] default = False
                                 ! barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
                                 ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _vdivided by the depth of
+                                ! using rates set by lin_drag_u & _v divided by the depth of
                                 ! the ocean.  This was introduced to facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
                                 ! If true, limit any velocity components that exceed
@@ -1180,7 +1180,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1263,6 +1263,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1326,7 +1329,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1334,7 +1337,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1542,12 +1546,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1643,7 +1647,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1800.0             !   [s] default = 900.0

--- a/ocean_only/seamount/rho/MOM_parameter_doc.all
+++ b/ocean_only/seamount/rho/MOM_parameter_doc.all
@@ -262,7 +262,8 @@ MINIMUM_DEPTH = 1.0             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -942,7 +943,8 @@ RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -997,7 +999,8 @@ HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
                                 ! stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
@@ -1233,7 +1236,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of

--- a/ocean_only/seamount/rho/MOM_parameter_doc.short
+++ b/ocean_only/seamount/rho/MOM_parameter_doc.short
@@ -103,7 +103,8 @@ MINIMUM_DEPTH = 1.0             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate

--- a/ocean_only/seamount/rho/MOM_parameter_doc.short
+++ b/ocean_only/seamount/rho/MOM_parameter_doc.short
@@ -165,8 +165,8 @@ REGRIDDING_COORDINATE_MODE = "RHO" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate

--- a/ocean_only/seamount/sigma/MOM_parameter_doc.all
+++ b/ocean_only/seamount/sigma/MOM_parameter_doc.all
@@ -262,7 +262,8 @@ MINIMUM_DEPTH = 1.0             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -893,7 +894,8 @@ RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -948,7 +950,8 @@ HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
                                 ! stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
@@ -1184,7 +1187,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of

--- a/ocean_only/seamount/sigma/MOM_parameter_doc.all
+++ b/ocean_only/seamount/sigma/MOM_parameter_doc.all
@@ -182,7 +182,7 @@ RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -429,15 +429,15 @@ REGRIDDING_COORDINATE_MODE = "SIGMA" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 REGRIDDING_COORDINATE_UNITS = "Non-dimensional" ! default = "Non-dimensional"
-                                ! Units of the regridding coordinuate.
+                                ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
                                 ! Determines how to specify the coordinate
                                 ! resolution. Valid options are:
@@ -474,7 +474,7 @@ REMAPPING_SCHEME = "PPM_IH4"    ! default = "PLM"
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
                                 ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicty or an inconsistency is
+                                ! consistency and if non-monotonicity or an inconsistency is
                                 ! detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
                                 ! If true, the results of remapping are checked for
@@ -503,15 +503,15 @@ REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
-                                ! REGRID_FILTER_SHALLOW_DEPTH the filter wieghts adopt a cubic profile.
+                                ! REGRID_FILTER_SHALLOW_DEPTH the filter weights adopt a cubic profile.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 THICKNESS_CONFIG = "seamount"   !
                                 ! A string that determines how the initial layer
@@ -592,7 +592,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
@@ -615,7 +615,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -691,8 +691,8 @@ LINEAR_DRAG = True              !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -740,7 +740,7 @@ KV = 1.0E-04                    !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -788,7 +788,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -915,7 +915,7 @@ KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
                                 ! The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latidutinally-dependent background
+                                ! The amplitude of a latitudinally-dependent background
                                 ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
@@ -987,7 +987,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -1012,7 +1012,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
                                 ! If true, and BOUND_BT_CORRECTION is true, use the
                                 ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocites
+                                ! MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
                                 ! If true, adjust the curve fit to the BT_cont type
@@ -1040,7 +1040,7 @@ NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
                                 ! USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = False     !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -1075,7 +1075,7 @@ BT_STRONG_DRAG = False          !   [Boolean] default = False
                                 ! barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
                                 ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _vdivided by the depth of
+                                ! using rates set by lin_drag_u & _v divided by the depth of
                                 ! the ocean.  This was introduced to facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
                                 ! If true, limit any velocity components that exceed
@@ -1131,7 +1131,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1214,6 +1214,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1277,7 +1280,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1285,7 +1288,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1493,12 +1497,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1594,7 +1598,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1800.0             !   [s] default = 900.0

--- a/ocean_only/seamount/sigma/MOM_parameter_doc.short
+++ b/ocean_only/seamount/sigma/MOM_parameter_doc.short
@@ -165,8 +165,8 @@ REGRIDDING_COORDINATE_MODE = "SIGMA" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate

--- a/ocean_only/seamount/sigma/MOM_parameter_doc.short
+++ b/ocean_only/seamount/sigma/MOM_parameter_doc.short
@@ -103,7 +103,8 @@ MINIMUM_DEPTH = 1.0             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate

--- a/ocean_only/seamount/z/MOM_parameter_doc.all
+++ b/ocean_only/seamount/z/MOM_parameter_doc.all
@@ -262,7 +262,8 @@ MINIMUM_DEPTH = 1.0             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -893,7 +894,8 @@ RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -948,7 +950,8 @@ HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
                                 ! stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
@@ -1184,7 +1187,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of

--- a/ocean_only/seamount/z/MOM_parameter_doc.all
+++ b/ocean_only/seamount/z/MOM_parameter_doc.all
@@ -182,7 +182,7 @@ RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -429,15 +429,15 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
-                                ! Units of the regridding coordinuate.
+                                ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
                                 ! Determines how to specify the coordinate
                                 ! resolution. Valid options are:
@@ -474,7 +474,7 @@ REMAPPING_SCHEME = "PPM_IH4"    ! default = "PLM"
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
                                 ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicty or an inconsistency is
+                                ! consistency and if non-monotonicity or an inconsistency is
                                 ! detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
                                 ! If true, the results of remapping are checked for
@@ -503,15 +503,15 @@ REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
-                                ! REGRID_FILTER_SHALLOW_DEPTH the filter wieghts adopt a cubic profile.
+                                ! REGRID_FILTER_SHALLOW_DEPTH the filter weights adopt a cubic profile.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 THICKNESS_CONFIG = "seamount"   !
                                 ! A string that determines how the initial layer
@@ -592,7 +592,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
@@ -615,7 +615,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -691,8 +691,8 @@ LINEAR_DRAG = True              !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -740,7 +740,7 @@ KV = 1.0E-04                    !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -788,7 +788,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -915,7 +915,7 @@ KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
                                 ! The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latidutinally-dependent background
+                                ! The amplitude of a latitudinally-dependent background
                                 ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
@@ -987,7 +987,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -1012,7 +1012,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
                                 ! If true, and BOUND_BT_CORRECTION is true, use the
                                 ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocites
+                                ! MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
                                 ! If true, adjust the curve fit to the BT_cont type
@@ -1040,7 +1040,7 @@ NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
                                 ! USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = False     !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -1075,7 +1075,7 @@ BT_STRONG_DRAG = False          !   [Boolean] default = False
                                 ! barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
                                 ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _vdivided by the depth of
+                                ! using rates set by lin_drag_u & _v divided by the depth of
                                 ! the ocean.  This was introduced to facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
                                 ! If true, limit any velocity components that exceed
@@ -1131,7 +1131,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1214,6 +1214,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1277,7 +1280,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1285,7 +1288,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1493,12 +1497,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1594,7 +1598,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 1800.0             !   [s] default = 900.0

--- a/ocean_only/seamount/z/MOM_parameter_doc.short
+++ b/ocean_only/seamount/z/MOM_parameter_doc.short
@@ -165,8 +165,8 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate

--- a/ocean_only/seamount/z/MOM_parameter_doc.short
+++ b/ocean_only/seamount/z/MOM_parameter_doc.short
@@ -103,7 +103,8 @@ MINIMUM_DEPTH = 1.0             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate

--- a/ocean_only/single_column/BML/MOM_parameter_doc.all
+++ b/ocean_only/single_column/BML/MOM_parameter_doc.all
@@ -176,7 +176,7 @@ RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -383,8 +383,8 @@ COORD_VAR = "Layer"             ! default = "Layer"
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
@@ -452,7 +452,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 SPONGE = False                  !   [Boolean] default = False
                                 ! If true, sponges may be applied anywhere in the domain.
@@ -471,7 +471,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -547,8 +547,8 @@ LINEAR_DRAG = False             !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 0.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -596,7 +596,7 @@ KV = 1.0E-04                    !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -622,7 +622,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -778,7 +778,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -810,7 +810,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -899,6 +899,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -987,7 +990,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -995,7 +998,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1210,7 +1214,7 @@ CORRECT_ABSORPTION_DEPTH = True !   [Boolean] default = False
                                 ! heating depth of an exponential profile by moving some
                                 ! of the heating upward in the water column.
 DO_RIVERMIX = False             !   [Boolean] default = False
-                                ! If true, apply additional mixing whereever there is
+                                ! If true, apply additional mixing wherever there is
                                 ! runoff, so that it is mixed down to RIVERMIX_DEPTH,
                                 ! if the ocean is that deep.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
@@ -1277,12 +1281,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1381,7 +1385,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 3600.0             !   [s] default = 3600.0

--- a/ocean_only/single_column/BML/MOM_parameter_doc.all
+++ b/ocean_only/single_column/BML/MOM_parameter_doc.all
@@ -245,7 +245,8 @@ MAXIMUM_DEPTH = 6000.0          !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -727,7 +728,8 @@ RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -750,7 +752,8 @@ USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
                                 ! for new experiments.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
@@ -869,7 +872,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of

--- a/ocean_only/single_column/BML/MOM_parameter_doc.short
+++ b/ocean_only/single_column/BML/MOM_parameter_doc.short
@@ -148,8 +148,8 @@ COORD_FILE = "../isopyc_coords.nc" !
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===

--- a/ocean_only/single_column/BML/MOM_parameter_doc.short
+++ b/ocean_only/single_column/BML/MOM_parameter_doc.short
@@ -102,7 +102,8 @@ MAXIMUM_DEPTH = 6000.0          !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate

--- a/ocean_only/single_column/EPBL/MOM_parameter_doc.all
+++ b/ocean_only/single_column/EPBL/MOM_parameter_doc.all
@@ -247,7 +247,8 @@ MAXIMUM_DEPTH = 6000.0          !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -802,7 +803,8 @@ RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -825,7 +827,8 @@ USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
                                 ! for new experiments.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
@@ -949,7 +952,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of
@@ -1060,21 +1064,25 @@ MATCH_TECHNIQUE = "SimpleShapes" ! default = "SimpleShapes"
                                 ! CVMix method to set profile function for diffusivity and NLT,
                                 ! as well as matching across OBL base. Allowed values are:
                                 !    SimpleShapes      = sigma*(1-sigma)^2 for both diffusivity and NLT
-                                !    MatchGradient     = sigma*(1-sigma)^2 for NLT; diffusivity profile from matching
+                                !    MatchGradient     = sigma*(1-sigma)^2 for NLT; diffusivity profile from
+                                !      matching
                                 !    MatchBoth         = match gradient for both diffusivity and NLT
                                 !    ParabolicNonLocal = sigma*(1-sigma)^2 for diffusivity; (1-sigma)^2 for NLT
 KPP_ZERO_DIFFUSIVITY = False    !   [Boolean] default = False
                                 ! If True, zeroes the KPP diffusivity and viscosity; for testing purpose.
 KPP_IS_ADDITIVE = True          !   [Boolean] default = True
-                                ! If true, adds KPP diffusivity to diffusivity from other schemes.If false, KPP is the only diffusivity wherever KPP is non-zero.
+                                ! If true, adds KPP diffusivity to diffusivity from other schemes.
+                                ! If false, KPP is the only diffusivity wherever KPP is non-zero.
 KPP_SHORTWAVE_METHOD = "MXL_SW" ! default = "MXL_SW"
-                                ! Determines contribution of shortwave radiation to KPP surface buoyancy flux.  Options include:
+                                ! Determines contribution of shortwave radiation to KPP surface
+                                ! buoyancy flux.  Options include:
                                 !   ALL_SW: use total shortwave radiation
-                                !   MXL_SW:  use shortwave radiation absorbed by mixing layer
-                                !   LV1_SW:  use shortwave radiation absorbed by top model layer
+                                !   MXL_SW: use shortwave radiation absorbed by mixing layer
+                                !   LV1_SW: use shortwave radiation absorbed by top model layer
 CVMix_ZERO_H_WORK_AROUND = 0.0  !   [m] default = 0.0
                                 ! A minimum thickness used to avoid division by small numbers in the vicinity
-                                ! of vanished layers. This is independent of MIN_THICKNESS used in other parts of MOM.
+                                ! of vanished layers. This is independent of MIN_THICKNESS used in other parts
+                                ! of MOM.
 USE_KPP_LT_K = False            ! default = False
                                 ! Flag for Langmuir turbulence enhancement of turbulentmixing coefficient.
 STOKES_MIXING = False           ! default = False

--- a/ocean_only/single_column/EPBL/MOM_parameter_doc.all
+++ b/ocean_only/single_column/EPBL/MOM_parameter_doc.all
@@ -178,7 +178,7 @@ RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -382,15 +382,15 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
-                                ! Units of the regridding coordinuate.
+                                ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "FILE:./INPUT/vgrid_cm4.nc,dz" ! default = "UNIFORM"
                                 ! Determines how to specify the coordinate
                                 ! resolution. Valid options are:
@@ -427,7 +427,7 @@ REMAPPING_SCHEME = "PLM"        ! default = "PLM"
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
                                 ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicty or an inconsistency is
+                                ! consistency and if non-monotonicity or an inconsistency is
                                 ! detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
                                 ! If true, the results of remapping are checked for
@@ -456,15 +456,15 @@ REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
-                                ! REGRID_FILTER_SHALLOW_DEPTH the filter wieghts adopt a cubic profile.
+                                ! REGRID_FILTER_SHALLOW_DEPTH the filter weights adopt a cubic profile.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
@@ -523,7 +523,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
@@ -546,7 +546,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -622,8 +622,8 @@ LINEAR_DRAG = False             !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -671,7 +671,7 @@ KV = 1.0E-04                    !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -697,7 +697,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -861,7 +861,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -893,7 +893,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -979,6 +979,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1160,7 +1163,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1168,7 +1171,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1321,7 +1325,7 @@ IGNORE_FLUXES_OVER_LAND = False !   [Boolean] default = False
                                 ! be different than the ocean mask to avoid sea ice formation
                                 ! under ice shelves. This flag only works when use_ePBL = True.
 DO_RIVERMIX = False             !   [Boolean] default = False
-                                ! If true, apply additional mixing whereever there is
+                                ! If true, apply additional mixing wherever there is
                                 ! runoff, so that it is mixed down to RIVERMIX_DEPTH
                                 ! if the ocean is that deep.
 USE_RIVER_HEAT_CONTENT = False  !   [Boolean] default = False
@@ -1386,7 +1390,7 @@ EKMAN_SCALE_COEF = 1.0          !   [nondim] default = 1.0
                                 ! decreases the PBL diffusivity.
 USE_MLD_ITERATION = False       !   [Boolean] default = False
                                 ! A logical that specifies whether or not to use the
-                                ! distance to the bottom of the actively turblent boundary
+                                ! distance to the bottom of the actively turbulent boundary
                                 ! layer to help set the EPBL length scale.
 ORIG_MLD_ITERATION = True       !   [Boolean] default = True
                                 ! A logical that specifies whether or not to use the
@@ -1488,12 +1492,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1592,7 +1596,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 3600.0             !   [s] default = 3600.0

--- a/ocean_only/single_column/EPBL/MOM_parameter_doc.short
+++ b/ocean_only/single_column/EPBL/MOM_parameter_doc.short
@@ -105,7 +105,8 @@ MAXIMUM_DEPTH = 6000.0          !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate

--- a/ocean_only/single_column/EPBL/MOM_parameter_doc.short
+++ b/ocean_only/single_column/EPBL/MOM_parameter_doc.short
@@ -147,8 +147,8 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
@@ -181,8 +181,8 @@ ALE_COORDINATE_CONFIG = "FILE:./INPUT/vgrid_cm4.nc,dz" ! default = "UNIFORM"
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===

--- a/ocean_only/single_column/KPP/MOM_parameter_doc.all
+++ b/ocean_only/single_column/KPP/MOM_parameter_doc.all
@@ -247,7 +247,8 @@ MAXIMUM_DEPTH = 6000.0          !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -802,7 +803,8 @@ RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -825,7 +827,8 @@ USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
                                 ! for new experiments.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
@@ -949,7 +952,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of
@@ -1060,21 +1064,25 @@ MATCH_TECHNIQUE = "SimpleShapes" ! default = "SimpleShapes"
                                 ! CVMix method to set profile function for diffusivity and NLT,
                                 ! as well as matching across OBL base. Allowed values are:
                                 !    SimpleShapes      = sigma*(1-sigma)^2 for both diffusivity and NLT
-                                !    MatchGradient     = sigma*(1-sigma)^2 for NLT; diffusivity profile from matching
+                                !    MatchGradient     = sigma*(1-sigma)^2 for NLT; diffusivity profile from
+                                !      matching
                                 !    MatchBoth         = match gradient for both diffusivity and NLT
                                 !    ParabolicNonLocal = sigma*(1-sigma)^2 for diffusivity; (1-sigma)^2 for NLT
 KPP_ZERO_DIFFUSIVITY = False    !   [Boolean] default = False
                                 ! If True, zeroes the KPP diffusivity and viscosity; for testing purpose.
 KPP_IS_ADDITIVE = True          !   [Boolean] default = True
-                                ! If true, adds KPP diffusivity to diffusivity from other schemes.If false, KPP is the only diffusivity wherever KPP is non-zero.
+                                ! If true, adds KPP diffusivity to diffusivity from other schemes.
+                                ! If false, KPP is the only diffusivity wherever KPP is non-zero.
 KPP_SHORTWAVE_METHOD = "MXL_SW" ! default = "MXL_SW"
-                                ! Determines contribution of shortwave radiation to KPP surface buoyancy flux.  Options include:
+                                ! Determines contribution of shortwave radiation to KPP surface
+                                ! buoyancy flux.  Options include:
                                 !   ALL_SW: use total shortwave radiation
-                                !   MXL_SW:  use shortwave radiation absorbed by mixing layer
-                                !   LV1_SW:  use shortwave radiation absorbed by top model layer
+                                !   MXL_SW: use shortwave radiation absorbed by mixing layer
+                                !   LV1_SW: use shortwave radiation absorbed by top model layer
 CVMix_ZERO_H_WORK_AROUND = 0.0  !   [m] default = 0.0
                                 ! A minimum thickness used to avoid division by small numbers in the vicinity
-                                ! of vanished layers. This is independent of MIN_THICKNESS used in other parts of MOM.
+                                ! of vanished layers. This is independent of MIN_THICKNESS used in other parts
+                                ! of MOM.
 USE_KPP_LT_K = False            ! default = False
                                 ! Flag for Langmuir turbulence enhancement of turbulentmixing coefficient.
 STOKES_MIXING = False           ! default = False

--- a/ocean_only/single_column/KPP/MOM_parameter_doc.all
+++ b/ocean_only/single_column/KPP/MOM_parameter_doc.all
@@ -178,7 +178,7 @@ RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -382,15 +382,15 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
-                                ! Units of the regridding coordinuate.
+                                ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "FILE:./INPUT/vgrid_cm4.nc,dz" ! default = "UNIFORM"
                                 ! Determines how to specify the coordinate
                                 ! resolution. Valid options are:
@@ -427,7 +427,7 @@ REMAPPING_SCHEME = "PLM"        ! default = "PLM"
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
                                 ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicty or an inconsistency is
+                                ! consistency and if non-monotonicity or an inconsistency is
                                 ! detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
                                 ! If true, the results of remapping are checked for
@@ -456,15 +456,15 @@ REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
-                                ! REGRID_FILTER_SHALLOW_DEPTH the filter wieghts adopt a cubic profile.
+                                ! REGRID_FILTER_SHALLOW_DEPTH the filter weights adopt a cubic profile.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===
@@ -523,7 +523,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
@@ -546,7 +546,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -622,8 +622,8 @@ LINEAR_DRAG = False             !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -671,7 +671,7 @@ KV = 1.0E-04                    !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -697,7 +697,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -861,7 +861,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -893,7 +893,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -979,6 +979,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1160,7 +1163,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1168,7 +1171,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1381,12 +1385,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1485,7 +1489,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 3600.0             !   [s] default = 3600.0

--- a/ocean_only/single_column/KPP/MOM_parameter_doc.short
+++ b/ocean_only/single_column/KPP/MOM_parameter_doc.short
@@ -105,7 +105,8 @@ MAXIMUM_DEPTH = 6000.0          !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate

--- a/ocean_only/single_column/KPP/MOM_parameter_doc.short
+++ b/ocean_only/single_column/KPP/MOM_parameter_doc.short
@@ -147,8 +147,8 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
@@ -181,8 +181,8 @@ ALE_COORDINATE_CONFIG = "FILE:./INPUT/vgrid_cm4.nc,dz" ! default = "UNIFORM"
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 
 ! === module MOM_initialize_layers_from_Z ===

--- a/ocean_only/sloshing/layer/MOM_parameter_doc.all
+++ b/ocean_only/sloshing/layer/MOM_parameter_doc.all
@@ -182,7 +182,7 @@ RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -404,8 +404,8 @@ GFS = 0.98                      !   [m s-2] default = 9.8
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 THICKNESS_CONFIG = "sloshing"   !
                                 ! A string that determines how the initial layer
@@ -490,7 +490,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 SPONGE = False                  !   [Boolean] default = False
                                 ! If true, sponges may be applied anywhere in the domain.
@@ -509,7 +509,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -585,8 +585,8 @@ LINEAR_DRAG = True              !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -634,7 +634,7 @@ KV = 0.0                        !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -682,7 +682,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -809,7 +809,7 @@ KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
                                 ! The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latidutinally-dependent background
+                                ! The amplitude of a latitudinally-dependent background
                                 ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = True           !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
@@ -884,7 +884,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -909,7 +909,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
                                 ! If true, and BOUND_BT_CORRECTION is true, use the
                                 ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocites
+                                ! MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
                                 ! If true, adjust the curve fit to the BT_cont type
@@ -937,7 +937,7 @@ NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
                                 ! USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = False     !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -972,7 +972,7 @@ BT_STRONG_DRAG = False          !   [Boolean] default = False
                                 ! barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
                                 ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _vdivided by the depth of
+                                ! using rates set by lin_drag_u & _v divided by the depth of
                                 ! the ocean.  This was introduced to facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
                                 ! If true, limit any velocity components that exceed
@@ -1028,7 +1028,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1111,6 +1111,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1174,7 +1177,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1182,7 +1185,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1390,12 +1394,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1491,7 +1495,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 3600.0             !   [s] default = 900.0

--- a/ocean_only/sloshing/layer/MOM_parameter_doc.all
+++ b/ocean_only/sloshing/layer/MOM_parameter_doc.all
@@ -254,7 +254,8 @@ MINIMUM_DEPTH = 1.0             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -787,7 +788,8 @@ RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -845,7 +847,8 @@ HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
                                 ! stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
@@ -1081,7 +1084,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of

--- a/ocean_only/sloshing/layer/MOM_parameter_doc.short
+++ b/ocean_only/sloshing/layer/MOM_parameter_doc.short
@@ -105,7 +105,8 @@ MINIMUM_DEPTH = 1.0             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate

--- a/ocean_only/sloshing/rho/MOM_parameter_doc.all
+++ b/ocean_only/sloshing/rho/MOM_parameter_doc.all
@@ -254,7 +254,8 @@ MINIMUM_DEPTH = 1.0             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -920,7 +921,8 @@ RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -978,7 +980,8 @@ HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
                                 ! stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
@@ -1214,7 +1217,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of

--- a/ocean_only/sloshing/rho/MOM_parameter_doc.all
+++ b/ocean_only/sloshing/rho/MOM_parameter_doc.all
@@ -182,7 +182,7 @@ RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -406,15 +406,15 @@ REGRIDDING_COORDINATE_MODE = "RHO" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 REGRIDDING_COORDINATE_UNITS = "kg m^-3" ! default = "kg m^-3"
-                                ! Units of the regridding coordinuate.
+                                ! Units of the regridding coordinate.
 INTERPOLATION_SCHEME = "PQM_IH4IH3" ! default = "P1M_H2"
                                 ! This sets the interpolation scheme to use to
                                 ! determine the new grid. These parameters are
@@ -462,7 +462,7 @@ ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
                                 ! RHO target densities for interfaces
 REGRID_COMPRESSIBILITY_FRACTION = 0.0 !   [not defined] default = 0.0
                                 ! When interpolating potential density profiles we can add
-                                ! some artificial compressibility solely to make homogenous
+                                ! some artificial compressibility solely to make homogeneous
                                 ! regions appear stratified.
 MIN_THICKNESS = 0.001           !   [m] default = 0.001
                                 ! When regridding, this is the minimum layer
@@ -497,7 +497,7 @@ REMAPPING_SCHEME = "PQM_IH4IH3" ! default = "PLM"
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
                                 ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicty or an inconsistency is
+                                ! consistency and if non-monotonicity or an inconsistency is
                                 ! detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
                                 ! If true, the results of remapping are checked for
@@ -526,15 +526,15 @@ REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
-                                ! REGRID_FILTER_SHALLOW_DEPTH the filter wieghts adopt a cubic profile.
+                                ! REGRID_FILTER_SHALLOW_DEPTH the filter weights adopt a cubic profile.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 THICKNESS_CONFIG = "sloshing"   !
                                 ! A string that determines how the initial layer
@@ -619,7 +619,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
@@ -642,7 +642,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -718,8 +718,8 @@ LINEAR_DRAG = True              !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -767,7 +767,7 @@ KV = 0.0                        !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -815,7 +815,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -942,7 +942,7 @@ KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
                                 ! The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latidutinally-dependent background
+                                ! The amplitude of a latitudinally-dependent background
                                 ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = True           !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
@@ -1017,7 +1017,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -1042,7 +1042,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
                                 ! If true, and BOUND_BT_CORRECTION is true, use the
                                 ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocites
+                                ! MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
                                 ! If true, adjust the curve fit to the BT_cont type
@@ -1070,7 +1070,7 @@ NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
                                 ! USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = False     !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -1105,7 +1105,7 @@ BT_STRONG_DRAG = False          !   [Boolean] default = False
                                 ! barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
                                 ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _vdivided by the depth of
+                                ! using rates set by lin_drag_u & _v divided by the depth of
                                 ! the ocean.  This was introduced to facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
                                 ! If true, limit any velocity components that exceed
@@ -1161,7 +1161,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1244,6 +1244,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1307,7 +1310,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1315,7 +1318,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1523,12 +1527,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1624,7 +1628,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 3600.0             !   [s] default = 900.0

--- a/ocean_only/sloshing/rho/MOM_parameter_doc.short
+++ b/ocean_only/sloshing/rho/MOM_parameter_doc.short
@@ -101,7 +101,8 @@ MINIMUM_DEPTH = 1.0             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate

--- a/ocean_only/sloshing/rho/MOM_parameter_doc.short
+++ b/ocean_only/sloshing/rho/MOM_parameter_doc.short
@@ -158,8 +158,8 @@ REGRIDDING_COORDINATE_MODE = "RHO" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate

--- a/ocean_only/sloshing/z/MOM_parameter_doc.all
+++ b/ocean_only/sloshing/z/MOM_parameter_doc.all
@@ -182,7 +182,7 @@ RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -406,15 +406,15 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
-                                ! Units of the regridding coordinuate.
+                                ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
                                 ! Determines how to specify the coordinate
                                 ! resolution. Valid options are:
@@ -451,7 +451,7 @@ REMAPPING_SCHEME = "PQM_IH4IH3" ! default = "PLM"
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
                                 ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicty or an inconsistency is
+                                ! consistency and if non-monotonicity or an inconsistency is
                                 ! detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
                                 ! If true, the results of remapping are checked for
@@ -480,15 +480,15 @@ REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
-                                ! REGRID_FILTER_SHALLOW_DEPTH the filter wieghts adopt a cubic profile.
+                                ! REGRID_FILTER_SHALLOW_DEPTH the filter weights adopt a cubic profile.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 THICKNESS_CONFIG = "sloshing"   !
                                 ! A string that determines how the initial layer
@@ -573,7 +573,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
@@ -596,7 +596,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -672,8 +672,8 @@ LINEAR_DRAG = True              !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -721,7 +721,7 @@ KV = 0.0                        !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -769,7 +769,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -896,7 +896,7 @@ KH_VEL_SCALE = 0.003            !   [m s-1] default = 0.0
                                 ! The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latidutinally-dependent background
+                                ! The amplitude of a latitudinally-dependent background
                                 ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = True           !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
@@ -971,7 +971,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -996,7 +996,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
                                 ! If true, and BOUND_BT_CORRECTION is true, use the
                                 ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocites
+                                ! MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
                                 ! If true, adjust the curve fit to the BT_cont type
@@ -1024,7 +1024,7 @@ NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
                                 ! USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = False     !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -1059,7 +1059,7 @@ BT_STRONG_DRAG = False          !   [Boolean] default = False
                                 ! barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
                                 ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _vdivided by the depth of
+                                ! using rates set by lin_drag_u & _v divided by the depth of
                                 ! the ocean.  This was introduced to facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
                                 ! If true, limit any velocity components that exceed
@@ -1115,7 +1115,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1198,6 +1198,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1261,7 +1264,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1269,7 +1272,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1477,12 +1481,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1578,7 +1582,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 3600.0             !   [s] default = 900.0

--- a/ocean_only/sloshing/z/MOM_parameter_doc.all
+++ b/ocean_only/sloshing/z/MOM_parameter_doc.all
@@ -254,7 +254,8 @@ MINIMUM_DEPTH = 1.0             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -874,7 +875,8 @@ RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -932,7 +934,8 @@ HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
                                 ! stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
@@ -1168,7 +1171,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of

--- a/ocean_only/sloshing/z/MOM_parameter_doc.short
+++ b/ocean_only/sloshing/z/MOM_parameter_doc.short
@@ -101,7 +101,8 @@ MINIMUM_DEPTH = 1.0             !   [m] default = 0.0
                                 ! MINIMUM_DEPTH but deeper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate

--- a/ocean_only/sloshing/z/MOM_parameter_doc.short
+++ b/ocean_only/sloshing/z/MOM_parameter_doc.short
@@ -158,8 +158,8 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate

--- a/ocean_only/torus_advection_test/MOM_parameter_doc.all
+++ b/ocean_only/torus_advection_test/MOM_parameter_doc.all
@@ -182,7 +182,7 @@ RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 0.0                  !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -424,8 +424,8 @@ GINT = 7.89E-04                 !   [m s-2]
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 THICKNESS_CONFIG = "uniform"    !
                                 ! A string that determines how the initial layer
@@ -502,7 +502,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 
 ! === module MOM_diag_mediator ===
@@ -517,7 +517,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -593,8 +593,8 @@ LINEAR_DRAG = False             !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -628,7 +628,7 @@ KV = 1.0E-04                    !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -676,7 +676,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -803,7 +803,7 @@ KH_VEL_SCALE = 0.0              !   [m s-1] default = 0.0
                                 ! The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latidutinally-dependent background
+                                ! The amplitude of a latitudinally-dependent background
                                 ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = False          !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
@@ -872,7 +872,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -897,7 +897,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
                                 ! If true, and BOUND_BT_CORRECTION is true, use the
                                 ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocites
+                                ! MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
                                 ! If true, adjust the curve fit to the BT_cont type
@@ -929,7 +929,7 @@ NONLIN_BT_CONT_UPDATE_PERIOD = 1 !   [nondim] default = 1
                                 ! areas, or 0 to update only before the barotropic stepping.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -964,7 +964,7 @@ BT_STRONG_DRAG = False          !   [Boolean] default = False
                                 ! barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
                                 ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _vdivided by the depth of
+                                ! using rates set by lin_drag_u & _v divided by the depth of
                                 ! the ocean.  This was introduced to facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
                                 ! If true, limit any velocity components that exceed
@@ -1020,7 +1020,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1103,6 +1103,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1157,7 +1160,8 @@ ML_RADIATION = False            !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1365,12 +1369,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1466,7 +1470,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 3600.0             !   [s] default = 3600.0

--- a/ocean_only/torus_advection_test/MOM_parameter_doc.all
+++ b/ocean_only/torus_advection_test/MOM_parameter_doc.all
@@ -251,7 +251,8 @@ MAXIMUM_DEPTH = 200.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -781,7 +782,8 @@ RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -832,7 +834,8 @@ USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
                                 ! for new experiments.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False
@@ -1073,7 +1076,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of

--- a/ocean_only/torus_advection_test/MOM_parameter_doc.short
+++ b/ocean_only/torus_advection_test/MOM_parameter_doc.short
@@ -117,7 +117,8 @@ MAXIMUM_DEPTH = 200.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 ROTATION = "beta"               ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate

--- a/ocean_only/torus_advection_test/MOM_parameter_doc.short
+++ b/ocean_only/torus_advection_test/MOM_parameter_doc.short
@@ -56,7 +56,7 @@ RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
                                 ! properties, or with BOUSSINSEQ false to convert some
                                 ! parameters from vertical units of m to kg m-2.
 ANGSTROM = 0.0                  !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 NK = 5                          !   [nondim]
                                 ! The number of model layers.
 
@@ -329,7 +329,7 @@ NONLINEAR_BT_CONTINUITY = True  !   [Boolean] default = False
                                 ! USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted

--- a/ocean_only/tracer_mixing/rho/MOM_parameter_doc.all
+++ b/ocean_only/tracer_mixing/rho/MOM_parameter_doc.all
@@ -251,7 +251,8 @@ MAXIMUM_DEPTH = 100.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -925,7 +926,8 @@ RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -983,7 +985,8 @@ HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
                                 ! stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
@@ -1219,7 +1222,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of

--- a/ocean_only/tracer_mixing/rho/MOM_parameter_doc.all
+++ b/ocean_only/tracer_mixing/rho/MOM_parameter_doc.all
@@ -182,7 +182,7 @@ RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-15              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -403,15 +403,15 @@ REGRIDDING_COORDINATE_MODE = "RHO" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 REGRIDDING_COORDINATE_UNITS = "kg m^-3" ! default = "kg m^-3"
-                                ! Units of the regridding coordinuate.
+                                ! Units of the regridding coordinate.
 INTERPOLATION_SCHEME = "P3M_IH4IH3" ! default = "P1M_H2"
                                 ! This sets the interpolation scheme to use to
                                 ! determine the new grid. These parameters are
@@ -459,7 +459,7 @@ ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
                                 ! RHO target densities for interfaces
 REGRID_COMPRESSIBILITY_FRACTION = 0.0 !   [not defined] default = 0.0
                                 ! When interpolating potential density profiles we can add
-                                ! some artificial compressibility solely to make homogenous
+                                ! some artificial compressibility solely to make homogeneous
                                 ! regions appear stratified.
 MIN_THICKNESS = 1.0E-04         !   [m] default = 0.001
                                 ! When regridding, this is the minimum layer
@@ -494,7 +494,7 @@ REMAPPING_SCHEME = "PPM_IH4"    ! default = "PLM"
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
                                 ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicty or an inconsistency is
+                                ! consistency and if non-monotonicity or an inconsistency is
                                 ! detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
                                 ! If true, the results of remapping are checked for
@@ -523,15 +523,15 @@ REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
-                                ! REGRID_FILTER_SHALLOW_DEPTH the filter wieghts adopt a cubic profile.
+                                ! REGRID_FILTER_SHALLOW_DEPTH the filter weights adopt a cubic profile.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 THICKNESS_CONFIG = "uniform"    !
                                 ! A string that determines how the initial layer
@@ -624,7 +624,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
@@ -647,7 +647,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -723,8 +723,8 @@ LINEAR_DRAG = False             !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -772,7 +772,7 @@ KV = 1.0E-06                    !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -820,7 +820,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -947,7 +947,7 @@ KH_VEL_SCALE = 0.0              !   [m s-1] default = 0.0
                                 ! The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latidutinally-dependent background
+                                ! The amplitude of a latitudinally-dependent background
                                 ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = True           !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
@@ -1022,7 +1022,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -1047,7 +1047,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
                                 ! If true, and BOUND_BT_CORRECTION is true, use the
                                 ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocites
+                                ! MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
                                 ! If true, adjust the curve fit to the BT_cont type
@@ -1075,7 +1075,7 @@ NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
                                 ! USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -1110,7 +1110,7 @@ BT_STRONG_DRAG = False          !   [Boolean] default = False
                                 ! barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
                                 ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _vdivided by the depth of
+                                ! using rates set by lin_drag_u & _v divided by the depth of
                                 ! the ocean.  This was introduced to facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
                                 ! If true, limit any velocity components that exceed
@@ -1166,7 +1166,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1249,6 +1249,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1312,7 +1315,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1320,7 +1323,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1528,12 +1532,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1639,7 +1643,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 3600.0             !   [s] default = 3600.0

--- a/ocean_only/tracer_mixing/rho/MOM_parameter_doc.short
+++ b/ocean_only/tracer_mixing/rho/MOM_parameter_doc.short
@@ -50,7 +50,7 @@ RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
                                 ! properties, or with BOUSSINSEQ false to convert some
                                 ! parameters from vertical units of m to kg m-2.
 ANGSTROM = 1.0E-15              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 NK = 10                         !   [nondim]
                                 ! The number of model layers.
 
@@ -169,8 +169,8 @@ REGRIDDING_COORDINATE_MODE = "RHO" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
@@ -378,7 +378,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
                                 ! less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted

--- a/ocean_only/tracer_mixing/rho/MOM_parameter_doc.short
+++ b/ocean_only/tracer_mixing/rho/MOM_parameter_doc.short
@@ -111,7 +111,8 @@ MAXIMUM_DEPTH = 100.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 ROTATION = "beta"               ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate

--- a/ocean_only/tracer_mixing/z/MOM_parameter_doc.all
+++ b/ocean_only/tracer_mixing/z/MOM_parameter_doc.all
@@ -251,7 +251,8 @@ MAXIMUM_DEPTH = 100.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -879,7 +880,8 @@ RECONSTRUCT_FOR_PRESSURE = True !   [Boolean] default = True
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -937,7 +939,8 @@ HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
                                 ! stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = True            !   [Boolean] default = False
@@ -1173,7 +1176,8 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
                                 ! If true, the net incoming and outgoing fresh water fluxes are combined
                                 ! and applied as either incoming or outgoing depending on the sign of the net.
                                 ! If false, the net incoming fresh water flux is added to the model and
-                                ! thereafter the net outgoing is removed from the updated state.into the first non-vanished layer for which the column remains stable
+                                ! thereafter the net outgoing is removed from the topmost non-vanished
+                                ! layers of the updated state.
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at
                                 ! the bottom into the interior as though a diffusivity of

--- a/ocean_only/tracer_mixing/z/MOM_parameter_doc.all
+++ b/ocean_only/tracer_mixing/z/MOM_parameter_doc.all
@@ -182,7 +182,7 @@ RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-15              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -403,15 +403,15 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 REGRIDDING_COORDINATE_UNITS = "m" ! default = "m"
-                                ! Units of the regridding coordinuate.
+                                ! Units of the regridding coordinate.
 ALE_COORDINATE_CONFIG = "UNIFORM" ! default = "UNIFORM"
                                 ! Determines how to specify the coordinate
                                 ! resolution. Valid options are:
@@ -448,7 +448,7 @@ REMAPPING_SCHEME = "PPM_IH4"    ! default = "PLM"
                                 ! PQM_IH6IH5  (5th-order accurate)
 FATAL_CHECK_RECONSTRUCTIONS = False !   [Boolean] default = False
                                 ! If true, cell-by-cell reconstructions are checked for
-                                ! consistency and if non-monotonicty or an inconsistency is
+                                ! consistency and if non-monotonicity or an inconsistency is
                                 ! detected then a FATAL error is issued.
 FATAL_CHECK_REMAPPING = False   !   [Boolean] default = False
                                 ! If true, the results of remapping are checked for
@@ -477,15 +477,15 @@ REGRID_FILTER_SHALLOW_DEPTH = 0.0 !   [m] default = 0.0
 REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
                                 ! The depth below which full time-filtering is applied with time-scale
                                 ! REGRID_TIME_SCALE. Between depths REGRID_FILTER_SHALLOW_DEPTH and
-                                ! REGRID_FILTER_SHALLOW_DEPTH the filter wieghts adopt a cubic profile.
+                                ! REGRID_FILTER_SHALLOW_DEPTH the filter weights adopt a cubic profile.
 
 ! === module MOM_grid ===
 ! Parameters providing information about the lateral grid.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 THICKNESS_CONFIG = "uniform"    !
                                 ! A string that determines how the initial layer
@@ -578,7 +578,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
                                 ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
@@ -601,7 +601,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -677,8 +677,8 @@ LINEAR_DRAG = False             !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag
                                 ! law is cdrag*DRAG_BG_VEL*u.
 DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivitives for temperature or salt
-                                ! based on double-diffusive paramaterization from MOM4/KPP.
+                                ! If true, increase diffusivites for temperature or salt
+                                ! based on double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear
                                 ! instability.
@@ -726,7 +726,7 @@ KV = 1.0E-06                    !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -774,7 +774,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = False !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -901,7 +901,7 @@ KH_VEL_SCALE = 0.0              !   [m s-1] default = 0.0
                                 ! The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky and Leith viscosities, and KH.
 KH_SIN_LAT = 0.0                !   [m2 s-1] default = 0.0
-                                ! The amplitude of a latidutinally-dependent background
+                                ! The amplitude of a latitudinally-dependent background
                                 ! viscosity of the form KH_SIN_LAT*(SIN(LAT)**KH_PWR_OF_SINE).
 SMAGORINSKY_KH = True           !   [Boolean] default = False
                                 ! If true, use a Smagorinsky nonlinear eddy viscosity.
@@ -976,7 +976,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -1001,7 +1001,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
 BT_CONT_CORR_BOUNDS = True      !   [Boolean] default = True
                                 ! If true, and BOUND_BT_CORRECTION is true, use the
                                 ! BT_cont_type variables to set limits determined by
-                                ! MAXCFL_BT_CONT on the CFL number of the velocites
+                                ! MAXCFL_BT_CONT on the CFL number of the velocities
                                 ! that are likely to be driven by the corrective mass fluxes.
 ADJUST_BT_CONT = False          !   [Boolean] default = False
                                 ! If true, adjust the curve fit to the BT_cont type
@@ -1029,7 +1029,7 @@ NONLINEAR_BT_CONTINUITY = False !   [Boolean] default = False
                                 ! USE_BT_CONT_TYPE is true.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted
@@ -1064,7 +1064,7 @@ BT_STRONG_DRAG = False          !   [Boolean] default = False
                                 ! barotropic steps.
 BT_LINEAR_WAVE_DRAG = False     !   [Boolean] default = False
                                 ! If true, apply a linear drag to the barotropic velocities,
-                                ! using rates set by lin_drag_u & _vdivided by the depth of
+                                ! using rates set by lin_drag_u & _v divided by the depth of
                                 ! the ocean.  This was introduced to facilitate tide modeling.
 CLIP_BT_VELOCITY = False        !   [Boolean] default = False
                                 ! If true, limit any velocity components that exceed
@@ -1120,7 +1120,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -1203,6 +1203,9 @@ DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! layer depth, MLD_user, following the definition of Levitus 1982.
                                 ! The MLD is the depth at which the density is larger than the
                                 ! surface density by the specified amount.
+DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
+                                ! The distance over which to calculate a diagnostic of the
+                                ! stratification at the base of the mixed layer.
 
 ! === module MOM_CVMix_KPP ===
 ! This is the MOM wrapper to CVMix:KPP
@@ -1266,7 +1269,7 @@ BBL_MIXING_MAX_DECAY = 0.0      !   [m] default = 0.0
 BBL_MIXING_AS_MAX = True        !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
-                                ! diffusiviy from the BBL_mixing is simply added.
+                                ! diffusivity from the BBL_mixing is simply added.
 USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
                                 ! If true, uses a simple, imprecise but non-coordinate dependent, model
                                 ! of BBL mixing diffusivity based on Law of the Wall. Otherwise, uses
@@ -1274,7 +1277,8 @@ USE_LOTW_BBL_DIFFUSIVITY = False !   [Boolean] default = False
 SIMPLE_TKE_TO_KD = False        !   [Boolean] default = False
                                 ! If true, uses a simple estimate of Kd/TKE that will
                                 ! work for arbitrary vertical coordinates. If false,
-                                ! calculates Kd/TKE and bounds based on exact energetics/nfor an isopycnal layer-formulation.
+                                ! calculates Kd/TKE and bounds based on exact energetics
+                                ! for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
@@ -1482,12 +1486,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -1593,7 +1597,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 3600.0             !   [s] default = 3600.0

--- a/ocean_only/tracer_mixing/z/MOM_parameter_doc.short
+++ b/ocean_only/tracer_mixing/z/MOM_parameter_doc.short
@@ -111,7 +111,8 @@ MAXIMUM_DEPTH = 100.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 ROTATION = "beta"               ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate

--- a/ocean_only/tracer_mixing/z/MOM_parameter_doc.short
+++ b/ocean_only/tracer_mixing/z/MOM_parameter_doc.short
@@ -50,7 +50,7 @@ RHO_0 = 1000.0                  !   [kg m-3] default = 1035.0
                                 ! properties, or with BOUSSINSEQ false to convert some
                                 ! parameters from vertical units of m to kg m-2.
 ANGSTROM = 1.0E-15              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 NK = 10                         !   [nondim]
                                 ! The number of model layers.
 
@@ -169,8 +169,8 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 ! Coordinate mode for vertical regridding.
                                 ! Choose among the following possibilities:
                                 !  LAYER - Isopycnal or stacked shallow water layers
-                                !  ZSTAR, Z* - stetched geopotential z*
-                                !  SIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf
+                                !  ZSTAR, Z* - stretched geopotential z*
+                                !  SIGMA_SHELF_ZSTAR - stretched geopotential z* ignoring shelf
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
@@ -354,7 +354,7 @@ BOUND_BT_CORRECTION = True      !   [Boolean] default = False
                                 ! less than maxCFL_BT_cont to be accommodated.
 BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! If true, step the barotropic velocity first and project
-                                ! out the velocity tendancy by 1+BEBT when calculating the
+                                ! out the velocity tendency by 1+BEBT when calculating the
                                 ! transport.  The default (false) is to use a predictor
                                 ! continuity step to find the pressure field, and then
                                 ! to do a corrector continuity step using a weighted

--- a/ocean_only/unit_tests/MOM_parameter_doc.all
+++ b/ocean_only/unit_tests/MOM_parameter_doc.all
@@ -157,7 +157,7 @@ RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
 BOUSSINESQ = True               !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 ANGSTROM = 1.0E-10              !   [m] default = 1.0E-10
-                                ! The minumum layer thickness, usually one-Angstrom.
+                                ! The minimum layer thickness, usually one-Angstrom.
 H_TO_M = 1.0                    !   [m H-1] default = 1.0
                                 ! A constant that translates the model's internal
                                 ! units of thickness into m.
@@ -329,8 +329,8 @@ GFS = 9.8                       !   [m s-2] default = 9.8
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
-                                ! If true, intialize the layer thicknesses, temperatures,
-                                ! and salnities from a Z-space file on a latitude-
+                                ! If true, initialize the layer thicknesses, temperatures,
+                                ! and salinities from a Z-space file on a latitude-
                                 ! longitude grid.
 THICKNESS_CONFIG = "uniform"    !
                                 ! A string that determines how the initial layer
@@ -380,7 +380,7 @@ DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
                                 ! tsunamis when a large surface pressure is applied.
 TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
                                 ! If true, cuts way the top of the column for initial conditions
-                                ! at the depth where the hydrostatic presure matches the imposed
+                                ! at the depth where the hydrostatic pressure matches the imposed
                                 ! surface pressure which is read from file.
 SPONGE = False                  !   [Boolean] default = False
                                 ! If true, sponges may be applied anywhere in the domain.
@@ -399,7 +399,7 @@ DIAG_MISVAL = 1.0E+20           !   [not defined] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
                                 ! Instead of writing diagnostics to the diag manager, write
-                                ! a textfile containing the checksum (bitcount) of the array.
+                                ! a text file containing the checksum (bitcount) of the array.
 AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000000"
                                 ! A file into which to write a list of all available
                                 ! ocean diagnostics that can be included in a diag_table.
@@ -505,7 +505,7 @@ KV = 1.0                        !   [m2 s-1]
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
 ADD_KV_SLOW = False             !   [Boolean] default = False
                                 ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
+                                ! (i.e., tidal + background + shear + convection) is added
                                 ! when computing the coupling coefficient. The purpose of this
                                 ! flag is to be able to recover previous answers and it will likely
                                 ! be removed in the future since this option should always be true.
@@ -531,7 +531,7 @@ MONOTONIC_CONTINUITY = False    !   [Boolean] default = False
 SIMPLE_2ND_PPM_CONTINUITY = True !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic
@@ -722,7 +722,7 @@ CFL_REPORT = 0.5                !   [nondim] default = 0.5
                                 ! The value of the CFL number that causes accelerations
                                 ! to be reported; the default is CFL_TRUNCATE.
 CFL_TRUNCATE_RAMP_TIME = 0.0    !   [s] default = 0.0
-                                ! The time over which the CFL trunction value is ramped
+                                ! The time over which the CFL truncation value is ramped
                                 ! up at the beginning of the run.
 CFL_TRUNCATE_START = 0.0        !   [nondim] default = 0.0
                                 ! The start value of the truncation CFL number used when
@@ -752,7 +752,7 @@ KHTH_MAX_CFL = 0.8              !   [nondimensional] default = 0.8
                                 ! ALE-based models.
 DETANGLE_INTERFACES = False     !   [Boolean] default = False
                                 ! If defined add 3-d structured enhanced interface height
-                                ! diffusivities to horizonally smooth jagged layers.
+                                ! diffusivities to horizontally smooth jagged layers.
 KHTH_SLOPE_MAX = 0.01           !   [nondim] default = 0.01
                                 ! A slope beyond which the calculated isopycnal slope is
                                 ! not reliable and is scaled away.
@@ -802,12 +802,12 @@ KHTR_MAX = 0.0                  !   [m2 s-1] default = 0.0
                                 ! The maximum along-isopycnal tracer diffusivity.
 KHTR_PASSIVITY_COEFF = 0.0      !   [nondim] default = 0.0
                                 ! The coefficient that scales deformation radius over
-                                ! grid-spacing in passivity, where passiviity is the ratio
-                                ! between along isopycnal mxiing of tracers to thickness mixing.
+                                ! grid-spacing in passivity, where passivity is the ratio
+                                ! between along isopycnal mixing of tracers to thickness mixing.
                                 ! A non-zero value enables this parameterization.
 KHTR_PASSIVITY_MIN = 0.5        !   [nondim] default = 0.5
                                 ! The minimum passivity which is the ratio between
-                                ! along isopycnal mxiing of tracers to thickness mixing.
+                                ! along isopycnal mixing of tracers to thickness mixing.
 DIFFUSE_ML_TO_INTERIOR = False  !   [Boolean] default = False
                                 ! If true, enable epipycnal mixing between the surface
                                 ! boundary layer and the interior.
@@ -903,7 +903,7 @@ USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
                                 ! The depth (normalized by BLD) to average Stokes drift over in
-                                !  Lanmguir number calculation, where La = sqrt(ust/Stokes).
+                                !  Langmuir number calculation, where La = sqrt(ust/Stokes).
 
 ! === module MOM_main (MOM_driver) ===
 DT_FORCING = 8.64E+04           !   [s] default = 8.64E+04

--- a/ocean_only/unit_tests/MOM_parameter_doc.all
+++ b/ocean_only/unit_tests/MOM_parameter_doc.all
@@ -226,7 +226,8 @@ MAXIMUM_DEPTH = 100.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 OBC_NUMBER_OF_SEGMENTS = 0      ! default = 0
                                 ! The number of open boundary segments.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
@@ -636,7 +637,8 @@ RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
                                 ! The default is set by USE_REGRIDDING.
 PRESSURE_RECONSTRUCTION_SCHEME = 1 ! default = 1
                                 ! Order of vertical reconstruction of T/S to use in the
-                                ! integrals within the FV pressure gradient calculation. 0: PCM or no reconstruction.
+                                ! integrals within the FV pressure gradient calculation.
+                                !  0: PCM or no reconstruction.
                                 !  1: PLM reconstruction.
                                 !  2: PPM reconstruction.
 BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
@@ -682,7 +684,8 @@ HORVISC_BOUND_COEF = 0.8        !   [nondim] default = 0.8
                                 ! stability without considering other terms.
 USE_KH_BG_2D = False            !   [Boolean] default = False
                                 ! If true, read a file containing 2-d background harmonic
-                                ! viscosities. The final viscosity is the maximum of the other terms and this background value.
+                                ! viscosities. The final viscosity is the maximum of the other
+                                ! terms and this background value.
 
 ! === module MOM_vert_friction ===
 DIRECT_STRESS = False           !   [Boolean] default = False

--- a/ocean_only/unit_tests/MOM_parameter_doc.short
+++ b/ocean_only/unit_tests/MOM_parameter_doc.short
@@ -175,7 +175,7 @@ KV = 1.0                        !   [m2 s-1]
 SIMPLE_2ND_PPM_CONTINUITY = True !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM uses a simple 2nd order
                                 ! (arithmetic mean) interpolation of the edge values.
-                                ! This may give better PV conservation propterties. While
+                                ! This may give better PV conservation properties. While
                                 ! it formally reduces the accuracy of the continuity
                                 ! solver itself in the strongly advective limit, it does
                                 ! not reduce the overall order of accuracy of the dynamic

--- a/ocean_only/unit_tests/MOM_parameter_doc.short
+++ b/ocean_only/unit_tests/MOM_parameter_doc.short
@@ -86,7 +86,8 @@ MAXIMUM_DEPTH = 100.0           !   [m]
                                 ! The maximum depth of the ocean.
 
 ! === module MOM_open_boundary ===
-! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply, if any.
+! Controls where open boundaries are located, what kind of boundary condition
+! to impose, and what data to apply, if any.
 
 ! === module MOM_tracer_registry ===
 


### PR DESCRIPTION
  Added a new run-time parameter to set the minimum salinity, corrected the
calculation of the diagnostic subML_N2 and corrected spelling error in
descriptions that are logged to the MOM_parameter_doc files.  By default, all
answers are bitwise identical, but there are numerous minor changes to the
MOM_parameter_doc files, which are being updated in MOM6-examples.  MOM6 commits
in  https://github.com/NOAA-GFDL/MOM6/pull/920 include:

 - NOAA-GFDL/MOM6@d927495 +Corrected spelling errors in documentation
 - NOAA-GFDL/MOM6@550308c +Corrected documentation of HALF_STRAT_DEPTH
 - NOAA-GFDL/MOM6@62c113e +Added MIN_SALINITY as a new runtime parameter.
 - NOAA-GFDL/MOM6@dc35d3a +(*)Revised the diagnostic subML_N2
 - NOAA-GFDL/MOM6@2015e63 (*)Revised propagate_int_tide code for symmetry