### PR TITLE
Z diag purge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build*
 .datasets
 # Ignore model output
 *.out
+CPU_stats
 CPU_stats.*
 _read_error.nml
 available_diags.0*
@@ -14,7 +15,9 @@ fort.20
 *.nc
 *.nc.*
 RESTART
+ocean.stats
 ocean.stats.*
+seaice.stats
 seaice.stats.*
 # Ignore python .pyc files
 *.pyc

--- a/coupled_AM2_LM3_SIS/AM2_MOM6i_1deg/MOM_input
+++ b/coupled_AM2_LM3_SIS/AM2_MOM6i_1deg/MOM_input
@@ -85,11 +85,6 @@ DT_THERM = 7200.0               !   [s] default = 3600.0
                                 ! Ideally DT_THERM should be an integer multiple of DT
                                 ! and less than the forcing or coupling time-step.
                                 ! By default DT_THERM is set to DT.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
                                 ! The period between recalculations of DTBT (if DTBT <= 0).
                                 ! If DTBT_RESET_PERIOD is negative, DTBT is set based
@@ -406,13 +401,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
                                 ! geostrophic kinetic energy or 1 plus the square of the
                                 ! grid spacing over the deformation radius, as detailed
                                 ! by Fox-Kemper et al. (2010)
-Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
-!NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/coupled_AM2_LM3_SIS/CM2G63L/MOM_input
+++ b/coupled_AM2_LM3_SIS/CM2G63L/MOM_input
@@ -30,11 +30,6 @@ DT_THERM = 7200.0               !   [s] default = 3600.0
                                 ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
                                 ! can be an integer multiple of the coupling timestep.  By
                                 ! default DT_THERM is set to DT.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 FRAZIL = True                   !   [Boolean] default = False
                                 ! If true, water freezes if it gets too cold, and the
                                 ! the accumulated heat deficit is returned in the
@@ -400,15 +395,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
                                 ! geostrophic kinetic energy or 1 plus the square of the
                                 ! grid spacing over the deformation radius, as detailed
                                 ! by Fox-Kemper et al. (2010)
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
-!NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/coupled_AM2_LM3_SIS/CM2G63L/MOM_parameter_doc.all
+++ b/coupled_AM2_LM3_SIS/CM2G63L/MOM_parameter_doc.all
@@ -70,7 +70,7 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
+MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
                                 ! The minimum amount of time in seconds between calculations of depth-space
                                 ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
@@ -1057,12 +1057,9 @@ DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
+Z_OUTPUT_GRID_FILE = ""         ! default = ""
                                 ! The file that specifies the vertical grid for depth-space diagnostics, or
                                 ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/coupled_AM2_LM3_SIS/CM2G63L/MOM_parameter_doc.short
+++ b/coupled_AM2_LM3_SIS/CM2G63L/MOM_parameter_doc.short
@@ -18,10 +18,6 @@ DT_THERM = 7200.0               !   [s] default = 3600.0
                                 ! an integer multiple of DT and less than the forcing or coupling time-step,
                                 ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
                                 ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 FRAZIL = True                   !   [Boolean] default = False
                                 ! If true, water freezes if it gets too cold, and the the accumulated heat
                                 ! deficit is returned in the surface state.  FRAZIL is only used if
@@ -343,12 +339,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
                                 ! (2010)
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/coupled_AM2_LM3_SIS2/AM2_SIS2B_MOM6i_1deg/MOM_input
+++ b/coupled_AM2_LM3_SIS2/AM2_SIS2B_MOM6i_1deg/MOM_input
@@ -85,11 +85,6 @@ DT_THERM = 7200.0               !   [s] default = 3600.0
                                 ! Ideally DT_THERM should be an integer multiple of DT
                                 ! and less than the forcing or coupling time-step.
                                 ! By default DT_THERM is set to DT.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
                                 ! The period between recalculations of DTBT (if DTBT <= 0).
                                 ! If DTBT_RESET_PERIOD is negative, DTBT is set based
@@ -407,13 +402,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
                                 ! geostrophic kinetic energy or 1 plus the square of the
                                 ! grid spacing over the deformation radius, as detailed
                                 ! by Fox-Kemper et al. (2010)
-Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
-!NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/MOM_input
+++ b/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/MOM_input
@@ -85,11 +85,6 @@ DT_THERM = 7200.0               !   [s] default = 3600.0
                                 ! Ideally DT_THERM should be an integer multiple of DT
                                 ! and less than the forcing or coupling time-step.
                                 ! By default DT_THERM is set to DT.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
                                 ! The period between recalculations of DTBT (if DTBT <= 0).
                                 ! If DTBT_RESET_PERIOD is negative, DTBT is set based
@@ -407,13 +402,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
                                 ! geostrophic kinetic energy or 1 plus the square of the
                                 ! grid spacing over the deformation radius, as detailed
                                 ! by Fox-Kemper et al. (2010)
-Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
-!NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/MOM_parameter_doc.all
+++ b/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/MOM_parameter_doc.all
@@ -70,7 +70,7 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
+MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
                                 ! The minimum amount of time in seconds between calculations of depth-space
                                 ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
@@ -1053,12 +1053,9 @@ DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
+Z_OUTPUT_GRID_FILE = ""         ! default = ""
                                 ! The file that specifies the vertical grid for depth-space diagnostics, or
                                 ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/MOM_parameter_doc.short
+++ b/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/MOM_parameter_doc.short
@@ -18,10 +18,6 @@ DT_THERM = 7200.0               !   [s] default = 3600.0
                                 ! an integer multiple of DT and less than the forcing or coupling time-step,
                                 ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
                                 ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
                                 ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
                                 ! is negative, DTBT is set based only on information available at
@@ -339,12 +335,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
                                 ! (2010)
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/MOM_input
+++ b/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/MOM_input
@@ -85,11 +85,6 @@ DT_THERM = 7200.0               !   [s] default = 3600.0
                                 ! Ideally DT_THERM should be an integer multiple of DT
                                 ! and less than the forcing or coupling time-step.
                                 ! By default DT_THERM is set to DT.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
                                 ! The period between recalculations of DTBT (if DTBT <= 0).
                                 ! If DTBT_RESET_PERIOD is negative, DTBT is set based
@@ -407,13 +402,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
                                 ! geostrophic kinetic energy or 1 plus the square of the
                                 ! grid spacing over the deformation radius, as detailed
                                 ! by Fox-Kemper et al. (2010)
-Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
-!NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/MOM_parameter_doc.all
+++ b/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/MOM_parameter_doc.all
@@ -70,7 +70,7 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
+MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
                                 ! The minimum amount of time in seconds between calculations of depth-space
                                 ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
@@ -1053,12 +1053,9 @@ DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
+Z_OUTPUT_GRID_FILE = ""         ! default = ""
                                 ! The file that specifies the vertical grid for depth-space diagnostics, or
                                 ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/MOM_parameter_doc.short
+++ b/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/MOM_parameter_doc.short
@@ -18,10 +18,6 @@ DT_THERM = 7200.0               !   [s] default = 3600.0
                                 ! an integer multiple of DT and less than the forcing or coupling time-step,
                                 ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
                                 ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
                                 ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
                                 ! is negative, DTBT is set based only on information available at
@@ -339,12 +335,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
                                 ! (2010)
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/MOM_input
+++ b/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/MOM_input
@@ -89,11 +89,6 @@ DT_THERM = 7200.0               !   [s] default = 3600.0
                                 ! Ideally DT_THERM should be an integer multiple of DT
                                 ! and less than the forcing or coupling time-step.
                                 ! By default DT_THERM is set to DT.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
                                 ! The period between recalculations of DTBT (if DTBT <= 0).
                                 ! If DTBT_RESET_PERIOD is negative, DTBT is set based
@@ -411,13 +406,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
                                 ! geostrophic kinetic energy or 1 plus the square of the
                                 ! grid spacing over the deformation radius, as detailed
                                 ! by Fox-Kemper et al. (2010)
-Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
-!NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/MOM_parameter_doc.all
+++ b/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/MOM_parameter_doc.all
@@ -70,7 +70,7 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
+MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
                                 ! The minimum amount of time in seconds between calculations of depth-space
                                 ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
@@ -1053,12 +1053,9 @@ DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
+Z_OUTPUT_GRID_FILE = ""         ! default = ""
                                 ! The file that specifies the vertical grid for depth-space diagnostics, or
                                 ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/MOM_parameter_doc.short
+++ b/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/MOM_parameter_doc.short
@@ -21,10 +21,6 @@ DT_THERM = 7200.0               !   [s] default = 3600.0
                                 ! an integer multiple of DT and less than the forcing or coupling time-step,
                                 ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
                                 ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
                                 ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
                                 ! is negative, DTBT is set based only on information available at
@@ -342,12 +338,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
                                 ! (2010)
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ice_ocean_SIS/Amery/MOM_input
+++ b/ice_ocean_SIS/Amery/MOM_input
@@ -4,7 +4,7 @@
 !* appropriate, MKS units are used.                                   *
 !********+*********+*********+*********+*********+*********+*********+*
 
-!SYMMETRIC_MEMORY_ = True       
+!SYMMETRIC_MEMORY_ = True
 
 DAYMAX = 36500.0
 
@@ -190,15 +190,6 @@ SAVE_INITIAL_CONDS = True       !    If defined, the inital conditions are
                                 !  new run.
 IC_OUTPUT_FILE = "MOM_IC"       !  The name-root of a file into which the
                                 !  initial conditions are written for a new run.
-
-Z_OUTPUT_GRID_FILE = "zgrid.nc"
-                                !    The file that specifies the vertical grid
-                                !  for depth-space diagnostics.
-MIN_Z_DIAG_INTERVAL = 2.16e4    ! The minimum amount of time in seconds between
-                                !  calculations of depth-space diagnostics.
-                                !  Making this larger than DT_THERM reduces the
-                                !  performance penalty of regridding to depth
-                                !  online.
 
 MAXCPU = 86400.0                !   The maximum amount of cpu time per processor
                                 !  for which MOM should run before saving a

--- a/ice_ocean_SIS/GIS_0125/MOM_input
+++ b/ice_ocean_SIS/GIS_0125/MOM_input
@@ -188,15 +188,6 @@ SAVE_INITIAL_CONDS = True       !    If defined, the inital conditions are
 IC_OUTPUT_FILE = "MOM_IC"       !  The name-root of a file into which the
                                 !  initial conditions are written for a new run.
 
-Z_OUTPUT_GRID_FILE = "zgrid.nc"
-                                !    The file that specifies the vertical grid
-                                !  for depth-space diagnostics.
-MIN_Z_DIAG_INTERVAL = 2.16e4    ! The minimum amount of time in seconds between
-                                !  calculations of depth-space diagnostics.
-                                !  Making this larger than DT_THERM reduces the
-                                !  performance penalty of regridding to depth
-                                !  online.
-
 MAXCPU = 86400.0                !   The maximum amount of cpu time per processor
                                 !  for which MOM should run before saving a
                                 !  restart file and quitting with a return value

--- a/ice_ocean_SIS/GOLD_SIS/MOM_input
+++ b/ice_ocean_SIS/GOLD_SIS/MOM_input
@@ -85,11 +85,6 @@ DT_THERM = 7200.0               !   [s] default = 3600.0
                                 ! Ideally DT_THERM should be an integer multiple of DT
                                 ! and less than the forcing or coupling time-step.
                                 ! By default DT_THERM is set to DT.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
                                 ! The period between recalculations of DTBT (if DTBT <= 0).
                                 ! If DTBT_RESET_PERIOD is negative, DTBT is set based
@@ -434,13 +429,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
                                 ! geostrophic kinetic energy or 1 plus the square of the
                                 ! grid spacing over the deformation radius, as detailed
                                 ! by Fox-Kemper et al. (2010)
-Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
-!NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ice_ocean_SIS/GOLD_SIS_025/MOM_input
+++ b/ice_ocean_SIS/GOLD_SIS_025/MOM_input
@@ -81,11 +81,6 @@ DT_THERM = 3600.0               !   [s] default = 1200.0
                                 ! Ideally DT_THERM should be an integer multiple of DT
                                 ! and less than the forcing or coupling time-step.
                                 ! By default DT_THERM is set to DT.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 DTBT_RESET_PERIOD = -1.0        !   [s] default = 3600.0
                                 ! The period between recalculations of DTBT (if DTBT <= 0).
                                 ! If DTBT_RESET_PERIOD is negative, DTBT is set based
@@ -382,13 +377,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 5.0 !   [nondim] default = 0.0
                                 ! geostrophic kinetic energy or 1 plus the square of the
                                 ! grid spacing over the deformation radius, as detailed
                                 ! by Fox-Kemper et al. (2010)
-Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
-!NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ice_ocean_SIS/GOLD_SIS_icebergs/MOM_input
+++ b/ice_ocean_SIS/GOLD_SIS_icebergs/MOM_input
@@ -85,11 +85,6 @@ DT_THERM = 7200.0               !   [s] default = 3600.0
                                 ! Ideally DT_THERM should be an integer multiple of DT
                                 ! and less than the forcing or coupling time-step.
                                 ! By default DT_THERM is set to DT.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
                                 ! The period between recalculations of DTBT (if DTBT <= 0).
                                 ! If DTBT_RESET_PERIOD is negative, DTBT is set based
@@ -434,13 +429,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
                                 ! geostrophic kinetic energy or 1 plus the square of the
                                 ! grid spacing over the deformation radius, as detailed
                                 ! by Fox-Kemper et al. (2010)
-Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
-!NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ice_ocean_SIS2/Baltic/MOM_input
+++ b/ice_ocean_SIS2/Baltic/MOM_input
@@ -86,11 +86,6 @@ DT_THERM = 7200.0               !   [s] default = 3600.0
                                 ! Ideally DT_THERM should be an integer multiple of DT
                                 ! and less than the forcing or coupling time-step.
                                 ! By default DT_THERM is set to DT.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
                                 ! The period between recalculations of DTBT (if DTBT <= 0).
                                 ! If DTBT_RESET_PERIOD is negative, DTBT is set based
@@ -406,13 +401,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
                                 ! geostrophic kinetic energy or 1 plus the square of the
                                 ! grid spacing over the deformation radius, as detailed
                                 ! by Fox-Kemper et al. (2010)
-Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
-!NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ice_ocean_SIS2/Baltic/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/Baltic/MOM_parameter_doc.all
@@ -70,7 +70,7 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
+MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
                                 ! The minimum amount of time in seconds between calculations of depth-space
                                 ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
@@ -1053,12 +1053,9 @@ DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
+Z_OUTPUT_GRID_FILE = ""         ! default = ""
                                 ! The file that specifies the vertical grid for depth-space diagnostics, or
                                 ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ice_ocean_SIS2/Baltic/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/Baltic/MOM_parameter_doc.short
@@ -18,10 +18,6 @@ DT_THERM = 7200.0               !   [s] default = 3600.0
                                 ! an integer multiple of DT and less than the forcing or coupling time-step,
                                 ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
                                 ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
                                 ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
                                 ! is negative, DTBT is set based only on information available at
@@ -350,12 +346,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
                                 ! (2010)
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/MOM_input
+++ b/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/MOM_input
@@ -86,11 +86,6 @@ DT_THERM = 7200.0               !   [s] default = 3600.0
                                 ! Ideally DT_THERM should be an integer multiple of DT
                                 ! and less than the forcing or coupling time-step.
                                 ! By default DT_THERM is set to DT.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
                                 ! The period between recalculations of DTBT (if DTBT <= 0).
                                 ! If DTBT_RESET_PERIOD is negative, DTBT is set based
@@ -429,13 +424,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
                                 ! geostrophic kinetic energy or 1 plus the square of the
                                 ! grid spacing over the deformation radius, as detailed
                                 ! by Fox-Kemper et al. (2010)
-Z_OUTPUT_GRID_FILE = "analysis_vgrid_lev35.v1.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
-!NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/MOM_parameter_doc.all
@@ -78,7 +78,7 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
+MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
                                 ! The minimum amount of time in seconds between calculations of depth-space
                                 ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
@@ -1276,12 +1276,9 @@ DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "analysis_vgrid_lev35.v1.nc" ! default = ""
+Z_OUTPUT_GRID_FILE = ""         ! default = ""
                                 ! The file that specifies the vertical grid for depth-space diagnostics, or
                                 ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/MOM_parameter_doc.short
@@ -21,10 +21,6 @@ DT_THERM = 7200.0               !   [s] default = 3600.0
                                 ! an integer multiple of DT and less than the forcing or coupling time-step,
                                 ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
                                 ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
                                 ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
                                 ! is negative, DTBT is set based only on information available at
@@ -406,12 +402,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
                                 ! (2010)
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "analysis_vgrid_lev35.v1.nc" ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ice_ocean_SIS2/Baltic_OM4_025/MOM_input
+++ b/ice_ocean_SIS2/Baltic_OM4_025/MOM_input
@@ -37,11 +37,6 @@ THERMO_SPANS_COUPLING = True    !   [Boolean] default = False
                                 ! The actual thermodynamic timestep that is used in this
                                 ! case is the largest integer multiple of the coupling
                                 ! timestep that is less than or equal to DT_THERM.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 FRAZIL = True                   !   [Boolean] default = False
                                 ! If true, water freezes if it gets too cold, and the
                                 ! the accumulated heat deficit is returned in the
@@ -574,15 +569,6 @@ MLE_MLD_DECAY_TIME = 2.592E+06  !   [s] default = 0.0
                                 ! depth used in the MLE restratification parameterization. When
                                 ! the MLD deepens below the current running-mean the running-mean
                                 ! is instantaneously set to the current MLD.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "analysis_vgrid_lev35.v1.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ice_ocean_SIS2/Baltic_OM4_025/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/Baltic_OM4_025/MOM_parameter_doc.all
@@ -78,7 +78,7 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
+MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
                                 ! The minimum amount of time in seconds between calculations of depth-space
                                 ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
@@ -1286,12 +1286,9 @@ DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "analysis_vgrid_lev35.v1.nc" ! default = ""
+Z_OUTPUT_GRID_FILE = ""         ! default = ""
                                 ! The file that specifies the vertical grid for depth-space diagnostics, or
                                 ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ice_ocean_SIS2/Baltic_OM4_025/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/Baltic_OM4_025/MOM_parameter_doc.short
@@ -26,10 +26,6 @@ THERMO_SPANS_COUPLING = True    !   [Boolean] default = False
                                 ! longer than the coupling timestep. The actual thermodynamic timestep that is
                                 ! used in this case is the largest integer multiple of the coupling timestep
                                 ! that is less than or equal to DT_THERM.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 FRAZIL = True                   !   [Boolean] default = False
                                 ! If true, water freezes if it gets too cold, and the the accumulated heat
                                 ! deficit is returned in the surface state.  FRAZIL is only used if
@@ -505,12 +501,6 @@ MLE_MLD_DECAY_TIME = 2.592E+06  !   [s] default = 0.0
                                 ! MLD.
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "analysis_vgrid_lev35.v1.nc" ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ice_ocean_SIS2/Baltic_OM4_025/ocean.stats
+++ b/ice_ocean_SIS2/Baltic_OM4_025/ocean.stats
@@ -1,4 +1,0 @@
-  Step,       Day,  Truncs,      Energy/Mass,      Maximum CFL,  Mean Sea Level,  Total Mass,  Mean Salin, Mean Temp, Frac Mass Err,   Salin Err,    Temp Err
-            [days]                 [m2 s-2]           [Nondim]       [m]             [kg]         [PSU]      [degC]       [Nondim]        [PSU]        [degC]
-     0,  693135.000,     0, En 4.056814460564E-01, CFL  0.00000, SL -1.5454E-13, M 4.64979E+16, S 22.7321, T  5.3249, Me  0.00E+00, Se  0.00E+00, Te  0.00E+00
-    12,  693135.250,     0, En 4.075240676792E-01, CFL  0.02559, SL -1.4033E-13, M 4.64979E+16, S 22.7321, T  5.3117, Me  5.85E-19, Se -1.68E-15, Te -1.29E-16

--- a/ice_ocean_SIS2/Baltic_OM4_05/MOM_input
+++ b/ice_ocean_SIS2/Baltic_OM4_05/MOM_input
@@ -37,11 +37,6 @@ THERMO_SPANS_COUPLING = True    !   [Boolean] default = False
                                 ! The actual thermodynamic timestep that is used in this
                                 ! case is the largest integer multiple of the coupling
                                 ! timestep that is less than or equal to DT_THERM.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 FRAZIL = True                   !   [Boolean] default = False
                                 ! If true, water freezes if it gets too cold, and the
                                 ! the accumulated heat deficit is returned in the
@@ -599,15 +594,6 @@ MLE_MLD_DECAY_TIME = 2.592E+06  !   [s] default = 0.0
                                 ! depth used in the MLE restratification parameterization. When
                                 ! the MLD deepens below the current running-mean the running-mean
                                 ! is instantaneously set to the current MLD.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "analysis_vgrid_lev35.v1.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ice_ocean_SIS2/Baltic_OM4_05/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/Baltic_OM4_05/MOM_parameter_doc.all
@@ -78,7 +78,7 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
+MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
                                 ! The minimum amount of time in seconds between calculations of depth-space
                                 ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
@@ -1299,12 +1299,9 @@ DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "analysis_vgrid_lev35.v1.nc" ! default = ""
+Z_OUTPUT_GRID_FILE = ""         ! default = ""
                                 ! The file that specifies the vertical grid for depth-space diagnostics, or
                                 ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ice_ocean_SIS2/Baltic_OM4_05/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/Baltic_OM4_05/MOM_parameter_doc.short
@@ -26,10 +26,6 @@ THERMO_SPANS_COUPLING = True    !   [Boolean] default = False
                                 ! longer than the coupling timestep. The actual thermodynamic timestep that is
                                 ! used in this case is the largest integer multiple of the coupling timestep
                                 ! that is less than or equal to DT_THERM.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 FRAZIL = True                   !   [Boolean] default = False
                                 ! If true, water freezes if it gets too cold, and the the accumulated heat
                                 ! deficit is returned in the surface state.  FRAZIL is only used if
@@ -527,12 +523,6 @@ MLE_MLD_DECAY_TIME = 2.592E+06  !   [s] default = 0.0
                                 ! MLD.
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "analysis_vgrid_lev35.v1.nc" ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ice_ocean_SIS2/OM4_025/MOM_input
+++ b/ice_ocean_SIS2/OM4_025/MOM_input
@@ -37,11 +37,6 @@ THERMO_SPANS_COUPLING = True    !   [Boolean] default = False
                                 ! The actual thermodynamic timestep that is used in this
                                 ! case is the largest integer multiple of the coupling
                                 ! timestep that is less than or equal to DT_THERM.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 FRAZIL = True                   !   [Boolean] default = False
                                 ! If true, water freezes if it gets too cold, and the
                                 ! the accumulated heat deficit is returned in the
@@ -583,15 +578,6 @@ MLE_MLD_DECAY_TIME = 2.592E+06  !   [s] default = 0.0
                                 ! depth used in the MLE restratification parameterization. When
                                 ! the MLD deepens below the current running-mean the running-mean
                                 ! is instantaneously set to the current MLD.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "analysis_vgrid_lev35.v1.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ice_ocean_SIS2/OM4_025/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/OM4_025/MOM_parameter_doc.all
@@ -78,7 +78,7 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
+MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
                                 ! The minimum amount of time in seconds between calculations of depth-space
                                 ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
@@ -1286,12 +1286,9 @@ DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "analysis_vgrid_lev35.v1.nc" ! default = ""
+Z_OUTPUT_GRID_FILE = ""         ! default = ""
                                 ! The file that specifies the vertical grid for depth-space diagnostics, or
                                 ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ice_ocean_SIS2/OM4_025/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/OM4_025/MOM_parameter_doc.short
@@ -26,10 +26,6 @@ THERMO_SPANS_COUPLING = True    !   [Boolean] default = False
                                 ! longer than the coupling timestep. The actual thermodynamic timestep that is
                                 ! used in this case is the largest integer multiple of the coupling timestep
                                 ! that is less than or equal to DT_THERM.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 FRAZIL = True                   !   [Boolean] default = False
                                 ! If true, water freezes if it gets too cold, and the the accumulated heat
                                 ! deficit is returned in the surface state.  FRAZIL is only used if
@@ -512,12 +508,6 @@ MLE_MLD_DECAY_TIME = 2.592E+06  !   [s] default = 0.0
                                 ! MLD.
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "analysis_vgrid_lev35.v1.nc" ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ice_ocean_SIS2/OM4_05/MOM_input
+++ b/ice_ocean_SIS2/OM4_05/MOM_input
@@ -37,11 +37,6 @@ THERMO_SPANS_COUPLING = True    !   [Boolean] default = False
                                 ! The actual thermodynamic timestep that is used in this
                                 ! case is the largest integer multiple of the coupling
                                 ! timestep that is less than or equal to DT_THERM.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 FRAZIL = True                   !   [Boolean] default = False
                                 ! If true, water freezes if it gets too cold, and the
                                 ! the accumulated heat deficit is returned in the
@@ -615,15 +610,6 @@ MLE_MLD_DECAY_TIME = 2.592E+06  !   [s] default = 0.0
                                 ! depth used in the MLE restratification parameterization. When
                                 ! the MLD deepens below the current running-mean the running-mean
                                 ! is instantaneously set to the current MLD.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "analysis_vgrid_lev35.v1.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ice_ocean_SIS2/OM4_05/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/OM4_05/MOM_parameter_doc.all
@@ -78,7 +78,7 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
+MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
                                 ! The minimum amount of time in seconds between calculations of depth-space
                                 ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
@@ -1304,12 +1304,9 @@ DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "analysis_vgrid_lev35.v1.nc" ! default = ""
+Z_OUTPUT_GRID_FILE = ""         ! default = ""
                                 ! The file that specifies the vertical grid for depth-space diagnostics, or
                                 ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ice_ocean_SIS2/OM4_05/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/OM4_05/MOM_parameter_doc.short
@@ -26,10 +26,6 @@ THERMO_SPANS_COUPLING = True    !   [Boolean] default = False
                                 ! longer than the coupling timestep. The actual thermodynamic timestep that is
                                 ! used in this case is the largest integer multiple of the coupling timestep
                                 ! that is less than or equal to DT_THERM.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 FRAZIL = True                   !   [Boolean] default = False
                                 ! If true, water freezes if it gets too cold, and the the accumulated heat
                                 ! deficit is returned in the surface state.  FRAZIL is only used if
@@ -538,12 +534,6 @@ MLE_MLD_DECAY_TIME = 2.592E+06  !   [s] default = 0.0
                                 ! MLD.
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "analysis_vgrid_lev35.v1.nc" ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ice_ocean_SIS2/SIS2/MOM_input
+++ b/ice_ocean_SIS2/SIS2/MOM_input
@@ -85,11 +85,6 @@ DT_THERM = 7200.0               !   [s] default = 3600.0
                                 ! Ideally DT_THERM should be an integer multiple of DT
                                 ! and less than the forcing or coupling time-step.
                                 ! By default DT_THERM is set to DT.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
                                 ! The period between recalculations of DTBT (if DTBT <= 0).
                                 ! If DTBT_RESET_PERIOD is negative, DTBT is set based
@@ -437,13 +432,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
                                 ! geostrophic kinetic energy or 1 plus the square of the
                                 ! grid spacing over the deformation radius, as detailed
                                 ! by Fox-Kemper et al. (2010)
-Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
-!NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ice_ocean_SIS2/SIS2/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/SIS2/MOM_parameter_doc.all
@@ -70,7 +70,7 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
+MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
                                 ! The minimum amount of time in seconds between calculations of depth-space
                                 ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
@@ -1077,12 +1077,9 @@ DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
+Z_OUTPUT_GRID_FILE = ""         ! default = ""
                                 ! The file that specifies the vertical grid for depth-space diagnostics, or
                                 ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ice_ocean_SIS2/SIS2/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/SIS2/MOM_parameter_doc.short
@@ -18,10 +18,6 @@ DT_THERM = 7200.0               !   [s] default = 3600.0
                                 ! an integer multiple of DT and less than the forcing or coupling time-step,
                                 ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
                                 ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
                                 ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
                                 ! is negative, DTBT is set based only on information available at
@@ -377,12 +373,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
                                 ! (2010)
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ice_ocean_SIS2/SIS2_bergs_cgrid/MOM_input
+++ b/ice_ocean_SIS2/SIS2_bergs_cgrid/MOM_input
@@ -85,11 +85,6 @@ DT_THERM = 7200.0               !   [s] default = 3600.0
                                 ! Ideally DT_THERM should be an integer multiple of DT
                                 ! and less than the forcing or coupling time-step.
                                 ! By default DT_THERM is set to DT.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
                                 ! The period between recalculations of DTBT (if DTBT <= 0).
                                 ! If DTBT_RESET_PERIOD is negative, DTBT is set based
@@ -437,13 +432,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
                                 ! geostrophic kinetic energy or 1 plus the square of the
                                 ! grid spacing over the deformation radius, as detailed
                                 ! by Fox-Kemper et al. (2010)
-Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
-!NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ice_ocean_SIS2/SIS2_bergs_cgrid/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/SIS2_bergs_cgrid/MOM_parameter_doc.all
@@ -70,7 +70,7 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
+MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
                                 ! The minimum amount of time in seconds between calculations of depth-space
                                 ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
@@ -1077,12 +1077,9 @@ DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
+Z_OUTPUT_GRID_FILE = ""         ! default = ""
                                 ! The file that specifies the vertical grid for depth-space diagnostics, or
                                 ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ice_ocean_SIS2/SIS2_bergs_cgrid/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/SIS2_bergs_cgrid/MOM_parameter_doc.short
@@ -18,10 +18,6 @@ DT_THERM = 7200.0               !   [s] default = 3600.0
                                 ! an integer multiple of DT and less than the forcing or coupling time-step,
                                 ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
                                 ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
                                 ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
                                 ! is negative, DTBT is set based only on information available at
@@ -377,12 +373,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
                                 ! (2010)
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ice_ocean_SIS2/SIS2_cgrid/MOM_input
+++ b/ice_ocean_SIS2/SIS2_cgrid/MOM_input
@@ -85,11 +85,6 @@ DT_THERM = 7200.0               !   [s] default = 3600.0
                                 ! Ideally DT_THERM should be an integer multiple of DT
                                 ! and less than the forcing or coupling time-step.
                                 ! By default DT_THERM is set to DT.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
                                 ! The period between recalculations of DTBT (if DTBT <= 0).
                                 ! If DTBT_RESET_PERIOD is negative, DTBT is set based
@@ -437,13 +432,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
                                 ! geostrophic kinetic energy or 1 plus the square of the
                                 ! grid spacing over the deformation radius, as detailed
                                 ! by Fox-Kemper et al. (2010)
-Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
-!NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ice_ocean_SIS2/SIS2_cgrid/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/SIS2_cgrid/MOM_parameter_doc.all
@@ -70,7 +70,7 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
+MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
                                 ! The minimum amount of time in seconds between calculations of depth-space
                                 ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
@@ -1077,12 +1077,9 @@ DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
+Z_OUTPUT_GRID_FILE = ""         ! default = ""
                                 ! The file that specifies the vertical grid for depth-space diagnostics, or
                                 ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ice_ocean_SIS2/SIS2_cgrid/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/SIS2_cgrid/MOM_parameter_doc.short
@@ -18,10 +18,6 @@ DT_THERM = 7200.0               !   [s] default = 3600.0
                                 ! an integer multiple of DT and less than the forcing or coupling time-step,
                                 ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
                                 ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
                                 ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
                                 ! is negative, DTBT is set based only on information available at
@@ -377,12 +373,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
                                 ! (2010)
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ice_ocean_SIS2/SIS2_icebergs/MOM_input
+++ b/ice_ocean_SIS2/SIS2_icebergs/MOM_input
@@ -85,11 +85,6 @@ DT_THERM = 7200.0               !   [s] default = 3600.0
                                 ! Ideally DT_THERM should be an integer multiple of DT
                                 ! and less than the forcing or coupling time-step.
                                 ! By default DT_THERM is set to DT.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
                                 ! The period between recalculations of DTBT (if DTBT <= 0).
                                 ! If DTBT_RESET_PERIOD is negative, DTBT is set based
@@ -434,13 +429,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
                                 ! geostrophic kinetic energy or 1 plus the square of the
                                 ! grid spacing over the deformation radius, as detailed
                                 ! by Fox-Kemper et al. (2010)
-Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
-!NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/land_ice_ocean_LM3_SIS2/OM_360x320_C180/MOM_input
+++ b/land_ice_ocean_LM3_SIS2/OM_360x320_C180/MOM_input
@@ -95,11 +95,6 @@ DT_THERM = 3600.0               !   [s] default = 1200.0
                                 ! THERMO_SPANS_COUPLING is true, in which case DT_THERM
                                 ! can be an integer multiple of the coupling timestep.  By
                                 ! default DT_THERM is set to DT.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 DTBT_RESET_PERIOD = -1.0        !   [s] default = 3600.0
                                 ! The period between recalculations of DTBT (if DTBT <= 0).
                                 ! If DTBT_RESET_PERIOD is negative, DTBT is set based
@@ -490,13 +485,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 10.0 !   [nondim] default = 0.0
                                 ! geostrophic kinetic energy or 1 plus the square of the
                                 ! grid spacing over the deformation radius, as detailed
                                 ! by Fox-Kemper et al. (2010)
-Z_OUTPUT_GRID_FILE = "vgrid_75_2m.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/land_ice_ocean_LM3_SIS2/OM_360x320_C180/MOM_parameter_doc.all
+++ b/land_ice_ocean_LM3_SIS2/OM_360x320_C180/MOM_parameter_doc.all
@@ -78,7 +78,7 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
+MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
                                 ! The minimum amount of time in seconds between calculations of depth-space
                                 ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
@@ -1213,12 +1213,9 @@ DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "vgrid_75_2m.nc" ! default = ""
+Z_OUTPUT_GRID_FILE = ""         ! default = ""
                                 ! The file that specifies the vertical grid for depth-space diagnostics, or
                                 ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/land_ice_ocean_LM3_SIS2/OM_360x320_C180/MOM_parameter_doc.short
+++ b/land_ice_ocean_LM3_SIS2/OM_360x320_C180/MOM_parameter_doc.short
@@ -24,10 +24,6 @@ DT_THERM = 3600.0               !   [s] default = 1800.0
                                 ! an integer multiple of DT and less than the forcing or coupling time-step,
                                 ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
                                 ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 DTBT_RESET_PERIOD = -1.0        !   [s] default = 3600.0
                                 ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
                                 ! is negative, DTBT is set based only on information available at
@@ -427,12 +423,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 10.0 !   [nondim] default = 0.0
                                 ! (2010)
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "vgrid_75_2m.nc" ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/CVmix_SCM_tests/common_BML/MOM_input
+++ b/ocean_only/CVmix_SCM_tests/common_BML/MOM_input
@@ -66,10 +66,6 @@ DT = 1200.0                     !   [s]
                                 ! is actually used will be an integer fraction of the
                                 ! forcing time-step (DT_FORCING in ocean-only mode or the
                                 ! coupling timestep in coupled mode.)
-Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
 C_P = 3992.10322329649          !   [J kg-1 K-1] default = 3991.86795711963
                                 ! The heat capacity of sea water, approximated as a
                                 ! constant. This is only used if ENABLE_THERMODYNAMICS is

--- a/ocean_only/CVmix_SCM_tests/common_EPBL/MOM_input
+++ b/ocean_only/CVmix_SCM_tests/common_EPBL/MOM_input
@@ -65,11 +65,6 @@ DT = 1200.0                     !   [s]
                                 ! is actually used will be an integer fraction of the
                                 ! forcing time-step (DT_FORCING in ocean-only mode or the
                                 ! coupling timestep in coupled mode.)
-Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
-
 C_P = 3992.10322329649          !   [J kg-1 K-1] default = 3991.86795711963
                                 ! The heat capacity of sea water, approximated as a
                                 ! constant. This is only used if ENABLE_THERMODYNAMICS is

--- a/ocean_only/CVmix_SCM_tests/common_KPP/MOM_input
+++ b/ocean_only/CVmix_SCM_tests/common_KPP/MOM_input
@@ -65,11 +65,6 @@ DT = 1200.0                     !   [s]
                                 ! is actually used will be an integer fraction of the
                                 ! forcing time-step (DT_FORCING in ocean-only mode or the
                                 ! coupling timestep in coupled mode.)
-Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
-
 C_P = 3992.10322329649          !   [J kg-1 K-1] default = 3991.86795711963
                                 ! The heat capacity of sea water, approximated as a
                                 ! constant. This is only used if ENABLE_THERMODYNAMICS is

--- a/ocean_only/CVmix_SCM_tests/cooling_only/BML/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/BML/MOM_parameter_doc.all
@@ -783,12 +783,9 @@ DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
+Z_OUTPUT_GRID_FILE = ""         ! default = ""
                                 ! The file that specifies the vertical grid for depth-space diagnostics, or
                                 ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/CVmix_SCM_tests/cooling_only/BML/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/BML/MOM_parameter_doc.short
@@ -285,12 +285,6 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 ! === module MOM_mixed_layer_restrat ===
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/CVmix_SCM_tests/cooling_only/EPBL/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/EPBL/MOM_parameter_doc.all
@@ -867,12 +867,9 @@ DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
+Z_OUTPUT_GRID_FILE = ""         ! default = ""
                                 ! The file that specifies the vertical grid for depth-space diagnostics, or
                                 ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/CVmix_SCM_tests/cooling_only/EPBL/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/EPBL/MOM_parameter_doc.short
@@ -305,12 +305,6 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 ! === module MOM_mixed_layer_restrat ===
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/CVmix_SCM_tests/cooling_only/KPP/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/KPP/MOM_parameter_doc.all
@@ -867,12 +867,9 @@ DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
+Z_OUTPUT_GRID_FILE = ""         ! default = ""
                                 ! The file that specifies the vertical grid for depth-space diagnostics, or
                                 ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/CVmix_SCM_tests/cooling_only/KPP/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/KPP/MOM_parameter_doc.short
@@ -305,12 +305,6 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 ! === module MOM_mixed_layer_restrat ===
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/CVmix_SCM_tests/mech_only/BML/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/mech_only/BML/MOM_parameter_doc.all
@@ -783,12 +783,9 @@ DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
+Z_OUTPUT_GRID_FILE = ""         ! default = ""
                                 ! The file that specifies the vertical grid for depth-space diagnostics, or
                                 ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/CVmix_SCM_tests/mech_only/BML/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/mech_only/BML/MOM_parameter_doc.short
@@ -285,12 +285,6 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 ! === module MOM_mixed_layer_restrat ===
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/CVmix_SCM_tests/mech_only/EPBL/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/mech_only/EPBL/MOM_parameter_doc.all
@@ -867,12 +867,9 @@ DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
+Z_OUTPUT_GRID_FILE = ""         ! default = ""
                                 ! The file that specifies the vertical grid for depth-space diagnostics, or
                                 ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/CVmix_SCM_tests/mech_only/EPBL/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/mech_only/EPBL/MOM_parameter_doc.short
@@ -305,12 +305,6 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 ! === module MOM_mixed_layer_restrat ===
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/CVmix_SCM_tests/mech_only/KPP/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/mech_only/KPP/MOM_parameter_doc.all
@@ -867,12 +867,9 @@ DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
+Z_OUTPUT_GRID_FILE = ""         ! default = ""
                                 ! The file that specifies the vertical grid for depth-space diagnostics, or
                                 ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/CVmix_SCM_tests/mech_only/KPP/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/mech_only/KPP/MOM_parameter_doc.short
@@ -305,12 +305,6 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 ! === module MOM_mixed_layer_restrat ===
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/BML/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/BML/MOM_parameter_doc.all
@@ -783,12 +783,9 @@ DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
+Z_OUTPUT_GRID_FILE = ""         ! default = ""
                                 ! The file that specifies the vertical grid for depth-space diagnostics, or
                                 ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/BML/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/BML/MOM_parameter_doc.short
@@ -283,12 +283,6 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 ! === module MOM_mixed_layer_restrat ===
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/EPBL/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/EPBL/MOM_parameter_doc.all
@@ -867,12 +867,9 @@ DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
+Z_OUTPUT_GRID_FILE = ""         ! default = ""
                                 ! The file that specifies the vertical grid for depth-space diagnostics, or
                                 ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/EPBL/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/EPBL/MOM_parameter_doc.short
@@ -303,12 +303,6 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 ! === module MOM_mixed_layer_restrat ===
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/KPP/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/KPP/MOM_parameter_doc.all
@@ -867,12 +867,9 @@ DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
+Z_OUTPUT_GRID_FILE = ""         ! default = ""
                                 ! The file that specifies the vertical grid for depth-space diagnostics, or
                                 ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/KPP/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/KPP/MOM_parameter_doc.short
@@ -303,12 +303,6 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 ! === module MOM_mixed_layer_restrat ===
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/CVmix_SCM_tests/wind_only/BML/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/wind_only/BML/MOM_parameter_doc.all
@@ -783,12 +783,9 @@ DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
+Z_OUTPUT_GRID_FILE = ""         ! default = ""
                                 ! The file that specifies the vertical grid for depth-space diagnostics, or
                                 ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/CVmix_SCM_tests/wind_only/BML/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/wind_only/BML/MOM_parameter_doc.short
@@ -285,12 +285,6 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 ! === module MOM_mixed_layer_restrat ===
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/CVmix_SCM_tests/wind_only/EPBL/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/wind_only/EPBL/MOM_parameter_doc.all
@@ -867,12 +867,9 @@ DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
+Z_OUTPUT_GRID_FILE = ""         ! default = ""
                                 ! The file that specifies the vertical grid for depth-space diagnostics, or
                                 ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/CVmix_SCM_tests/wind_only/EPBL/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/wind_only/EPBL/MOM_parameter_doc.short
@@ -305,12 +305,6 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 ! === module MOM_mixed_layer_restrat ===
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/CVmix_SCM_tests/wind_only/KPP/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/wind_only/KPP/MOM_parameter_doc.all
@@ -867,12 +867,9 @@ DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
+Z_OUTPUT_GRID_FILE = ""         ! default = ""
                                 ! The file that specifies the vertical grid for depth-space diagnostics, or
                                 ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/CVmix_SCM_tests/wind_only/KPP/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/wind_only/KPP/MOM_parameter_doc.short
@@ -305,12 +305,6 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 ! === module MOM_mixed_layer_restrat ===
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/MESO_025_23L/MOM_input
+++ b/ocean_only/MESO_025_23L/MOM_input
@@ -220,15 +220,6 @@ SAVE_INITIAL_CONDS = True       !    If defined, the inital conditions are
                                 !  new run.
 IC_OUTPUT_FILE = "MOM_IC"      !  The name-root of a file into which the
                                 !  initial conditions are written for a new run.
-Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc"
-                                !    The file that specifies the vertical grid
-                                !  for depth-space diagnostics.
-MIN_Z_DIAG_INTERVAL = 2.16e4    ! The minimum amount of time in seconds between
-                                !  calculations of depth-space diagnostics.
-                                !  Making this larger than DT_THERM reduces the
-                                !  performance penalty of regridding to depth
-                                !  online.
-
 MAXCPU = 86400.0                !   The maximum amount of cpu time per processor
                                 !  for which MOM should run before saving a
                                 !  restart file and quitting with a return value

--- a/ocean_only/MESO_025_63L/MOM_input
+++ b/ocean_only/MESO_025_63L/MOM_input
@@ -79,11 +79,6 @@ DT_THERM = 3600.0               !   [s] default = 600.0
                                 ! Ideally DT_THERM should be an integer multiple of DT
                                 ! and less than the forcing or coupling time-step.
                                 ! By default DT_THERM is set to DT.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 DTBT_RESET_PERIOD = -1.0        !   [s] default = 3600.0
                                 ! The period between recalculations of DTBT (if DTBT <= 0).
                                 ! If DTBT_RESET_PERIOD is negative, DTBT is set based
@@ -402,13 +397,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 5.0 !   [nondim] default = 0.0
                                 ! geostrophic kinetic energy or 1 plus the square of the
                                 ! grid spacing over the deformation radius, as detailed
                                 ! by Fox-Kemper et al. (2010)
-Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
-!NK_ZSPACE (from file) = -1     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/SCM_idealized_hurricane/MOM_input
+++ b/ocean_only/SCM_idealized_hurricane/MOM_input
@@ -73,11 +73,6 @@ DT = 1200.0                     !   [s]
                                 ! is actually used will be an integer fraction of the
                                 ! forcing time-step (DT_FORCING in ocean-only mode or the
                                 ! coupling timestep in coupled mode.)
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 FRAZIL = True                   !   [Boolean] default = False
                                 ! If true, water freezes if it gets too cold, and the
                                 ! the accumulated heat deficit is returned in the

--- a/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.all
+++ b/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.all
@@ -80,7 +80,7 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
+MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
                                 ! The minimum amount of time in seconds between calculations of depth-space
                                 ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.

--- a/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.short
+++ b/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.short
@@ -13,10 +13,6 @@ DT = 1200.0                     !   [s]
                                 ! The (baroclinic) dynamics time step.  The time-step that is actually used will
                                 ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
                                 ! or the coupling timestep in coupled mode.)
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 FRAZIL = True                   !   [Boolean] default = False
                                 ! If true, water freezes if it gets too cold, and the the accumulated heat
                                 ! deficit is returned in the surface state.  FRAZIL is only used if

--- a/ocean_only/global/MOM_input
+++ b/ocean_only/global/MOM_input
@@ -81,11 +81,6 @@ DT_THERM = 7200.0               !   [s] default = 3600.0
                                 ! Ideally DT_THERM should be an integer multiple of DT
                                 ! and less than the forcing or coupling time-step.
                                 ! By default DT_THERM is set to DT.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
                                 ! The period between recalculations of DTBT (if DTBT <= 0).
                                 ! If DTBT_RESET_PERIOD is negative, DTBT is set based
@@ -437,13 +432,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
                                 ! geostrophic kinetic energy or 1 plus the square of the
                                 ! grid spacing over the deformation radius, as detailed
                                 ! by Fox-Kemper et al. (2010)
-Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
-!NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/global_ALE/common/MOM_input
+++ b/ocean_only/global_ALE/common/MOM_input
@@ -83,11 +83,6 @@ DT_THERM = 7200.0               !   [s] default = 3600.0
                                 ! Ideally DT_THERM should be an integer multiple of DT
                                 ! and less than the forcing or coupling time-step.
                                 ! By default DT_THERM is set to DT.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
                                 ! The period between recalculations of DTBT (if DTBT <= 0).
                                 ! If DTBT_RESET_PERIOD is negative, DTBT is set based
@@ -436,13 +431,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
                                 ! geostrophic kinetic energy or 1 plus the square of the
                                 ! grid spacing over the deformation radius, as detailed
                                 ! by Fox-Kemper et al. (2010)
-Z_OUTPUT_GRID_FILE = "analysis_vgrid_lev35.v1.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
-!NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/global_ALE/common/diag_table
+++ b/ocean_only/global_ALE/common/diag_table
@@ -4,7 +4,6 @@
 "layer",    1,"days",1,"days","Time",
 "prog",     1,"days",1,"days","Time",
 "prog_z",   1,"days",1,"days","Time",
-"prog_zold",1,"days",1,"days","Time",
 "ave_prog", 1,"days",1,"days","Time",
 "tracer",   1,"days",1,"days","Time",
 "cont",     1,"days",1,"days","Time",
@@ -78,9 +77,6 @@
 "ocean_model_z","temp","temp","prog_z","all",.true.,"none",2
 "ocean_model_z","temp_xyave","temp_xyave","prog_z","all",.true.,"none",2
 "ocean_model_z","salt","salt","prog_z","all",.true.,"none",2
-"ocean_model_zold","temp","temp","prog_zold","all",.true.,"none",2
-"ocean_model_zold","salt","salt","prog_zold","all",.true.,"none",2
-"ocean_model_zold","temp_xyave","temp_xyave","prog_zold","all",.true.,"none",2
 
 # Auxilary Tracers:
 #==================

--- a/ocean_only/global_ALE/hycom/MOM_parameter_doc.all
+++ b/ocean_only/global_ALE/hycom/MOM_parameter_doc.all
@@ -78,7 +78,7 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
+MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
                                 ! The minimum amount of time in seconds between calculations of depth-space
                                 ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
@@ -1316,12 +1316,9 @@ DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "analysis_vgrid_lev35.v1.nc" ! default = ""
+Z_OUTPUT_GRID_FILE = ""         ! default = ""
                                 ! The file that specifies the vertical grid for depth-space diagnostics, or
                                 ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/global_ALE/hycom/MOM_parameter_doc.short
+++ b/ocean_only/global_ALE/hycom/MOM_parameter_doc.short
@@ -24,10 +24,6 @@ DT_THERM = 7200.0               !   [s] default = 3600.0
                                 ! an integer multiple of DT and less than the forcing or coupling time-step,
                                 ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
                                 ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
                                 ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
                                 ! is negative, DTBT is set based only on information available at
@@ -432,12 +428,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
                                 ! (2010)
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "analysis_vgrid_lev35.v1.nc" ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/global_ALE/layer/MOM_parameter_doc.all
+++ b/ocean_only/global_ALE/layer/MOM_parameter_doc.all
@@ -70,7 +70,7 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
+MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
                                 ! The minimum amount of time in seconds between calculations of depth-space
                                 ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
@@ -1159,12 +1159,9 @@ DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "analysis_vgrid_lev35.v1.nc" ! default = ""
+Z_OUTPUT_GRID_FILE = ""         ! default = ""
                                 ! The file that specifies the vertical grid for depth-space diagnostics, or
                                 ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/global_ALE/layer/MOM_parameter_doc.short
+++ b/ocean_only/global_ALE/layer/MOM_parameter_doc.short
@@ -21,10 +21,6 @@ DT_THERM = 7200.0               !   [s] default = 3600.0
                                 ! an integer multiple of DT and less than the forcing or coupling time-step,
                                 ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
                                 ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
                                 ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
                                 ! is negative, DTBT is set based only on information available at
@@ -353,12 +349,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
                                 ! (2010)
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "analysis_vgrid_lev35.v1.nc" ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/global_ALE/layer/available_diags.000000
+++ b/ocean_only/global_ALE/layer/available_diags.000000
@@ -3838,26 +3838,6 @@
     ! units: Pa
     ! standard_name: sea_water_pressure_at_sea_floor
     ! cell_methods: xh:mean yh:mean area:mean
-"ocean_model_zold", "u"  [Unused] (CMOR equivalent is "uo")
-    ! long_name: Zonal Velocity in Depth Space
-    ! units: m s-1
-"ocean_model_zold", "uo"  [Unused] (native name is "u")
-    ! long_name: Sea Water X Velocity
-    ! units: m s-1
-    ! standard_name: sea_water_x_velocity
-"ocean_model_zold", "v"  [Unused] (CMOR equivalent is "vo")
-    ! long_name: Meridional Velocity in Depth Space
-    ! units: m s-1
-"ocean_model_zold", "vo"  [Unused] (native name is "v")
-    ! long_name: Sea Water Y Velocity
-    ! units: m s-1
-    ! standard_name: sea_water_y_velocity
-"ocean_model_zold", "uh"  [Unused]
-    ! long_name: Zonal Mass Transport (including SGS param) in Depth Space
-    ! units: m3 s-1
-"ocean_model_zold", "vh"  [Unused]
-    ! long_name: Meridional Mass Transport (including SGS param) in Depth Space
-    ! units: m3 s-1
 "ocean_model", "ea_t"  [Unused]
     ! long_name: Layer (heat) entrainment from above per timestep
     ! units: m
@@ -4326,21 +4306,6 @@
     ! long_name: Mixed layer depth (used defined)
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
-"ocean_model_zold", "Kd_interface"  [Unused]
-    ! long_name: Diapycnal diffusivity at interfaces, interpolated to z
-    ! units: m2 s-1
-"ocean_model_zold", "Tflx_dia_diff"  [Unused]
-    ! long_name: Diffusive diapycnal temperature flux across interfaces, interpolated to z
-    ! units: degC m s-1
-"ocean_model_zold", "Tflx_dia_adv"  [Unused]
-    ! long_name: Advective diapycnal temperature flux across interfaces, interpolated to z
-    ! units: degC m s-1
-"ocean_model_zold", "Sflx_dia_diff"  [Unused]
-    ! long_name: Diffusive diapycnal salinity flux across interfaces, interpolated to z
-    ! units: psu m s-1
-"ocean_model_zold", "Sflx_dia_adv"  [Unused]
-    ! long_name: Advective diapycnal salinity flux across interfaces, interpolated to z
-    ! units: psu m s-1
 "ocean_model", "u_predia"  [Unused]
     ! long_name: Zonal velocity before diabatic forcing
     ! units: m s-1
@@ -5125,9 +5090,6 @@
     ! long_name: Work done by Internal Tide Diapycnal Mixing (low modes)
     ! units: W m-2
     ! cell_methods: z_l:mean
-"ocean_model_zold", "Kd_itides"  [Unused]
-    ! long_name: Internal Tide Driven Diffusivity, interpolated to z
-    ! units: m2 s-1
 "ocean_model", "Kd_effective"  [Used]
     ! long_name: Diapycnal diffusivity as applied
     ! units: m2 s-1
@@ -5495,9 +5457,6 @@
     ! units: s-2
     ! standard_name: square_of_brunt_vaisala_frequency_in_sea_water
     ! cell_methods: z_i:point
-"ocean_model_zold", "N2"  [Unused]
-    ! long_name: Buoyancy frequency, interpolated to z
-    ! units: s-2
 "ocean_model", "Kd_shear"  [Used]
     ! long_name: Shear-driven Diapycnal Diffusivity
     ! units: m2 s-1
@@ -6882,30 +6841,6 @@
     ! units: W m-2
     ! standard_name: tendency_of_sea_water_potential_temperature_expressed_as_heat_content_vertical_sum
     ! cell_methods: xh:mean yh:mean area:mean
-"ocean_model_zold", "temp"  [Used]
-    ! long_name: Potential Temperature
-    ! units: degC
-    ! standard_name: not provided
-"ocean_model_zold", "temp_xyave"  [Used]
-    ! long_name: Potential Temperature
-    ! units: degC
-    ! standard_name: not provided
-"ocean_model_zold_d2", "temp_xyave"  [Unused]
-    ! long_name: Potential Temperature
-    ! units: degC
-    ! standard_name: not provided
-"ocean_model_zold", "thetao"  [Unused]
-    ! long_name: Sea Water Potential Temperature
-    ! units: degC
-    ! standard_name: sea_water_potential_temperature
-"ocean_model_zold", "thetao_xyave"  [Unused]
-    ! long_name: Sea Water Potential Temperature
-    ! units: degC
-    ! standard_name: sea_water_potential_temperature
-"ocean_model_zold_d2", "thetao_xyave"  [Unused]
-    ! long_name: Sea Water Potential Temperature
-    ! units: degC
-    ! standard_name: sea_water_potential_temperature
 "ocean_model", "salt"  [Used] (CMOR equivalent is "so")
     ! long_name: Salinity
     ! units: psu
@@ -7422,30 +7357,6 @@
     ! units: kg m-2 s-1
     ! standard_name: tendency_of_sea_water_salinity_expressed_as_salt_content_vertical_sum
     ! cell_methods: xh:mean yh:mean area:mean
-"ocean_model_zold", "salt"  [Used]
-    ! long_name: Salinity
-    ! units: psu
-    ! standard_name: not provided
-"ocean_model_zold", "salt_xyave"  [Unused]
-    ! long_name: Salinity
-    ! units: psu
-    ! standard_name: not provided
-"ocean_model_zold_d2", "salt_xyave"  [Unused]
-    ! long_name: Salinity
-    ! units: psu
-    ! standard_name: not provided
-"ocean_model_zold", "so"  [Unused]
-    ! long_name: Sea Water Salinity
-    ! units: psu
-    ! standard_name: sea_water_salinity
-"ocean_model_zold", "so_xyave"  [Unused]
-    ! long_name: Sea Water Salinity
-    ! units: psu
-    ! standard_name: sea_water_salinity
-"ocean_model_zold_d2", "so_xyave"  [Unused]
-    ! long_name: Sea Water Salinity
-    ! units: psu
-    ! standard_name: sea_water_salinity
 "ocean_model", "age"  [Unused] (CMOR equivalent is "agessc")
     ! long_name: Ideal Age Tracer
     ! units: yr
@@ -7862,30 +7773,6 @@
     ! long_name: Vertical sum of net time tendency for ideal age tracer
     ! units: yr m s-1
     ! cell_methods: xh:mean yh:mean area:mean
-"ocean_model_zold", "age"  [Unused]
-    ! long_name: Ideal Age Tracer
-    ! units: yr
-    ! standard_name: not provided
-"ocean_model_zold", "age_xyave"  [Unused]
-    ! long_name: Ideal Age Tracer
-    ! units: yr
-    ! standard_name: not provided
-"ocean_model_zold_d2", "age_xyave"  [Unused]
-    ! long_name: Ideal Age Tracer
-    ! units: yr
-    ! standard_name: not provided
-"ocean_model_zold", "agessc"  [Unused]
-    ! long_name: Ideal Age Tracer
-    ! units: yr
-    ! standard_name: ideal_age_tracer
-"ocean_model_zold", "agessc_xyave"  [Unused]
-    ! long_name: Ideal Age Tracer
-    ! units: yr
-    ! standard_name: ideal_age_tracer
-"ocean_model_zold_d2", "agessc_xyave"  [Unused]
-    ! long_name: Ideal Age Tracer
-    ! units: yr
-    ! standard_name: ideal_age_tracer
 "ocean_model", "taux"  [Used] (CMOR equivalent is "tauuo")
     ! long_name: Zonal surface stress from ocean interactions with atmos and ice
     ! units: Pa

--- a/ocean_only/global_ALE/z/MOM_parameter_doc.all
+++ b/ocean_only/global_ALE/z/MOM_parameter_doc.all
@@ -78,7 +78,7 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
+MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
                                 ! The minimum amount of time in seconds between calculations of depth-space
                                 ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
@@ -1273,12 +1273,9 @@ DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "analysis_vgrid_lev35.v1.nc" ! default = ""
+Z_OUTPUT_GRID_FILE = ""         ! default = ""
                                 ! The file that specifies the vertical grid for depth-space diagnostics, or
                                 ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/global_ALE/z/MOM_parameter_doc.short
+++ b/ocean_only/global_ALE/z/MOM_parameter_doc.short
@@ -24,10 +24,6 @@ DT_THERM = 7200.0               !   [s] default = 3600.0
                                 ! an integer multiple of DT and less than the forcing or coupling time-step,
                                 ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
                                 ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
                                 ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
                                 ! is negative, DTBT is set based only on information available at
@@ -407,12 +403,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
                                 ! (2010)
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "analysis_vgrid_lev35.v1.nc" ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 35     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/global_ALE/z/available_diags.000000
+++ b/ocean_only/global_ALE/z/available_diags.000000
@@ -3918,26 +3918,6 @@
     ! units: Pa
     ! standard_name: sea_water_pressure_at_sea_floor
     ! cell_methods: xh:mean yh:mean area:mean
-"ocean_model_zold", "u"  [Unused] (CMOR equivalent is "uo")
-    ! long_name: Zonal Velocity in Depth Space
-    ! units: m s-1
-"ocean_model_zold", "uo"  [Unused] (native name is "u")
-    ! long_name: Sea Water X Velocity
-    ! units: m s-1
-    ! standard_name: sea_water_x_velocity
-"ocean_model_zold", "v"  [Unused] (CMOR equivalent is "vo")
-    ! long_name: Meridional Velocity in Depth Space
-    ! units: m s-1
-"ocean_model_zold", "vo"  [Unused] (native name is "v")
-    ! long_name: Sea Water Y Velocity
-    ! units: m s-1
-    ! standard_name: sea_water_y_velocity
-"ocean_model_zold", "uh"  [Unused]
-    ! long_name: Zonal Mass Transport (including SGS param) in Depth Space
-    ! units: m3 s-1
-"ocean_model_zold", "vh"  [Unused]
-    ! long_name: Meridional Mass Transport (including SGS param) in Depth Space
-    ! units: m3 s-1
 "ocean_model", "ea_t"  [Unused]
     ! long_name: Layer (heat) entrainment from above per timestep
     ! units: m
@@ -4406,21 +4386,6 @@
     ! long_name: Mixed layer depth (used defined)
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
-"ocean_model_zold", "Kd_interface"  [Unused]
-    ! long_name: Diapycnal diffusivity at interfaces, interpolated to z
-    ! units: m2 s-1
-"ocean_model_zold", "Tflx_dia_diff"  [Unused]
-    ! long_name: Diffusive diapycnal temperature flux across interfaces, interpolated to z
-    ! units: degC m s-1
-"ocean_model_zold", "Tflx_dia_adv"  [Unused]
-    ! long_name: Advective diapycnal temperature flux across interfaces, interpolated to z
-    ! units: degC m s-1
-"ocean_model_zold", "Sflx_dia_diff"  [Unused]
-    ! long_name: Diffusive diapycnal salinity flux across interfaces, interpolated to z
-    ! units: psu m s-1
-"ocean_model_zold", "Sflx_dia_adv"  [Unused]
-    ! long_name: Advective diapycnal salinity flux across interfaces, interpolated to z
-    ! units: psu m s-1
 "ocean_model", "u_predia"  [Unused]
     ! long_name: Zonal velocity before diabatic forcing
     ! units: m s-1
@@ -5689,9 +5654,6 @@
     ! long_name: Work done by Internal Tide Diapycnal Mixing (low modes)
     ! units: W m-2
     ! cell_methods: z_l:mean
-"ocean_model_zold", "Kd_itides"  [Unused]
-    ! long_name: Internal Tide Driven Diffusivity, interpolated to z
-    ! units: m2 s-1
 "ocean_model", "Kd_effective"  [Used]
     ! long_name: Diapycnal diffusivity as applied
     ! units: m2 s-1
@@ -6059,9 +6021,6 @@
     ! units: s-2
     ! standard_name: square_of_brunt_vaisala_frequency_in_sea_water
     ! cell_methods: z_i:point
-"ocean_model_zold", "N2"  [Unused]
-    ! long_name: Buoyancy frequency, interpolated to z
-    ! units: s-2
 "ocean_model", "Kd_shear"  [Used]
     ! long_name: Shear-driven Diapycnal Diffusivity
     ! units: m2 s-1
@@ -7632,30 +7591,6 @@
     ! units: W m-2
     ! standard_name: tendency_of_sea_water_potential_temperature_expressed_as_heat_content_vertical_sum
     ! cell_methods: xh:mean yh:mean area:mean
-"ocean_model_zold", "temp"  [Used]
-    ! long_name: Potential Temperature
-    ! units: degC
-    ! standard_name: not provided
-"ocean_model_zold", "temp_xyave"  [Used]
-    ! long_name: Potential Temperature
-    ! units: degC
-    ! standard_name: not provided
-"ocean_model_zold_d2", "temp_xyave"  [Unused]
-    ! long_name: Potential Temperature
-    ! units: degC
-    ! standard_name: not provided
-"ocean_model_zold", "thetao"  [Unused]
-    ! long_name: Sea Water Potential Temperature
-    ! units: degC
-    ! standard_name: sea_water_potential_temperature
-"ocean_model_zold", "thetao_xyave"  [Unused]
-    ! long_name: Sea Water Potential Temperature
-    ! units: degC
-    ! standard_name: sea_water_potential_temperature
-"ocean_model_zold_d2", "thetao_xyave"  [Unused]
-    ! long_name: Sea Water Potential Temperature
-    ! units: degC
-    ! standard_name: sea_water_potential_temperature
 "ocean_model", "T_tendency_vert_remap"  [Unused]
     ! long_name: Vertical remapping tracer concentration tendency for temp
     ! units: degC s-1
@@ -8276,30 +8211,6 @@
     ! units: kg m-2 s-1
     ! standard_name: tendency_of_sea_water_salinity_expressed_as_salt_content_vertical_sum
     ! cell_methods: xh:mean yh:mean area:mean
-"ocean_model_zold", "salt"  [Used]
-    ! long_name: Salinity
-    ! units: psu
-    ! standard_name: not provided
-"ocean_model_zold", "salt_xyave"  [Unused]
-    ! long_name: Salinity
-    ! units: psu
-    ! standard_name: not provided
-"ocean_model_zold_d2", "salt_xyave"  [Unused]
-    ! long_name: Salinity
-    ! units: psu
-    ! standard_name: not provided
-"ocean_model_zold", "so"  [Unused]
-    ! long_name: Sea Water Salinity
-    ! units: psu
-    ! standard_name: sea_water_salinity
-"ocean_model_zold", "so_xyave"  [Unused]
-    ! long_name: Sea Water Salinity
-    ! units: psu
-    ! standard_name: sea_water_salinity
-"ocean_model_zold_d2", "so_xyave"  [Unused]
-    ! long_name: Sea Water Salinity
-    ! units: psu
-    ! standard_name: sea_water_salinity
 "ocean_model", "S_tendency_vert_remap"  [Unused]
     ! long_name: Vertical remapping tracer concentration tendency for salt
     ! units: psu s-1
@@ -8820,30 +8731,6 @@
     ! long_name: Vertical sum of net time tendency for ideal age tracer
     ! units: yr m s-1
     ! cell_methods: xh:mean yh:mean area:mean
-"ocean_model_zold", "age"  [Unused]
-    ! long_name: Ideal Age Tracer
-    ! units: yr
-    ! standard_name: not provided
-"ocean_model_zold", "age_xyave"  [Unused]
-    ! long_name: Ideal Age Tracer
-    ! units: yr
-    ! standard_name: not provided
-"ocean_model_zold_d2", "age_xyave"  [Unused]
-    ! long_name: Ideal Age Tracer
-    ! units: yr
-    ! standard_name: not provided
-"ocean_model_zold", "agessc"  [Unused]
-    ! long_name: Ideal Age Tracer
-    ! units: yr
-    ! standard_name: ideal_age_tracer
-"ocean_model_zold", "agessc_xyave"  [Unused]
-    ! long_name: Ideal Age Tracer
-    ! units: yr
-    ! standard_name: ideal_age_tracer
-"ocean_model_zold_d2", "agessc_xyave"  [Unused]
-    ! long_name: Ideal Age Tracer
-    ! units: yr
-    ! standard_name: ideal_age_tracer
 "ocean_model", "age_tendency_vert_remap"  [Unused]
     ! long_name: Vertical remapping tracer concentration tendency for age
     ! units: yr s-1

--- a/ocean_only/nonBous_global/MOM_input
+++ b/ocean_only/nonBous_global/MOM_input
@@ -87,11 +87,6 @@ DT_THERM = 7200.0               !   [s] default = 3600.0
                                 ! Ideally DT_THERM should be an integer multiple of DT
                                 ! and less than the forcing or coupling time-step.
                                 ! By default DT_THERM is set to DT.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
                                 ! The period between recalculations of DTBT (if DTBT <= 0).
                                 ! If DTBT_RESET_PERIOD is negative, DTBT is set based
@@ -440,13 +435,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
                                 ! geostrophic kinetic energy or 1 plus the square of the
                                 ! grid spacing over the deformation radius, as detailed
                                 ! by Fox-Kemper et al. (2010)
-Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
-!NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/nonBous_global/MOM_parameter_doc.all
+++ b/ocean_only/nonBous_global/MOM_parameter_doc.all
@@ -70,7 +70,7 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
+MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
                                 ! The minimum amount of time in seconds between calculations of depth-space
                                 ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
@@ -1081,12 +1081,9 @@ DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
+Z_OUTPUT_GRID_FILE = ""         ! default = ""
                                 ! The file that specifies the vertical grid for depth-space diagnostics, or
                                 ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/nonBous_global/MOM_parameter_doc.short
+++ b/ocean_only/nonBous_global/MOM_parameter_doc.short
@@ -18,10 +18,6 @@ DT_THERM = 7200.0               !   [s] default = 3600.0
                                 ! an integer multiple of DT and less than the forcing or coupling time-step,
                                 ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
                                 ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
                                 ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
                                 ! is negative, DTBT is set based only on information available at
@@ -382,12 +378,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
                                 ! (2010)
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "OM3_zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/single_column/BML/MOM_input
+++ b/ocean_only/single_column/BML/MOM_input
@@ -68,11 +68,6 @@ DT = 3600.0                     !   [s]
                                 ! is actually used will be an integer fraction of the
                                 ! forcing time-step (DT_FORCING in ocean-only mode or the
                                 ! coupling timestep in coupled mode.)
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 FRAZIL = True                   !   [Boolean] default = False
                                 ! If true, water freezes if it gets too cold, and the
                                 ! the accumulated heat deficit is returned in the
@@ -258,13 +253,6 @@ BBL_THICK_MIN = 0.1             !   [m] default = 0.0
 ! === module MOM_thickness_diffuse ===
 
 ! === module MOM_mixed_layer_restrat ===
-Z_OUTPUT_GRID_FILE = "../zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
-!NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/single_column/BML/MOM_parameter_doc.all
+++ b/ocean_only/single_column/BML/MOM_parameter_doc.all
@@ -72,7 +72,7 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
+MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
                                 ! The minimum amount of time in seconds between calculations of depth-space
                                 ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
@@ -746,12 +746,9 @@ DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "../zgrid.nc" ! default = ""
+Z_OUTPUT_GRID_FILE = ""         ! default = ""
                                 ! The file that specifies the vertical grid for depth-space diagnostics, or
                                 ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 60     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/single_column/BML/MOM_parameter_doc.short
+++ b/ocean_only/single_column/BML/MOM_parameter_doc.short
@@ -10,10 +10,6 @@ DT = 3600.0                     !   [s]
                                 ! The (baroclinic) dynamics time step.  The time-step that is actually used will
                                 ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
                                 ! or the coupling timestep in coupled mode.)
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 FRAZIL = True                   !   [Boolean] default = False
                                 ! If true, water freezes if it gets too cold, and the the accumulated heat
                                 ! deficit is returned in the surface state.  FRAZIL is only used if
@@ -240,12 +236,6 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 ! === module MOM_mixed_layer_restrat ===
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "../zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 60     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/single_column/EPBL/MOM_input
+++ b/ocean_only/single_column/EPBL/MOM_input
@@ -77,11 +77,6 @@ DT = 3600.0                     !   [s]
                                 ! is actually used will be an integer fraction of the
                                 ! forcing time-step (DT_FORCING in ocean-only mode or the
                                 ! coupling timestep in coupled mode.)
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 FRAZIL = True                   !   [Boolean] default = False
                                 ! If true, water freezes if it gets too cold, and the
                                 ! the accumulated heat deficit is returned in the
@@ -295,13 +290,6 @@ BBL_THICK_MIN = 0.1             !   [m] default = 0.0
 ! === module MOM_thickness_diffuse ===
 
 ! === module MOM_mixed_layer_restrat ===
-Z_OUTPUT_GRID_FILE = "../zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
-!NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/single_column/EPBL/MOM_parameter_doc.all
+++ b/ocean_only/single_column/EPBL/MOM_parameter_doc.all
@@ -80,7 +80,7 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
+MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
                                 ! The minimum amount of time in seconds between calculations of depth-space
                                 ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
@@ -823,12 +823,9 @@ DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "../zgrid.nc" ! default = ""
+Z_OUTPUT_GRID_FILE = ""         ! default = ""
                                 ! The file that specifies the vertical grid for depth-space diagnostics, or
                                 ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 60     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/single_column/EPBL/MOM_parameter_doc.short
+++ b/ocean_only/single_column/EPBL/MOM_parameter_doc.short
@@ -13,10 +13,6 @@ DT = 3600.0                     !   [s]
                                 ! The (baroclinic) dynamics time step.  The time-step that is actually used will
                                 ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
                                 ! or the coupling timestep in coupled mode.)
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 FRAZIL = True                   !   [Boolean] default = False
                                 ! If true, water freezes if it gets too cold, and the the accumulated heat
                                 ! deficit is returned in the surface state.  FRAZIL is only used if
@@ -277,12 +273,6 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 ! === module MOM_mixed_layer_restrat ===
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "../zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 60     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/single_column/KPP/MOM_input
+++ b/ocean_only/single_column/KPP/MOM_input
@@ -77,11 +77,6 @@ DT = 3600.0                     !   [s]
                                 ! is actually used will be an integer fraction of the
                                 ! forcing time-step (DT_FORCING in ocean-only mode or the
                                 ! coupling timestep in coupled mode.)
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 FRAZIL = True                   !   [Boolean] default = False
                                 ! If true, water freezes if it gets too cold, and the
                                 ! the accumulated heat deficit is returned in the
@@ -295,13 +290,6 @@ BBL_THICK_MIN = 0.1             !   [m] default = 0.0
 ! === module MOM_thickness_diffuse ===
 
 ! === module MOM_mixed_layer_restrat ===
-Z_OUTPUT_GRID_FILE = "../zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for
-                                ! depth-space diagnostics, or blank to disable
-                                ! depth-space output.
-!NK_ZSPACE (from file) = 50     !   [nondim]
-                                ! The number of depth-space levels.  This is determined
-                                ! from the size of the variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/single_column/KPP/MOM_parameter_doc.all
+++ b/ocean_only/single_column/KPP/MOM_parameter_doc.all
@@ -80,7 +80,7 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
+MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
                                 ! The minimum amount of time in seconds between calculations of depth-space
                                 ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
                                 ! of regridding to depth online.
@@ -823,12 +823,9 @@ DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! calculating the equivalent barotropic wave speed.
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "../zgrid.nc" ! default = ""
+Z_OUTPUT_GRID_FILE = ""         ! default = ""
                                 ! The file that specifies the vertical grid for depth-space diagnostics, or
                                 ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 60     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/single_column/KPP/MOM_parameter_doc.short
+++ b/ocean_only/single_column/KPP/MOM_parameter_doc.short
@@ -13,10 +13,6 @@ DT = 3600.0                     !   [s]
                                 ! The (baroclinic) dynamics time step.  The time-step that is actually used will
                                 ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
                                 ! or the coupling timestep in coupled mode.)
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 FRAZIL = True                   !   [Boolean] default = False
                                 ! If true, water freezes if it gets too cold, and the the accumulated heat
                                 ! deficit is returned in the surface state.  FRAZIL is only used if
@@ -277,12 +273,6 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 ! === module MOM_mixed_layer_restrat ===
 
 ! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = "../zgrid.nc" ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
-!NK_ZSPACE (from file) = 60     !   [nondim]
-                                ! The number of depth-space levels.  This is determined from the size of the
-                                ! variable zw in the output grid file.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/tides_025/MOM_input
+++ b/ocean_only/tides_025/MOM_input
@@ -366,8 +366,6 @@ DTBT = -0.9                     !   [s or nondim] default = -0.98
 
 ! === module MOM_mixed_layer_restrat ===
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/ocean_only/unit_tests/MOM_input
+++ b/ocean_only/unit_tests/MOM_input
@@ -189,8 +189,6 @@ HMIX_FIXED = 1.0                !   [m]
 
 ! === module MOM_mixed_layer_restrat ===
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 


### PR DESCRIPTION
This commit removes the parameters and diagnostics related to the legacy
Z level interpolation.

The following parameters are removed:

* MIN_Z_DIAG_INTERVAL
* Z_OUTPUT_GRID_FILE

Any diagnostics using a `*_zold` module have also been removed.

This commit also removes an unused ocean.stats output file for the
Baltic_OM4_025 experiment, and updates .gitignore to support stats files
without compiler suffixes.