### PR TITLE
Set VEL_UNDERFLOW = 1e-30 in 12 test cases

### DIFF
--- a/ocean_only/CVmix_SCM_tests/common_BML/MOM_input
+++ b/ocean_only/CVmix_SCM_tests/common_BML/MOM_input
@@ -305,6 +305,11 @@ KV = 0.0                        !   [m2 s-1]
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity
                                 ! components are truncated.
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
+                                ! A negligibly small velocity magnitude below which velocity
+                                ! components are set to 0.  A reasonable value might be
+                                ! 1e-30 m/s, which is less than an Angstrom divided by
+                                ! the age of the universe.
 
 ! === module MOM_PointAccel ===
 

--- a/ocean_only/CVmix_SCM_tests/common_EPBL/MOM_input
+++ b/ocean_only/CVmix_SCM_tests/common_EPBL/MOM_input
@@ -303,6 +303,11 @@ KV = 0.0                        !   [m2 s-1]
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity
                                 ! components are truncated.
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
+                                ! A negligibly small velocity magnitude below which velocity
+                                ! components are set to 0.  A reasonable value might be
+                                ! 1e-30 m/s, which is less than an Angstrom divided by
+                                ! the age of the universe.
 
 ! === module MOM_PointAccel ===
 

--- a/ocean_only/CVmix_SCM_tests/common_KPP/MOM_input
+++ b/ocean_only/CVmix_SCM_tests/common_KPP/MOM_input
@@ -303,6 +303,11 @@ KV = 0.0                        !   [m2 s-1]
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity
                                 ! components are truncated.
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
+                                ! A negligibly small velocity magnitude below which velocity
+                                ! components are set to 0.  A reasonable value might be
+                                ! 1e-30 m/s, which is less than an Angstrom divided by
+                                ! the age of the universe.
 
 ! === module MOM_PointAccel ===
 

--- a/ocean_only/CVmix_SCM_tests/cooling_only/BML/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/BML/MOM_parameter_doc.all
@@ -821,7 +821,7 @@ STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
                                 ! Flag to use Stokes drift Mixing via the Lagrangian
                                 !  current (Eulerian plus Stokes drift).
                                 !  Still needs work and testing, so not recommended for use.
-VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
                                 ! A negligibly small velocity magnitude below which velocity
                                 ! components are set to 0.  A reasonable value might be
                                 ! 1e-30 m/s, which is less than an Angstrom divided by

--- a/ocean_only/CVmix_SCM_tests/cooling_only/BML/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/BML/MOM_parameter_doc.short
@@ -292,6 +292,11 @@ HARMONIC_VISC = True            !   [Boolean] default = False
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity
                                 ! components are truncated.
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
+                                ! A negligibly small velocity magnitude below which velocity
+                                ! components are set to 0.  A reasonable value might be
+                                ! 1e-30 m/s, which is less than an Angstrom divided by
+                                ! the age of the universe.
 
 ! === module MOM_PointAccel ===
 

--- a/ocean_only/CVmix_SCM_tests/cooling_only/EPBL/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/EPBL/MOM_parameter_doc.all
@@ -913,7 +913,7 @@ STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
                                 ! Flag to use Stokes drift Mixing via the Lagrangian
                                 !  current (Eulerian plus Stokes drift).
                                 !  Still needs work and testing, so not recommended for use.
-VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
                                 ! A negligibly small velocity magnitude below which velocity
                                 ! components are set to 0.  A reasonable value might be
                                 ! 1e-30 m/s, which is less than an Angstrom divided by

--- a/ocean_only/CVmix_SCM_tests/cooling_only/EPBL/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/EPBL/MOM_parameter_doc.short
@@ -314,6 +314,11 @@ HMIX_FIXED = 0.01               !   [m]
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity
                                 ! components are truncated.
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
+                                ! A negligibly small velocity magnitude below which velocity
+                                ! components are set to 0.  A reasonable value might be
+                                ! 1e-30 m/s, which is less than an Angstrom divided by
+                                ! the age of the universe.
 
 ! === module MOM_PointAccel ===
 

--- a/ocean_only/CVmix_SCM_tests/cooling_only/KPP/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/KPP/MOM_parameter_doc.all
@@ -913,7 +913,7 @@ STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
                                 ! Flag to use Stokes drift Mixing via the Lagrangian
                                 !  current (Eulerian plus Stokes drift).
                                 !  Still needs work and testing, so not recommended for use.
-VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
                                 ! A negligibly small velocity magnitude below which velocity
                                 ! components are set to 0.  A reasonable value might be
                                 ! 1e-30 m/s, which is less than an Angstrom divided by

--- a/ocean_only/CVmix_SCM_tests/cooling_only/KPP/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/KPP/MOM_parameter_doc.short
@@ -314,6 +314,11 @@ HMIX_FIXED = 0.01               !   [m]
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity
                                 ! components are truncated.
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
+                                ! A negligibly small velocity magnitude below which velocity
+                                ! components are set to 0.  A reasonable value might be
+                                ! 1e-30 m/s, which is less than an Angstrom divided by
+                                ! the age of the universe.
 
 ! === module MOM_PointAccel ===
 

--- a/ocean_only/CVmix_SCM_tests/mech_only/BML/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/mech_only/BML/MOM_parameter_doc.all
@@ -821,7 +821,7 @@ STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
                                 ! Flag to use Stokes drift Mixing via the Lagrangian
                                 !  current (Eulerian plus Stokes drift).
                                 !  Still needs work and testing, so not recommended for use.
-VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
                                 ! A negligibly small velocity magnitude below which velocity
                                 ! components are set to 0.  A reasonable value might be
                                 ! 1e-30 m/s, which is less than an Angstrom divided by

--- a/ocean_only/CVmix_SCM_tests/mech_only/BML/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/mech_only/BML/MOM_parameter_doc.short
@@ -292,6 +292,11 @@ HARMONIC_VISC = True            !   [Boolean] default = False
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity
                                 ! components are truncated.
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
+                                ! A negligibly small velocity magnitude below which velocity
+                                ! components are set to 0.  A reasonable value might be
+                                ! 1e-30 m/s, which is less than an Angstrom divided by
+                                ! the age of the universe.
 
 ! === module MOM_PointAccel ===
 

--- a/ocean_only/CVmix_SCM_tests/mech_only/EPBL/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/mech_only/EPBL/MOM_parameter_doc.all
@@ -913,7 +913,7 @@ STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
                                 ! Flag to use Stokes drift Mixing via the Lagrangian
                                 !  current (Eulerian plus Stokes drift).
                                 !  Still needs work and testing, so not recommended for use.
-VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
                                 ! A negligibly small velocity magnitude below which velocity
                                 ! components are set to 0.  A reasonable value might be
                                 ! 1e-30 m/s, which is less than an Angstrom divided by

--- a/ocean_only/CVmix_SCM_tests/mech_only/EPBL/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/mech_only/EPBL/MOM_parameter_doc.short
@@ -314,6 +314,11 @@ HMIX_FIXED = 0.01               !   [m]
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity
                                 ! components are truncated.
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
+                                ! A negligibly small velocity magnitude below which velocity
+                                ! components are set to 0.  A reasonable value might be
+                                ! 1e-30 m/s, which is less than an Angstrom divided by
+                                ! the age of the universe.
 
 ! === module MOM_PointAccel ===
 

--- a/ocean_only/CVmix_SCM_tests/mech_only/KPP/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/mech_only/KPP/MOM_parameter_doc.all
@@ -913,7 +913,7 @@ STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
                                 ! Flag to use Stokes drift Mixing via the Lagrangian
                                 !  current (Eulerian plus Stokes drift).
                                 !  Still needs work and testing, so not recommended for use.
-VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
                                 ! A negligibly small velocity magnitude below which velocity
                                 ! components are set to 0.  A reasonable value might be
                                 ! 1e-30 m/s, which is less than an Angstrom divided by

--- a/ocean_only/CVmix_SCM_tests/mech_only/KPP/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/mech_only/KPP/MOM_parameter_doc.short
@@ -314,6 +314,11 @@ HMIX_FIXED = 0.01               !   [m]
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity
                                 ! components are truncated.
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
+                                ! A negligibly small velocity magnitude below which velocity
+                                ! components are set to 0.  A reasonable value might be
+                                ! 1e-30 m/s, which is less than an Angstrom divided by
+                                ! the age of the universe.
 
 ! === module MOM_PointAccel ===
 

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/BML/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/BML/MOM_parameter_doc.all
@@ -821,7 +821,7 @@ STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
                                 ! Flag to use Stokes drift Mixing via the Lagrangian
                                 !  current (Eulerian plus Stokes drift).
                                 !  Still needs work and testing, so not recommended for use.
-VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
                                 ! A negligibly small velocity magnitude below which velocity
                                 ! components are set to 0.  A reasonable value might be
                                 ! 1e-30 m/s, which is less than an Angstrom divided by

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/BML/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/BML/MOM_parameter_doc.short
@@ -290,6 +290,11 @@ HARMONIC_VISC = True            !   [Boolean] default = False
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity
                                 ! components are truncated.
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
+                                ! A negligibly small velocity magnitude below which velocity
+                                ! components are set to 0.  A reasonable value might be
+                                ! 1e-30 m/s, which is less than an Angstrom divided by
+                                ! the age of the universe.
 
 ! === module MOM_PointAccel ===
 

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/EPBL/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/EPBL/MOM_parameter_doc.all
@@ -913,7 +913,7 @@ STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
                                 ! Flag to use Stokes drift Mixing via the Lagrangian
                                 !  current (Eulerian plus Stokes drift).
                                 !  Still needs work and testing, so not recommended for use.
-VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
                                 ! A negligibly small velocity magnitude below which velocity
                                 ! components are set to 0.  A reasonable value might be
                                 ! 1e-30 m/s, which is less than an Angstrom divided by

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/EPBL/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/EPBL/MOM_parameter_doc.short
@@ -312,6 +312,11 @@ HMIX_FIXED = 0.01               !   [m]
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity
                                 ! components are truncated.
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
+                                ! A negligibly small velocity magnitude below which velocity
+                                ! components are set to 0.  A reasonable value might be
+                                ! 1e-30 m/s, which is less than an Angstrom divided by
+                                ! the age of the universe.
 
 ! === module MOM_PointAccel ===
 

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/KPP/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/KPP/MOM_parameter_doc.all
@@ -913,7 +913,7 @@ STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
                                 ! Flag to use Stokes drift Mixing via the Lagrangian
                                 !  current (Eulerian plus Stokes drift).
                                 !  Still needs work and testing, so not recommended for use.
-VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
                                 ! A negligibly small velocity magnitude below which velocity
                                 ! components are set to 0.  A reasonable value might be
                                 ! 1e-30 m/s, which is less than an Angstrom divided by

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/KPP/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/KPP/MOM_parameter_doc.short
@@ -312,6 +312,11 @@ HMIX_FIXED = 0.01               !   [m]
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity
                                 ! components are truncated.
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
+                                ! A negligibly small velocity magnitude below which velocity
+                                ! components are set to 0.  A reasonable value might be
+                                ! 1e-30 m/s, which is less than an Angstrom divided by
+                                ! the age of the universe.
 
 ! === module MOM_PointAccel ===
 

--- a/ocean_only/CVmix_SCM_tests/wind_only/BML/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/wind_only/BML/MOM_parameter_doc.all
@@ -821,7 +821,7 @@ STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
                                 ! Flag to use Stokes drift Mixing via the Lagrangian
                                 !  current (Eulerian plus Stokes drift).
                                 !  Still needs work and testing, so not recommended for use.
-VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
                                 ! A negligibly small velocity magnitude below which velocity
                                 ! components are set to 0.  A reasonable value might be
                                 ! 1e-30 m/s, which is less than an Angstrom divided by

--- a/ocean_only/CVmix_SCM_tests/wind_only/BML/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/wind_only/BML/MOM_parameter_doc.short
@@ -292,6 +292,11 @@ HARMONIC_VISC = True            !   [Boolean] default = False
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity
                                 ! components are truncated.
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
+                                ! A negligibly small velocity magnitude below which velocity
+                                ! components are set to 0.  A reasonable value might be
+                                ! 1e-30 m/s, which is less than an Angstrom divided by
+                                ! the age of the universe.
 
 ! === module MOM_PointAccel ===
 

--- a/ocean_only/CVmix_SCM_tests/wind_only/EPBL/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/wind_only/EPBL/MOM_parameter_doc.all
@@ -913,7 +913,7 @@ STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
                                 ! Flag to use Stokes drift Mixing via the Lagrangian
                                 !  current (Eulerian plus Stokes drift).
                                 !  Still needs work and testing, so not recommended for use.
-VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
                                 ! A negligibly small velocity magnitude below which velocity
                                 ! components are set to 0.  A reasonable value might be
                                 ! 1e-30 m/s, which is less than an Angstrom divided by

--- a/ocean_only/CVmix_SCM_tests/wind_only/EPBL/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/wind_only/EPBL/MOM_parameter_doc.short
@@ -314,6 +314,11 @@ HMIX_FIXED = 0.01               !   [m]
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity
                                 ! components are truncated.
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
+                                ! A negligibly small velocity magnitude below which velocity
+                                ! components are set to 0.  A reasonable value might be
+                                ! 1e-30 m/s, which is less than an Angstrom divided by
+                                ! the age of the universe.
 
 ! === module MOM_PointAccel ===
 

--- a/ocean_only/CVmix_SCM_tests/wind_only/KPP/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/wind_only/KPP/MOM_parameter_doc.all
@@ -913,7 +913,7 @@ STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
                                 ! Flag to use Stokes drift Mixing via the Lagrangian
                                 !  current (Eulerian plus Stokes drift).
                                 !  Still needs work and testing, so not recommended for use.
-VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
                                 ! A negligibly small velocity magnitude below which velocity
                                 ! components are set to 0.  A reasonable value might be
                                 ! 1e-30 m/s, which is less than an Angstrom divided by

--- a/ocean_only/CVmix_SCM_tests/wind_only/KPP/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/wind_only/KPP/MOM_parameter_doc.short
@@ -314,6 +314,11 @@ HMIX_FIXED = 0.01               !   [m]
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity
                                 ! components are truncated.
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
+                                ! A negligibly small velocity magnitude below which velocity
+                                ! components are set to 0.  A reasonable value might be
+                                ! 1e-30 m/s, which is less than an Angstrom divided by
+                                ! the age of the universe.
 
 ! === module MOM_PointAccel ===
 

--- a/ocean_only/DOME/MOM_input
+++ b/ocean_only/DOME/MOM_input
@@ -289,6 +289,11 @@ HBBL = 10.0                     !   [m]
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity
                                 ! components are truncated.
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
+                                ! A negligibly small velocity magnitude below which velocity
+                                ! components are set to 0.  A reasonable value might be
+                                ! 1e-30 m/s, which is less than an Angstrom divided by
+                                ! the age of the universe.
 
 ! === module MOM_set_visc ===
 USE_JACKSON_PARAM = True        !   [Boolean] default = False

--- a/ocean_only/DOME/MOM_parameter_doc.all
+++ b/ocean_only/DOME/MOM_parameter_doc.all
@@ -860,7 +860,7 @@ STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
                                 ! Flag to use Stokes drift Mixing via the Lagrangian
                                 !  current (Eulerian plus Stokes drift).
                                 !  Still needs work and testing, so not recommended for use.
-VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
                                 ! A negligibly small velocity magnitude below which velocity
                                 ! components are set to 0.  A reasonable value might be
                                 ! 1e-30 m/s, which is less than an Angstrom divided by

--- a/ocean_only/DOME/MOM_parameter_doc.short
+++ b/ocean_only/DOME/MOM_parameter_doc.short
@@ -323,6 +323,11 @@ KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity
                                 ! components are truncated.
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
+                                ! A negligibly small velocity magnitude below which velocity
+                                ! components are set to 0.  A reasonable value might be
+                                ! 1e-30 m/s, which is less than an Angstrom divided by
+                                ! the age of the universe.
 
 ! === module MOM_barotropic ===
 BOUND_BT_CORRECTION = True      !   [Boolean] default = False

--- a/ocean_only/SCM_idealized_hurricane/MOM_input
+++ b/ocean_only/SCM_idealized_hurricane/MOM_input
@@ -295,6 +295,11 @@ HBBL = 10.0                     !   [m]
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity
                                 ! components are truncated.
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
+                                ! A negligibly small velocity magnitude below which velocity
+                                ! components are set to 0.  A reasonable value might be
+                                ! 1e-30 m/s, which is less than an Angstrom divided by
+                                ! the age of the universe.
 
 ! === module MOM_PointAccel ===
 

--- a/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.all
+++ b/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.all
@@ -913,7 +913,7 @@ STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
                                 ! Flag to use Stokes drift Mixing via the Lagrangian
                                 !  current (Eulerian plus Stokes drift).
                                 !  Still needs work and testing, so not recommended for use.
-VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
                                 ! A negligibly small velocity magnitude below which velocity
                                 ! components are set to 0.  A reasonable value might be
                                 ! 1e-30 m/s, which is less than an Angstrom divided by

--- a/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.short
+++ b/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.short
@@ -322,6 +322,11 @@ HMIX_FIXED = 0.01               !   [m]
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity
                                 ! components are truncated.
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
+                                ! A negligibly small velocity magnitude below which velocity
+                                ! components are set to 0.  A reasonable value might be
+                                ! 1e-30 m/s, which is less than an Angstrom divided by
+                                ! the age of the universe.
 
 ! === module MOM_PointAccel ===
 

--- a/ocean_only/adjustment2d/common/MOM_input
+++ b/ocean_only/adjustment2d/common/MOM_input
@@ -307,6 +307,11 @@ HBBL = 0.001                    !   [m]
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity
                                 ! components are truncated.
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
+                                ! A negligibly small velocity magnitude below which velocity
+                                ! components are set to 0.  A reasonable value might be
+                                ! 1e-30 m/s, which is less than an Angstrom divided by
+                                ! the age of the universe.
 
 ! === module MOM_PointAccel ===
 

--- a/ocean_only/adjustment2d/layer/MOM_parameter_doc.all
+++ b/ocean_only/adjustment2d/layer/MOM_parameter_doc.all
@@ -902,7 +902,7 @@ STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
                                 ! Flag to use Stokes drift Mixing via the Lagrangian
                                 !  current (Eulerian plus Stokes drift).
                                 !  Still needs work and testing, so not recommended for use.
-VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
                                 ! A negligibly small velocity magnitude below which velocity
                                 ! components are set to 0.  A reasonable value might be
                                 ! 1e-30 m/s, which is less than an Angstrom divided by

--- a/ocean_only/adjustment2d/layer/MOM_parameter_doc.short
+++ b/ocean_only/adjustment2d/layer/MOM_parameter_doc.short
@@ -324,6 +324,11 @@ KVML = 0.0                      !   [m2 s-1] default = 1.0E-06
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity
                                 ! components are truncated.
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
+                                ! A negligibly small velocity magnitude below which velocity
+                                ! components are set to 0.  A reasonable value might be
+                                ! 1e-30 m/s, which is less than an Angstrom divided by
+                                ! the age of the universe.
 
 ! === module MOM_PointAccel ===
 

--- a/ocean_only/adjustment2d/rho/MOM_parameter_doc.all
+++ b/ocean_only/adjustment2d/rho/MOM_parameter_doc.all
@@ -1033,7 +1033,7 @@ STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
                                 ! Flag to use Stokes drift Mixing via the Lagrangian
                                 !  current (Eulerian plus Stokes drift).
                                 !  Still needs work and testing, so not recommended for use.
-VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
                                 ! A negligibly small velocity magnitude below which velocity
                                 ! components are set to 0.  A reasonable value might be
                                 ! 1e-30 m/s, which is less than an Angstrom divided by

--- a/ocean_only/adjustment2d/rho/MOM_parameter_doc.short
+++ b/ocean_only/adjustment2d/rho/MOM_parameter_doc.short
@@ -372,6 +372,11 @@ KVML = 0.0                      !   [m2 s-1] default = 1.0E-06
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity
                                 ! components are truncated.
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
+                                ! A negligibly small velocity magnitude below which velocity
+                                ! components are set to 0.  A reasonable value might be
+                                ! 1e-30 m/s, which is less than an Angstrom divided by
+                                ! the age of the universe.
 
 ! === module MOM_PointAccel ===
 

--- a/ocean_only/adjustment2d/z/MOM_parameter_doc.all
+++ b/ocean_only/adjustment2d/z/MOM_parameter_doc.all
@@ -987,7 +987,7 @@ STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
                                 ! Flag to use Stokes drift Mixing via the Lagrangian
                                 !  current (Eulerian plus Stokes drift).
                                 !  Still needs work and testing, so not recommended for use.
-VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
                                 ! A negligibly small velocity magnitude below which velocity
                                 ! components are set to 0.  A reasonable value might be
                                 ! 1e-30 m/s, which is less than an Angstrom divided by

--- a/ocean_only/adjustment2d/z/MOM_parameter_doc.short
+++ b/ocean_only/adjustment2d/z/MOM_parameter_doc.short
@@ -348,6 +348,11 @@ KVML = 0.0                      !   [m2 s-1] default = 1.0E-06
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity
                                 ! components are truncated.
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
+                                ! A negligibly small velocity magnitude below which velocity
+                                ! components are set to 0.  A reasonable value might be
+                                ! 1e-30 m/s, which is less than an Angstrom divided by
+                                ! the age of the universe.
 
 ! === module MOM_PointAccel ===
 

--- a/ocean_only/external_gwave/MOM_input
+++ b/ocean_only/external_gwave/MOM_input
@@ -279,7 +279,7 @@ HBBL = 0.001                    !   [m]
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity
                                 ! components are truncated.
-VEL_UNDERFLOW = 1.0E-50         !   [m s-1] default = 0.0
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
                                 ! A negligibly small velocity magnitude below which velocity
                                 ! components are set to 0.  A reasonable value might be
                                 ! 1e-30 m/s, which is less than an Angstrom divided by

--- a/ocean_only/external_gwave/MOM_parameter_doc.all
+++ b/ocean_only/external_gwave/MOM_parameter_doc.all
@@ -879,7 +879,7 @@ STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
                                 ! Flag to use Stokes drift Mixing via the Lagrangian
                                 !  current (Eulerian plus Stokes drift).
                                 !  Still needs work and testing, so not recommended for use.
-VEL_UNDERFLOW = 1.0E-50         !   [m s-1] default = 0.0
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
                                 ! A negligibly small velocity magnitude below which velocity
                                 ! components are set to 0.  A reasonable value might be
                                 ! 1e-30 m/s, which is less than an Angstrom divided by

--- a/ocean_only/external_gwave/MOM_parameter_doc.short
+++ b/ocean_only/external_gwave/MOM_parameter_doc.short
@@ -303,7 +303,7 @@ HMIX_FIXED = 1.0E-10            !   [m]
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity
                                 ! components are truncated.
-VEL_UNDERFLOW = 1.0E-50         !   [m s-1] default = 0.0
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
                                 ! A negligibly small velocity magnitude below which velocity
                                 ! components are set to 0.  A reasonable value might be
                                 ! 1e-30 m/s, which is less than an Angstrom divided by

--- a/ocean_only/flow_downslope/common/MOM_input
+++ b/ocean_only/flow_downslope/common/MOM_input
@@ -303,6 +303,11 @@ HBBL = 10.0                     !   [m]
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity
                                 ! components are truncated.
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
+                                ! A negligibly small velocity magnitude below which velocity
+                                ! components are set to 0.  A reasonable value might be
+                                ! 1e-30 m/s, which is less than an Angstrom divided by
+                                ! the age of the universe.
 
 ! === module MOM_PointAccel ===
 

--- a/ocean_only/flow_downslope/layer/MOM_parameter_doc.all
+++ b/ocean_only/flow_downslope/layer/MOM_parameter_doc.all
@@ -894,7 +894,7 @@ STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
                                 ! Flag to use Stokes drift Mixing via the Lagrangian
                                 !  current (Eulerian plus Stokes drift).
                                 !  Still needs work and testing, so not recommended for use.
-VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
                                 ! A negligibly small velocity magnitude below which velocity
                                 ! components are set to 0.  A reasonable value might be
                                 ! 1e-30 m/s, which is less than an Angstrom divided by

--- a/ocean_only/flow_downslope/layer/MOM_parameter_doc.short
+++ b/ocean_only/flow_downslope/layer/MOM_parameter_doc.short
@@ -329,6 +329,11 @@ KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity
                                 ! components are truncated.
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
+                                ! A negligibly small velocity magnitude below which velocity
+                                ! components are set to 0.  A reasonable value might be
+                                ! 1e-30 m/s, which is less than an Angstrom divided by
+                                ! the age of the universe.
 
 ! === module MOM_PointAccel ===
 

--- a/ocean_only/flow_downslope/rho/MOM_parameter_doc.all
+++ b/ocean_only/flow_downslope/rho/MOM_parameter_doc.all
@@ -1027,7 +1027,7 @@ STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
                                 ! Flag to use Stokes drift Mixing via the Lagrangian
                                 !  current (Eulerian plus Stokes drift).
                                 !  Still needs work and testing, so not recommended for use.
-VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
                                 ! A negligibly small velocity magnitude below which velocity
                                 ! components are set to 0.  A reasonable value might be
                                 ! 1e-30 m/s, which is less than an Angstrom divided by

--- a/ocean_only/flow_downslope/rho/MOM_parameter_doc.short
+++ b/ocean_only/flow_downslope/rho/MOM_parameter_doc.short
@@ -379,6 +379,11 @@ KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity
                                 ! components are truncated.
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
+                                ! A negligibly small velocity magnitude below which velocity
+                                ! components are set to 0.  A reasonable value might be
+                                ! 1e-30 m/s, which is less than an Angstrom divided by
+                                ! the age of the universe.
 
 ! === module MOM_PointAccel ===
 

--- a/ocean_only/flow_downslope/sigma/MOM_parameter_doc.all
+++ b/ocean_only/flow_downslope/sigma/MOM_parameter_doc.all
@@ -981,7 +981,7 @@ STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
                                 ! Flag to use Stokes drift Mixing via the Lagrangian
                                 !  current (Eulerian plus Stokes drift).
                                 !  Still needs work and testing, so not recommended for use.
-VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
                                 ! A negligibly small velocity magnitude below which velocity
                                 ! components are set to 0.  A reasonable value might be
                                 ! 1e-30 m/s, which is less than an Angstrom divided by

--- a/ocean_only/flow_downslope/sigma/MOM_parameter_doc.short
+++ b/ocean_only/flow_downslope/sigma/MOM_parameter_doc.short
@@ -352,6 +352,11 @@ KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity
                                 ! components are truncated.
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
+                                ! A negligibly small velocity magnitude below which velocity
+                                ! components are set to 0.  A reasonable value might be
+                                ! 1e-30 m/s, which is less than an Angstrom divided by
+                                ! the age of the universe.
 
 ! === module MOM_PointAccel ===
 

--- a/ocean_only/flow_downslope/z/MOM_parameter_doc.all
+++ b/ocean_only/flow_downslope/z/MOM_parameter_doc.all
@@ -981,7 +981,7 @@ STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
                                 ! Flag to use Stokes drift Mixing via the Lagrangian
                                 !  current (Eulerian plus Stokes drift).
                                 !  Still needs work and testing, so not recommended for use.
-VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
                                 ! A negligibly small velocity magnitude below which velocity
                                 ! components are set to 0.  A reasonable value might be
                                 ! 1e-30 m/s, which is less than an Angstrom divided by

--- a/ocean_only/flow_downslope/z/MOM_parameter_doc.short
+++ b/ocean_only/flow_downslope/z/MOM_parameter_doc.short
@@ -352,6 +352,11 @@ KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity
                                 ! components are truncated.
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
+                                ! A negligibly small velocity magnitude below which velocity
+                                ! components are set to 0.  A reasonable value might be
+                                ! 1e-30 m/s, which is less than an Angstrom divided by
+                                ! the age of the universe.
 
 ! === module MOM_PointAccel ===
 

--- a/ocean_only/lock_exchange/MOM_input
+++ b/ocean_only/lock_exchange/MOM_input
@@ -273,6 +273,11 @@ HBBL = 0.001                    !   [m]
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity
                                 ! components are truncated.
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
+                                ! A negligibly small velocity magnitude below which velocity
+                                ! components are set to 0.  A reasonable value might be
+                                ! 1e-30 m/s, which is less than an Angstrom divided by
+                                ! the age of the universe.
 
 ! === module MOM_PointAccel ===
 

--- a/ocean_only/lock_exchange/MOM_parameter_doc.all
+++ b/ocean_only/lock_exchange/MOM_parameter_doc.all
@@ -882,7 +882,7 @@ STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
                                 ! Flag to use Stokes drift Mixing via the Lagrangian
                                 !  current (Eulerian plus Stokes drift).
                                 !  Still needs work and testing, so not recommended for use.
-VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
                                 ! A negligibly small velocity magnitude below which velocity
                                 ! components are set to 0.  A reasonable value might be
                                 ! 1e-30 m/s, which is less than an Angstrom divided by

--- a/ocean_only/lock_exchange/MOM_parameter_doc.short
+++ b/ocean_only/lock_exchange/MOM_parameter_doc.short
@@ -295,6 +295,11 @@ HMIX_FIXED = 1.0E-10            !   [m]
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity
                                 ! components are truncated.
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
+                                ! A negligibly small velocity magnitude below which velocity
+                                ! components are set to 0.  A reasonable value might be
+                                ! 1e-30 m/s, which is less than an Angstrom divided by
+                                ! the age of the universe.
 
 ! === module MOM_PointAccel ===
 

--- a/ocean_only/single_column/BML/MOM_input
+++ b/ocean_only/single_column/BML/MOM_input
@@ -234,6 +234,11 @@ HBBL = 10.0                     !   [m]
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity
                                 ! components are truncated.
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
+                                ! A negligibly small velocity magnitude below which velocity
+                                ! components are set to 0.  A reasonable value might be
+                                ! 1e-30 m/s, which is less than an Angstrom divided by
+                                ! the age of the universe.
 
 ! === module MOM_PointAccel ===
 

--- a/ocean_only/single_column/BML/MOM_parameter_doc.all
+++ b/ocean_only/single_column/BML/MOM_parameter_doc.all
@@ -790,7 +790,7 @@ STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
                                 ! Flag to use Stokes drift Mixing via the Lagrangian
                                 !  current (Eulerian plus Stokes drift).
                                 !  Still needs work and testing, so not recommended for use.
-VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
                                 ! A negligibly small velocity magnitude below which velocity
                                 ! components are set to 0.  A reasonable value might be
                                 ! 1e-30 m/s, which is less than an Angstrom divided by

--- a/ocean_only/single_column/BML/MOM_parameter_doc.short
+++ b/ocean_only/single_column/BML/MOM_parameter_doc.short
@@ -251,6 +251,11 @@ HARMONIC_VISC = True            !   [Boolean] default = False
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity
                                 ! components are truncated.
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
+                                ! A negligibly small velocity magnitude below which velocity
+                                ! components are set to 0.  A reasonable value might be
+                                ! 1e-30 m/s, which is less than an Angstrom divided by
+                                ! the age of the universe.
 
 ! === module MOM_PointAccel ===
 

--- a/ocean_only/single_column/EPBL/MOM_input
+++ b/ocean_only/single_column/EPBL/MOM_input
@@ -268,6 +268,11 @@ HBBL = 10.0                     !   [m]
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity
                                 ! components are truncated.
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
+                                ! A negligibly small velocity magnitude below which velocity
+                                ! components are set to 0.  A reasonable value might be
+                                ! 1e-30 m/s, which is less than an Angstrom divided by
+                                ! the age of the universe.
 
 ! === module MOM_PointAccel ===
 

--- a/ocean_only/single_column/EPBL/MOM_parameter_doc.all
+++ b/ocean_only/single_column/EPBL/MOM_parameter_doc.all
@@ -873,7 +873,7 @@ STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
                                 ! Flag to use Stokes drift Mixing via the Lagrangian
                                 !  current (Eulerian plus Stokes drift).
                                 !  Still needs work and testing, so not recommended for use.
-VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
                                 ! A negligibly small velocity magnitude below which velocity
                                 ! components are set to 0.  A reasonable value might be
                                 ! 1e-30 m/s, which is less than an Angstrom divided by

--- a/ocean_only/single_column/EPBL/MOM_parameter_doc.short
+++ b/ocean_only/single_column/EPBL/MOM_parameter_doc.short
@@ -290,6 +290,11 @@ HMIX_FIXED = 0.01               !   [m]
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity
                                 ! components are truncated.
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
+                                ! A negligibly small velocity magnitude below which velocity
+                                ! components are set to 0.  A reasonable value might be
+                                ! 1e-30 m/s, which is less than an Angstrom divided by
+                                ! the age of the universe.
 
 ! === module MOM_PointAccel ===
 

--- a/ocean_only/single_column/KPP/MOM_input
+++ b/ocean_only/single_column/KPP/MOM_input
@@ -268,6 +268,11 @@ HBBL = 10.0                     !   [m]
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity
                                 ! components are truncated.
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
+                                ! A negligibly small velocity magnitude below which velocity
+                                ! components are set to 0.  A reasonable value might be
+                                ! 1e-30 m/s, which is less than an Angstrom divided by
+                                ! the age of the universe.
 
 ! === module MOM_PointAccel ===
 

--- a/ocean_only/single_column/KPP/MOM_parameter_doc.all
+++ b/ocean_only/single_column/KPP/MOM_parameter_doc.all
@@ -873,7 +873,7 @@ STOKES_MIXING_COMBINED = False  !   [Boolean] default = False
                                 ! Flag to use Stokes drift Mixing via the Lagrangian
                                 !  current (Eulerian plus Stokes drift).
                                 !  Still needs work and testing, so not recommended for use.
-VEL_UNDERFLOW = 0.0             !   [m s-1] default = 0.0
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
                                 ! A negligibly small velocity magnitude below which velocity
                                 ! components are set to 0.  A reasonable value might be
                                 ! 1e-30 m/s, which is less than an Angstrom divided by

--- a/ocean_only/single_column/KPP/MOM_parameter_doc.short
+++ b/ocean_only/single_column/KPP/MOM_parameter_doc.short
@@ -290,6 +290,11 @@ HMIX_FIXED = 0.01               !   [m]
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity
                                 ! components are truncated.
+VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
+                                ! A negligibly small velocity magnitude below which velocity
+                                ! components are set to 0.  A reasonable value might be
+                                ! 1e-30 m/s, which is less than an Angstrom divided by
+                                ! the age of the universe.
 
 ! === module MOM_PointAccel ===
 


### PR DESCRIPTION
  Explicitly set the underflow velocity to 1e-30 in 12 MOM_input files for
ocean-only test cases where this value could change the answers in the
MOM6-examples test cases; different compilers change answers for different
cases.  Most of these are single column or other simple test cases.  This
changes is necessary to enable dimensional consistency testing involving
velocities.  New MOM_input, MOM_parameter_doc files and reference solutions have
been provided.