### PR TITLE
Add Z_INIT_SEPARATE_MIXED_LAYER to 5 MOM_input files

### DIFF
--- a/coupled_AM2_LM3_SIS2/AM2_SIS2B_MOM6i_1deg/MOM_input
+++ b/coupled_AM2_LM3_SIS2/AM2_SIS2B_MOM6i_1deg/MOM_input
@@ -213,6 +213,10 @@ Z_INIT_FILE_SALT_VAR = "SALT"   ! default = "salt"
 ADJUST_THICKNESS = True         !   [Boolean] default = False
                                 ! If true, all mass below the bottom removed if the topography is shallower than
                                 ! the thickness input file would indicate.
+Z_INIT_SEPARATE_MIXED_LAYER = True !   [Boolean] default = False
+                                ! If true, distribute the topmost Z_INIT_HMIX_DEPTH of water over NKML layers,
+                                ! and do not correct the density of the topmost NKML+NKBL layers.  Otherwise all
+                                ! layers are initialized based on the depths of their target densities.
 
 ! === module MOM_diag_mediator ===
 

--- a/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/MOM_input
+++ b/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/MOM_input
@@ -213,6 +213,10 @@ Z_INIT_FILE_SALT_VAR = "SALT"   ! default = "salt"
 ADJUST_THICKNESS = True         !   [Boolean] default = False
                                 ! If true, all mass below the bottom removed if the topography is shallower than
                                 ! the thickness input file would indicate.
+Z_INIT_SEPARATE_MIXED_LAYER = True !   [Boolean] default = False
+                                ! If true, distribute the topmost Z_INIT_HMIX_DEPTH of water over NKML layers,
+                                ! and do not correct the density of the topmost NKML+NKBL layers.  Otherwise all
+                                ! layers are initialized based on the depths of their target densities.
 
 ! === module MOM_diag_mediator ===
 

--- a/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/MOM_input
+++ b/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/MOM_input
@@ -213,6 +213,10 @@ Z_INIT_FILE_SALT_VAR = "SALT"   ! default = "salt"
 ADJUST_THICKNESS = True         !   [Boolean] default = False
                                 ! If true, all mass below the bottom removed if the topography is shallower than
                                 ! the thickness input file would indicate.
+Z_INIT_SEPARATE_MIXED_LAYER = True !   [Boolean] default = False
+                                ! If true, distribute the topmost Z_INIT_HMIX_DEPTH of water over NKML layers,
+                                ! and do not correct the density of the topmost NKML+NKBL layers.  Otherwise all
+                                ! layers are initialized based on the depths of their target densities.
 
 ! === module MOM_diag_mediator ===
 

--- a/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/MOM_input
+++ b/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/MOM_input
@@ -216,6 +216,10 @@ Z_INIT_FILE_SALT_VAR = "SALT"   ! default = "salt"
 ADJUST_THICKNESS = True         !   [Boolean] default = False
                                 ! If true, all mass below the bottom removed if the topography is shallower than
                                 ! the thickness input file would indicate.
+Z_INIT_SEPARATE_MIXED_LAYER = True !   [Boolean] default = False
+                                ! If true, distribute the topmost Z_INIT_HMIX_DEPTH of water over NKML layers,
+                                ! and do not correct the density of the topmost NKML+NKBL layers.  Otherwise all
+                                ! layers are initialized based on the depths of their target densities.
 
 ! === module MOM_diag_mediator ===
 

--- a/ice_ocean_SIS2/Baltic/MOM_input
+++ b/ice_ocean_SIS2/Baltic/MOM_input
@@ -217,6 +217,10 @@ Z_INIT_FILE_SALT_VAR = "SALT"   ! default = "salt"
 ADJUST_THICKNESS = True         !   [Boolean] default = False
                                 ! If true, all mass below the bottom removed if the topography is shallower than
                                 ! the thickness input file would indicate.
+Z_INIT_SEPARATE_MIXED_LAYER = True !   [Boolean] default = False
+                                ! If true, distribute the topmost Z_INIT_HMIX_DEPTH of water over NKML layers,
+                                ! and do not correct the density of the topmost NKML+NKBL layers.  Otherwise all
+                                ! layers are initialized based on the depths of their target densities.
 
 ! === module MOM_diag_mediator ===
 DIAG_COORD_DEF_Z = "FILE:OM3_zgrid.nc,interfaces=zw" ! default = "WOA09"


### PR DESCRIPTION
  Added the future runtime parameter Z_INIT_SEPARATE_MIXED_LAYER to 5 MOM_input
files so that when a change is made to the MOM6 code to address an issue with
inconsistent defaults for NKML and NKBL, the answers in the MOM6-examples test
suite will remain bitwise identical.  For now these parameters are not even
read, so answers are bitwise identical, but there will temporarily be entries
that will cause the model to fail if FATAL_UNUSED_PARAMS is true.