### PR TITLE
Remove FrictWorkMax from global_ALE params

### DIFF
--- a/ocean_only/global_ALE/layer/available_diags.000000
+++ b/ocean_only/global_ALE/layer/available_diags.000000
@@ -1302,38 +1302,6 @@
     ! long_name: Integral work done by lateral friction terms (excluding diffusion of energy)
     ! units: W m-2
     ! cell_methods: z_l:mean
-"ocean_model", "FrictWorkMax"  [Unused]
-    ! long_name: Maximum possible integral work done by lateral friction terms
-    ! units: W m-2
-    ! cell_methods: xh:mean yh:mean zl:mean area:mean
-"ocean_model", "FrictWorkMax_xyave"  [Unused]
-    ! long_name: Maximum possible integral work done by lateral friction terms
-    ! units: W m-2
-    ! cell_methods: zl:mean
-"ocean_model_z", "FrictWorkMax"  [Unused]
-    ! long_name: Maximum possible integral work done by lateral friction terms
-    ! units: W m-2
-    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
-"ocean_model_z", "FrictWorkMax_xyave"  [Unused]
-    ! long_name: Maximum possible integral work done by lateral friction terms
-    ! units: W m-2
-    ! cell_methods: z_l:mean
-"ocean_model_d2", "FrictWorkMax"  [Unused]
-    ! long_name: Maximum possible integral work done by lateral friction terms
-    ! units: W m-2
-    ! cell_methods: xh:mean yh:mean zl:mean area:mean
-"ocean_model_d2", "FrictWorkMax_xyave"  [Unused]
-    ! long_name: Maximum possible integral work done by lateral friction terms
-    ! units: W m-2
-    ! cell_methods: zl:mean
-"ocean_model_z_d2", "FrictWorkMax"  [Unused]
-    ! long_name: Maximum possible integral work done by lateral friction terms
-    ! units: W m-2
-    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
-"ocean_model_z_d2", "FrictWorkMax_xyave"  [Unused]
-    ! long_name: Maximum possible integral work done by lateral friction terms
-    ! units: W m-2
-    ! cell_methods: z_l:mean
 "ocean_model", "FrictWorkIntz"  [Unused] (CMOR equivalent is "dispkexyfo")
     ! long_name: Depth integrated work done by lateral friction
     ! units: W m-2

--- a/ocean_only/global_ALE/z/available_diags.000000
+++ b/ocean_only/global_ALE/z/available_diags.000000
@@ -1382,38 +1382,6 @@
     ! long_name: Integral work done by lateral friction terms (excluding diffusion of energy)
     ! units: W m-2
     ! cell_methods: z_l:mean
-"ocean_model", "FrictWorkMax"  [Unused]
-    ! long_name: Maximum possible integral work done by lateral friction terms
-    ! units: W m-2
-    ! cell_methods: xh:mean yh:mean zl:mean area:mean
-"ocean_model", "FrictWorkMax_xyave"  [Unused]
-    ! long_name: Maximum possible integral work done by lateral friction terms
-    ! units: W m-2
-    ! cell_methods: zl:mean
-"ocean_model_z", "FrictWorkMax"  [Unused]
-    ! long_name: Maximum possible integral work done by lateral friction terms
-    ! units: W m-2
-    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
-"ocean_model_z", "FrictWorkMax_xyave"  [Unused]
-    ! long_name: Maximum possible integral work done by lateral friction terms
-    ! units: W m-2
-    ! cell_methods: z_l:mean
-"ocean_model_d2", "FrictWorkMax"  [Unused]
-    ! long_name: Maximum possible integral work done by lateral friction terms
-    ! units: W m-2
-    ! cell_methods: xh:mean yh:mean zl:mean area:mean
-"ocean_model_d2", "FrictWorkMax_xyave"  [Unused]
-    ! long_name: Maximum possible integral work done by lateral friction terms
-    ! units: W m-2
-    ! cell_methods: zl:mean
-"ocean_model_z_d2", "FrictWorkMax"  [Unused]
-    ! long_name: Maximum possible integral work done by lateral friction terms
-    ! units: W m-2
-    ! cell_methods: xh:mean yh:mean z_l:mean area:mean
-"ocean_model_z_d2", "FrictWorkMax_xyave"  [Unused]
-    ! long_name: Maximum possible integral work done by lateral friction terms
-    ! units: W m-2
-    ! cell_methods: z_l:mean
 "ocean_model", "FrictWorkIntz"  [Unused] (CMOR equivalent is "dispkexyfo")
     ! long_name: Depth integrated work done by lateral friction
     ! units: W m-2


### PR DESCRIPTION
Runs using MEKE but lacking sufficient parameters to compute
FrictWorkMax no longer register this as a variable when it cannot be
computed, so they are now removed from available_diags.* output.