### PR TITLE
*Fixed input.nml for Intersperse_ice_1deg test case

### DIFF
--- a/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/CIOD_parameter_doc.all
+++ b/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/CIOD_parameter_doc.all
@@ -1,0 +1,25 @@
+! This file was written by the model and records all non-layout or debugging parameters used at run-time.
+
+! === module ice_ocean_driver_init ===
+SINGLE_MOM_CALL = False         !   [Boolean] default = True
+                                ! If true, advance the state of MOM with a single step
+                                ! including both dynamics and thermodynamics.  If false,
+                                ! the two phases are advanced with separate calls.
+INTERSPERSE_ICE_OCEAN = True    !   [Boolean] default = False
+                                ! If true, intersperse the ice and ocean thermodynamic and
+                                ! and dynamic updates.
+DT_COUPLED_ICE_OCEAN_DYN = 3600.0 !   [seconds] default = -1.0
+                                ! The time step for coupling the ice and ocean dynamics when
+                                ! INTERSPERSE_ICE_OCEAN is true, or <0 to use the coupled timestep.
+
+! === module MOM_file_parser ===
+SEND_LOG_TO_STDOUT = False      !   [Boolean] default = False
+                                ! If true, all log messages are also sent to stdout.
+DOCUMENT_FILE = "CIOD_parameter_doc" ! default = "MOM_parameter_doc"
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.
+COMPLETE_DOCUMENTATION = True   !   [Boolean] default = True
+                                ! If true, all run-time parameters are documented in CIOD_parameter_doc.all .
+MINIMAL_DOCUMENTATION = True    !   [Boolean] default = True
+                                ! If true, non-default run-time parameters are documented in
+                                ! CIOD_parameter_doc.short .

--- a/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/CIOD_parameter_doc.debugging
+++ b/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/CIOD_parameter_doc.debugging
@@ -1,0 +1,5 @@
+! This file was written by the model and records the debugging parameters used at run-time.
+REPORT_UNUSED_PARAMS = False    !   [Boolean] default = False
+                                ! If true, report any parameter lines that are not used in the run.
+FATAL_UNUSED_PARAMS = False     !   [Boolean] default = False
+                                ! If true, kill the run if there are any unused parameters.

--- a/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/CIOD_parameter_doc.layout
+++ b/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/CIOD_parameter_doc.layout
@@ -1,0 +1,1 @@
+! This file was written by the model and records the layout parameters used at run-time.

--- a/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/CIOD_parameter_doc.short
+++ b/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/CIOD_parameter_doc.short
@@ -1,0 +1,18 @@
+! This file was written by the model and records the non-default parameters used at run-time.
+
+! === module ice_ocean_driver_init ===
+SINGLE_MOM_CALL = False         !   [Boolean] default = True
+                                ! If true, advance the state of MOM with a single step
+                                ! including both dynamics and thermodynamics.  If false,
+                                ! the two phases are advanced with separate calls.
+INTERSPERSE_ICE_OCEAN = True    !   [Boolean] default = False
+                                ! If true, intersperse the ice and ocean thermodynamic and
+                                ! and dynamic updates.
+DT_COUPLED_ICE_OCEAN_DYN = 3600.0 !   [seconds] default = -1.0
+                                ! The time step for coupling the ice and ocean dynamics when
+                                ! INTERSPERSE_ICE_OCEAN is true, or <0 to use the coupled timestep.
+
+! === module MOM_file_parser ===
+DOCUMENT_FILE = "CIOD_parameter_doc" ! default = "MOM_parameter_doc"
+                                ! The basename for files where run-time parameters, their settings, units and
+                                ! defaults are documented. Blank will disable all parameter documentation.

--- a/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/input.nml
+++ b/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/input.nml
@@ -153,7 +153,8 @@
         concurrent = .true.,
         use_lag_fluxes = .false.,
         concurrent_ice = .true.,
-        slow_ice_with_ocean = .true.
+        slow_ice_with_ocean = .true.,
+        combined_ice_and_ocean = .true.
 /
 
  &cu_mo_trans_nml


### PR DESCRIPTION
  Added the line 'combined_ice_and_ocean = .true.' to the input.nml file for the
Intersperse_ice_1deg test case, which changes the solutions for this test case.
Also added 4 CIOD_parameter_doc files documenting the parameters for the
coupled-ice-ocean-driver code.