### PR TITLE
Z diag param purge

### DIFF
--- a/coupled_AM2_LM3_SIS/CM2G63L/MOM_parameter_doc.all
+++ b/coupled_AM2_LM3_SIS/CM2G63L/MOM_parameter_doc.all
@@ -70,10 +70,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -1055,11 +1051,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/coupled_AM2_LM3_SIS/CM2G63L/MOM_parameter_doc.short
+++ b/coupled_AM2_LM3_SIS/CM2G63L/MOM_parameter_doc.short
@@ -338,8 +338,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
                                 ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
                                 ! (2010)
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/MOM_parameter_doc.all
+++ b/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/MOM_parameter_doc.all
@@ -70,10 +70,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -1051,11 +1047,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/MOM_parameter_doc.short
+++ b/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/MOM_parameter_doc.short
@@ -334,8 +334,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
                                 ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
                                 ! (2010)
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/MOM_parameter_doc.all
+++ b/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/MOM_parameter_doc.all
@@ -70,10 +70,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -1051,11 +1047,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/MOM_parameter_doc.short
+++ b/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/MOM_parameter_doc.short
@@ -334,8 +334,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
                                 ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
                                 ! (2010)
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/MOM_parameter_doc.all
+++ b/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/MOM_parameter_doc.all
@@ -70,10 +70,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -1051,11 +1047,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/MOM_parameter_doc.short
+++ b/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/MOM_parameter_doc.short
@@ -337,8 +337,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
                                 ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
                                 ! (2010)
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/ice_ocean_SIS2/Baltic/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/Baltic/MOM_parameter_doc.all
@@ -70,10 +70,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -1051,11 +1047,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ice_ocean_SIS2/Baltic/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/Baltic/MOM_parameter_doc.short
@@ -345,8 +345,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
                                 ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
                                 ! (2010)
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/MOM_parameter_doc.all
@@ -78,10 +78,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -1274,11 +1270,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/MOM_parameter_doc.short
@@ -401,8 +401,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
                                 ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
                                 ! (2010)
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = True       !   [Boolean] default = False

--- a/ice_ocean_SIS2/Baltic_OM4_025/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/Baltic_OM4_025/MOM_parameter_doc.all
@@ -78,10 +78,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -1284,11 +1280,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ice_ocean_SIS2/Baltic_OM4_025/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/Baltic_OM4_025/MOM_parameter_doc.short
@@ -500,8 +500,6 @@ MLE_MLD_DECAY_TIME = 2.592E+06  !   [s] default = 0.0
                                 ! current running-mean the running-mean is instantaneously set to the current
                                 ! MLD.
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = True       !   [Boolean] default = False

--- a/ice_ocean_SIS2/Baltic_OM4_05/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/Baltic_OM4_05/MOM_parameter_doc.all
@@ -78,10 +78,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -1297,11 +1293,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ice_ocean_SIS2/Baltic_OM4_05/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/Baltic_OM4_05/MOM_parameter_doc.short
@@ -522,8 +522,6 @@ MLE_MLD_DECAY_TIME = 2.592E+06  !   [s] default = 0.0
                                 ! current running-mean the running-mean is instantaneously set to the current
                                 ! MLD.
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = True       !   [Boolean] default = False

--- a/ice_ocean_SIS2/OM4_025/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/OM4_025/MOM_parameter_doc.all
@@ -78,10 +78,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -1284,11 +1280,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ice_ocean_SIS2/OM4_025/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/OM4_025/MOM_parameter_doc.short
@@ -507,8 +507,6 @@ MLE_MLD_DECAY_TIME = 2.592E+06  !   [s] default = 0.0
                                 ! current running-mean the running-mean is instantaneously set to the current
                                 ! MLD.
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = True       !   [Boolean] default = False

--- a/ice_ocean_SIS2/OM4_05/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/OM4_05/MOM_parameter_doc.all
@@ -78,10 +78,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -1302,11 +1298,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ice_ocean_SIS2/OM4_05/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/OM4_05/MOM_parameter_doc.short
@@ -533,8 +533,6 @@ MLE_MLD_DECAY_TIME = 2.592E+06  !   [s] default = 0.0
                                 ! current running-mean the running-mean is instantaneously set to the current
                                 ! MLD.
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = True       !   [Boolean] default = False

--- a/ice_ocean_SIS2/SIS2/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/SIS2/MOM_parameter_doc.all
@@ -70,10 +70,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -1075,11 +1071,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ice_ocean_SIS2/SIS2/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/SIS2/MOM_parameter_doc.short
@@ -372,8 +372,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
                                 ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
                                 ! (2010)
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/ice_ocean_SIS2/SIS2_bergs_cgrid/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/SIS2_bergs_cgrid/MOM_parameter_doc.all
@@ -70,10 +70,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -1075,11 +1071,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ice_ocean_SIS2/SIS2_bergs_cgrid/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/SIS2_bergs_cgrid/MOM_parameter_doc.short
@@ -372,8 +372,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
                                 ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
                                 ! (2010)
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/ice_ocean_SIS2/SIS2_cgrid/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/SIS2_cgrid/MOM_parameter_doc.all
@@ -70,10 +70,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -1075,11 +1071,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ice_ocean_SIS2/SIS2_cgrid/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/SIS2_cgrid/MOM_parameter_doc.short
@@ -372,8 +372,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
                                 ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
                                 ! (2010)
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/land_ice_ocean_LM3_SIS2/OM_360x320_C180/MOM_parameter_doc.all
+++ b/land_ice_ocean_LM3_SIS2/OM_360x320_C180/MOM_parameter_doc.all
@@ -78,10 +78,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -1211,11 +1207,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/land_ice_ocean_LM3_SIS2/OM_360x320_C180/MOM_parameter_doc.short
+++ b/land_ice_ocean_LM3_SIS2/OM_360x320_C180/MOM_parameter_doc.short
@@ -422,8 +422,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 10.0 !   [nondim] default = 0.0
                                 ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
                                 ! (2010)
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = True       !   [Boolean] default = False

--- a/ocean_only/CVmix_SCM_tests/cooling_only/BML/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/BML/MOM_parameter_doc.all
@@ -72,10 +72,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -781,11 +777,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/CVmix_SCM_tests/cooling_only/BML/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/BML/MOM_parameter_doc.short
@@ -284,8 +284,6 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/ocean_only/CVmix_SCM_tests/cooling_only/EPBL/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/EPBL/MOM_parameter_doc.all
@@ -80,10 +80,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -865,11 +861,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/CVmix_SCM_tests/cooling_only/EPBL/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/EPBL/MOM_parameter_doc.short
@@ -304,8 +304,6 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = True       !   [Boolean] default = False

--- a/ocean_only/CVmix_SCM_tests/cooling_only/KPP/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/KPP/MOM_parameter_doc.all
@@ -80,10 +80,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -865,11 +861,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/CVmix_SCM_tests/cooling_only/KPP/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/KPP/MOM_parameter_doc.short
@@ -304,8 +304,6 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/ocean_only/CVmix_SCM_tests/mech_only/BML/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/mech_only/BML/MOM_parameter_doc.all
@@ -72,10 +72,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -781,11 +777,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/CVmix_SCM_tests/mech_only/BML/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/mech_only/BML/MOM_parameter_doc.short
@@ -284,8 +284,6 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/ocean_only/CVmix_SCM_tests/mech_only/EPBL/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/mech_only/EPBL/MOM_parameter_doc.all
@@ -80,10 +80,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -865,11 +861,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/CVmix_SCM_tests/mech_only/EPBL/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/mech_only/EPBL/MOM_parameter_doc.short
@@ -304,8 +304,6 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = True       !   [Boolean] default = False

--- a/ocean_only/CVmix_SCM_tests/mech_only/KPP/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/mech_only/KPP/MOM_parameter_doc.all
@@ -80,10 +80,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -865,11 +861,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/CVmix_SCM_tests/mech_only/KPP/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/mech_only/KPP/MOM_parameter_doc.short
@@ -304,8 +304,6 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/BML/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/BML/MOM_parameter_doc.all
@@ -72,10 +72,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -781,11 +777,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/BML/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/BML/MOM_parameter_doc.short
@@ -282,8 +282,6 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/EPBL/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/EPBL/MOM_parameter_doc.all
@@ -80,10 +80,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -865,11 +861,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/EPBL/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/EPBL/MOM_parameter_doc.short
@@ -302,8 +302,6 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = True       !   [Boolean] default = False

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/KPP/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/KPP/MOM_parameter_doc.all
@@ -80,10 +80,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -865,11 +861,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/KPP/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/KPP/MOM_parameter_doc.short
@@ -302,8 +302,6 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/ocean_only/CVmix_SCM_tests/wind_only/BML/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/wind_only/BML/MOM_parameter_doc.all
@@ -72,10 +72,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -781,11 +777,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/CVmix_SCM_tests/wind_only/BML/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/wind_only/BML/MOM_parameter_doc.short
@@ -284,8 +284,6 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/ocean_only/CVmix_SCM_tests/wind_only/EPBL/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/wind_only/EPBL/MOM_parameter_doc.all
@@ -80,10 +80,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -865,11 +861,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/CVmix_SCM_tests/wind_only/EPBL/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/wind_only/EPBL/MOM_parameter_doc.short
@@ -304,8 +304,6 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = True       !   [Boolean] default = False

--- a/ocean_only/CVmix_SCM_tests/wind_only/KPP/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/wind_only/KPP/MOM_parameter_doc.all
@@ -80,10 +80,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -865,11 +861,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/CVmix_SCM_tests/wind_only/KPP/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/wind_only/KPP/MOM_parameter_doc.short
@@ -304,8 +304,6 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/ocean_only/DOME/MOM_parameter_doc.all
+++ b/ocean_only/DOME/MOM_parameter_doc.all
@@ -78,10 +78,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -914,11 +910,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/DOME/MOM_parameter_doc.short
+++ b/ocean_only/DOME/MOM_parameter_doc.short
@@ -331,8 +331,6 @@ KHTH = 1.0E-04                  !   [m2 s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/ocean_only/Phillips_2layer/MOM_parameter_doc.all
+++ b/ocean_only/Phillips_2layer/MOM_parameter_doc.all
@@ -78,10 +78,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -886,11 +882,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/Phillips_2layer/MOM_parameter_doc.short
+++ b/ocean_only/Phillips_2layer/MOM_parameter_doc.short
@@ -336,8 +336,6 @@ KHTH = 8000.0                   !   [m2 s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.all
+++ b/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.all
@@ -80,10 +80,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -865,11 +861,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.short
+++ b/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.short
@@ -307,8 +307,6 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/ocean_only/adjustment2d/layer/MOM_parameter_doc.all
+++ b/ocean_only/adjustment2d/layer/MOM_parameter_doc.all
@@ -78,10 +78,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -944,11 +940,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/adjustment2d/layer/MOM_parameter_doc.short
+++ b/ocean_only/adjustment2d/layer/MOM_parameter_doc.short
@@ -348,8 +348,6 @@ KHTH = 1.0E-04                  !   [m2 s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/ocean_only/adjustment2d/rho/MOM_parameter_doc.all
+++ b/ocean_only/adjustment2d/rho/MOM_parameter_doc.all
@@ -78,10 +78,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -1062,11 +1058,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/adjustment2d/rho/MOM_parameter_doc.short
+++ b/ocean_only/adjustment2d/rho/MOM_parameter_doc.short
@@ -391,8 +391,6 @@ KHTH = 1.0E-04                  !   [m2 s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/ocean_only/adjustment2d/z/MOM_parameter_doc.all
+++ b/ocean_only/adjustment2d/z/MOM_parameter_doc.all
@@ -78,10 +78,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -1021,11 +1017,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/adjustment2d/z/MOM_parameter_doc.short
+++ b/ocean_only/adjustment2d/z/MOM_parameter_doc.short
@@ -371,8 +371,6 @@ KHTH = 1.0E-04                  !   [m2 s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/ocean_only/benchmark/MOM_parameter_doc.all
+++ b/ocean_only/benchmark/MOM_parameter_doc.all
@@ -70,10 +70,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -1012,11 +1008,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/benchmark/MOM_parameter_doc.short
+++ b/ocean_only/benchmark/MOM_parameter_doc.short
@@ -354,8 +354,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 5.0 !   [nondim] default = 0.0
                                 ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
                                 ! (2010)
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/ocean_only/circle_obcs/MOM_parameter_doc.all
+++ b/ocean_only/circle_obcs/MOM_parameter_doc.all
@@ -78,10 +78,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -991,11 +987,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/circle_obcs/MOM_parameter_doc.short
+++ b/ocean_only/circle_obcs/MOM_parameter_doc.short
@@ -312,8 +312,6 @@ DTBT = -0.95                    !   [s or nondim] default = -0.98
 
 ! === module MOM_mixed_layer_restrat ===
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/ocean_only/double_gyre/MOM_parameter_doc.all
+++ b/ocean_only/double_gyre/MOM_parameter_doc.all
@@ -78,10 +78,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -840,11 +836,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/double_gyre/MOM_parameter_doc.short
+++ b/ocean_only/double_gyre/MOM_parameter_doc.short
@@ -268,8 +268,6 @@ DTBT = -0.9                     !   [s or nondim] default = -0.98
 
 ! === module MOM_mixed_layer_restrat ===
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/ocean_only/external_gwave/MOM_parameter_doc.all
+++ b/ocean_only/external_gwave/MOM_parameter_doc.all
@@ -78,10 +78,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -930,11 +926,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/external_gwave/MOM_parameter_doc.short
+++ b/ocean_only/external_gwave/MOM_parameter_doc.short
@@ -325,8 +325,6 @@ DTBT = 20.0                     !   [s or nondim] default = -0.98
 
 ! === module MOM_mixed_layer_restrat ===
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/ocean_only/flow_downslope/layer/MOM_parameter_doc.all
+++ b/ocean_only/flow_downslope/layer/MOM_parameter_doc.all
@@ -78,10 +78,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -937,11 +933,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/flow_downslope/layer/MOM_parameter_doc.short
+++ b/ocean_only/flow_downslope/layer/MOM_parameter_doc.short
@@ -345,8 +345,6 @@ KHTH = 1.0E-04                  !   [m2 s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/ocean_only/flow_downslope/rho/MOM_parameter_doc.all
+++ b/ocean_only/flow_downslope/rho/MOM_parameter_doc.all
@@ -78,10 +78,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -1057,11 +1053,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/flow_downslope/rho/MOM_parameter_doc.short
+++ b/ocean_only/flow_downslope/rho/MOM_parameter_doc.short
@@ -390,8 +390,6 @@ KHTH = 1.0E-04                  !   [m2 s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/ocean_only/flow_downslope/sigma/MOM_parameter_doc.all
+++ b/ocean_only/flow_downslope/sigma/MOM_parameter_doc.all
@@ -78,10 +78,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -1016,11 +1012,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/flow_downslope/sigma/MOM_parameter_doc.short
+++ b/ocean_only/flow_downslope/sigma/MOM_parameter_doc.short
@@ -368,8 +368,6 @@ KHTH = 1.0E-04                  !   [m2 s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/ocean_only/flow_downslope/z/MOM_parameter_doc.all
+++ b/ocean_only/flow_downslope/z/MOM_parameter_doc.all
@@ -78,10 +78,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -1016,11 +1012,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/flow_downslope/z/MOM_parameter_doc.short
+++ b/ocean_only/flow_downslope/z/MOM_parameter_doc.short
@@ -368,8 +368,6 @@ KHTH = 1.0E-04                  !   [m2 s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/ocean_only/global_ALE/hycom/MOM_parameter_doc.all
+++ b/ocean_only/global_ALE/hycom/MOM_parameter_doc.all
@@ -78,10 +78,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -1314,11 +1310,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/global_ALE/hycom/MOM_parameter_doc.short
+++ b/ocean_only/global_ALE/hycom/MOM_parameter_doc.short
@@ -427,8 +427,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
                                 ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
                                 ! (2010)
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = True       !   [Boolean] default = False

--- a/ocean_only/global_ALE/layer/MOM_parameter_doc.all
+++ b/ocean_only/global_ALE/layer/MOM_parameter_doc.all
@@ -70,10 +70,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -1157,11 +1153,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/global_ALE/layer/MOM_parameter_doc.short
+++ b/ocean_only/global_ALE/layer/MOM_parameter_doc.short
@@ -348,8 +348,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
                                 ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
                                 ! (2010)
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/ocean_only/global_ALE/z/MOM_parameter_doc.all
+++ b/ocean_only/global_ALE/z/MOM_parameter_doc.all
@@ -78,10 +78,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -1271,11 +1267,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/global_ALE/z/MOM_parameter_doc.short
+++ b/ocean_only/global_ALE/z/MOM_parameter_doc.short
@@ -402,8 +402,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
                                 ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
                                 ! (2010)
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = True       !   [Boolean] default = False

--- a/ocean_only/lock_exchange/MOM_parameter_doc.all
+++ b/ocean_only/lock_exchange/MOM_parameter_doc.all
@@ -78,10 +78,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -933,11 +929,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/lock_exchange/MOM_parameter_doc.short
+++ b/ocean_only/lock_exchange/MOM_parameter_doc.short
@@ -315,8 +315,6 @@ DTBT = 25.0                     !   [s or nondim] default = -0.98
 
 ! === module MOM_mixed_layer_restrat ===
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/ocean_only/mixed_layer_restrat_2d/MOM_parameter_doc.all
+++ b/ocean_only/mixed_layer_restrat_2d/MOM_parameter_doc.all
@@ -78,10 +78,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -1045,11 +1041,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/mixed_layer_restrat_2d/MOM_parameter_doc.short
+++ b/ocean_only/mixed_layer_restrat_2d/MOM_parameter_doc.short
@@ -361,8 +361,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 10.0 !   [nondim] default = 0.0
                                 ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
                                 ! (2010)
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/ocean_only/nonBous_global/MOM_parameter_doc.all
+++ b/ocean_only/nonBous_global/MOM_parameter_doc.all
@@ -70,10 +70,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -1079,11 +1075,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/nonBous_global/MOM_parameter_doc.short
+++ b/ocean_only/nonBous_global/MOM_parameter_doc.short
@@ -377,8 +377,6 @@ FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
                                 ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
                                 ! (2010)
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/ocean_only/resting/layer/MOM_parameter_doc.all
+++ b/ocean_only/resting/layer/MOM_parameter_doc.all
@@ -78,10 +78,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -926,11 +922,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/resting/layer/MOM_parameter_doc.short
+++ b/ocean_only/resting/layer/MOM_parameter_doc.short
@@ -323,8 +323,6 @@ KHTH = 500.0                    !   [m2 s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/ocean_only/resting/z/MOM_parameter_doc.all
+++ b/ocean_only/resting/z/MOM_parameter_doc.all
@@ -78,10 +78,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -1005,11 +1001,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/resting/z/MOM_parameter_doc.short
+++ b/ocean_only/resting/z/MOM_parameter_doc.short
@@ -337,8 +337,6 @@ KHTH = 500.0                    !   [m2 s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/ocean_only/seamount/layer/MOM_parameter_doc.all
+++ b/ocean_only/seamount/layer/MOM_parameter_doc.all
@@ -78,10 +78,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -959,11 +955,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/seamount/layer/MOM_parameter_doc.short
+++ b/ocean_only/seamount/layer/MOM_parameter_doc.short
@@ -337,8 +337,6 @@ KHTH = 500.0                    !   [m2 s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/ocean_only/seamount/rho/MOM_parameter_doc.all
+++ b/ocean_only/seamount/rho/MOM_parameter_doc.all
@@ -78,10 +78,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -1077,11 +1073,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/seamount/rho/MOM_parameter_doc.short
+++ b/ocean_only/seamount/rho/MOM_parameter_doc.short
@@ -383,8 +383,6 @@ KHTH = 500.0                    !   [m2 s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/ocean_only/seamount/sigma/MOM_parameter_doc.all
+++ b/ocean_only/seamount/sigma/MOM_parameter_doc.all
@@ -78,10 +78,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -1033,11 +1029,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/seamount/sigma/MOM_parameter_doc.short
+++ b/ocean_only/seamount/sigma/MOM_parameter_doc.short
@@ -360,8 +360,6 @@ KHTH = 500.0                    !   [m2 s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/ocean_only/seamount/z/MOM_parameter_doc.all
+++ b/ocean_only/seamount/z/MOM_parameter_doc.all
@@ -78,10 +78,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -1033,11 +1029,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/seamount/z/MOM_parameter_doc.short
+++ b/ocean_only/seamount/z/MOM_parameter_doc.short
@@ -360,8 +360,6 @@ KHTH = 500.0                    !   [m2 s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/ocean_only/single_column/BML/MOM_parameter_doc.all
+++ b/ocean_only/single_column/BML/MOM_parameter_doc.all
@@ -72,10 +72,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -744,11 +740,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/single_column/BML/MOM_parameter_doc.short
+++ b/ocean_only/single_column/BML/MOM_parameter_doc.short
@@ -235,8 +235,6 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/ocean_only/single_column/EPBL/MOM_parameter_doc.all
+++ b/ocean_only/single_column/EPBL/MOM_parameter_doc.all
@@ -80,10 +80,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -821,11 +817,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/single_column/EPBL/MOM_parameter_doc.short
+++ b/ocean_only/single_column/EPBL/MOM_parameter_doc.short
@@ -272,8 +272,6 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 ENERGETICS_SFC_PBL = True       !   [Boolean] default = False

--- a/ocean_only/single_column/KPP/MOM_parameter_doc.all
+++ b/ocean_only/single_column/KPP/MOM_parameter_doc.all
@@ -80,10 +80,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -821,11 +817,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/single_column/KPP/MOM_parameter_doc.short
+++ b/ocean_only/single_column/KPP/MOM_parameter_doc.short
@@ -272,8 +272,6 @@ VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/ocean_only/sloshing/layer/MOM_parameter_doc.all
+++ b/ocean_only/sloshing/layer/MOM_parameter_doc.all
@@ -78,10 +78,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -938,11 +934,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/sloshing/layer/MOM_parameter_doc.short
+++ b/ocean_only/sloshing/layer/MOM_parameter_doc.short
@@ -334,8 +334,6 @@ KHTH = 500.0                    !   [m2 s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/ocean_only/sloshing/rho/MOM_parameter_doc.all
+++ b/ocean_only/sloshing/rho/MOM_parameter_doc.all
@@ -78,10 +78,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -1058,11 +1054,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/sloshing/rho/MOM_parameter_doc.short
+++ b/ocean_only/sloshing/rho/MOM_parameter_doc.short
@@ -377,8 +377,6 @@ KHTH = 500.0                    !   [m2 s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/ocean_only/sloshing/z/MOM_parameter_doc.all
+++ b/ocean_only/sloshing/z/MOM_parameter_doc.all
@@ -78,10 +78,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -1017,11 +1013,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/sloshing/z/MOM_parameter_doc.short
+++ b/ocean_only/sloshing/z/MOM_parameter_doc.short
@@ -357,8 +357,6 @@ KHTH = 500.0                    !   [m2 s-1] default = 0.0
 
 ! === module MOM_mixed_layer_restrat ===
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/ocean_only/torus_advection_test/MOM_parameter_doc.all
+++ b/ocean_only/torus_advection_test/MOM_parameter_doc.all
@@ -78,10 +78,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -936,11 +932,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/torus_advection_test/MOM_parameter_doc.short
+++ b/ocean_only/torus_advection_test/MOM_parameter_doc.short
@@ -331,8 +331,6 @@ DTBT = -0.9                     !   [s or nondim] default = -0.98
 
 ! === module MOM_mixed_layer_restrat ===
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/ocean_only/tracer_mixing/rho/MOM_parameter_doc.all
+++ b/ocean_only/tracer_mixing/rho/MOM_parameter_doc.all
@@ -78,10 +78,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -1063,11 +1059,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/tracer_mixing/rho/MOM_parameter_doc.short
+++ b/ocean_only/tracer_mixing/rho/MOM_parameter_doc.short
@@ -383,8 +383,6 @@ DTBT = 5.0                      !   [s or nondim] default = -0.98
 
 ! === module MOM_mixed_layer_restrat ===
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/ocean_only/tracer_mixing/z/MOM_parameter_doc.all
+++ b/ocean_only/tracer_mixing/z/MOM_parameter_doc.all
@@ -78,10 +78,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -1022,11 +1018,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/tracer_mixing/z/MOM_parameter_doc.short
+++ b/ocean_only/tracer_mixing/z/MOM_parameter_doc.short
@@ -363,8 +363,6 @@ DTBT = 5.0                      !   [s or nondim] default = -0.98
 
 ! === module MOM_mixed_layer_restrat ===
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 

--- a/ocean_only/unit_tests/MOM_parameter_doc.all
+++ b/ocean_only/unit_tests/MOM_parameter_doc.all
@@ -80,10 +80,6 @@ HFREEZE = -1.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-MIN_Z_DIAG_INTERVAL = 0.0       !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between calculations of depth-space
-                                ! diagnostics. Making this larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
@@ -708,11 +704,6 @@ DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
 DIAG_EBT_MONO_N2_DEPTH = -1.0   !   [m] default = -1.0
                                 ! The depth below which N2 is limited as monotonic for the purposes of
                                 ! calculating the equivalent barotropic wave speed.
-
-! === module MOM_diag_to_Z ===
-Z_OUTPUT_GRID_FILE = ""         ! default = ""
-                                ! The file that specifies the vertical grid for depth-space diagnostics, or
-                                ! blank to disable depth-space output.
 
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.

--- a/ocean_only/unit_tests/MOM_parameter_doc.short
+++ b/ocean_only/unit_tests/MOM_parameter_doc.short
@@ -189,8 +189,6 @@ HMIX_FIXED = 1.0                !   [m]
 
 ! === module MOM_mixed_layer_restrat ===
 
-! === module MOM_diag_to_Z ===
-
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
 


### PR DESCRIPTION
Updates the MOM6 source to 3ee6955, which includes the removal of the
Z-level diagnostics and associated parameters.

Also removes the references to the parameters from the MOM_parameter_doc
files.

- NOAA-GFDL/MOM6@3ee6955 Z_OUTPUT_GRID_FILE parameter obsolescence
- NOAA-GFDL/MOM6@c450cc6 Merge branch 'dev/gfdl' into z_diag_purge
- NOAA-GFDL/MOM6@eaf8c90 + Excise of legacy z-interpolated diagnostics