### PR TITLE
MOM6-examples: Explicitly set 5 parameters to default values

### DIFF
--- a/coupled_AM2_LM3_SIS2/AM2_SIS2B_MOM6i_1deg/SIS_input
+++ b/coupled_AM2_LM3_SIS2/AM2_SIS2B_MOM6i_1deg/SIS_input
@@ -46,6 +46,13 @@ REENTRANT_Y = False             !    If defined, the domain is meridionally
 TRIPOLAR_N = True               !    Use tripolar connectivity at the northern
                                 !  edge of the domain.  With TRIPOLAR_N, NIGLOBAL
                                 !  must be even.
+USE_TRIPOLAR_GEOLONB_BUG = True !   [Boolean] default = True
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
+GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 
 DEBUG = False                   !    If true, write out verbose debugging data.
 SEND_LOG_TO_STDOUT = False      !    If true write out log information to stdout.

--- a/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/SIS_input
+++ b/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/SIS_input
@@ -46,6 +46,13 @@ REENTRANT_Y = False             !    If defined, the domain is meridionally
 TRIPOLAR_N = True               !    Use tripolar connectivity at the northern
                                 !  edge of the domain.  With TRIPOLAR_N, NIGLOBAL
                                 !  must be even.
+USE_TRIPOLAR_GEOLONB_BUG = True !   [Boolean] default = True
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
+GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 
 DEBUG = False                   !    If true, write out verbose debugging data.
 SEND_LOG_TO_STDOUT = False      !    If true write out log information to stdout.

--- a/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/SIS_input
+++ b/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/SIS_input
@@ -46,6 +46,13 @@ REENTRANT_Y = False             !    If defined, the domain is meridionally
 TRIPOLAR_N = True               !    Use tripolar connectivity at the northern
                                 !  edge of the domain.  With TRIPOLAR_N, NIGLOBAL
                                 !  must be even.
+USE_TRIPOLAR_GEOLONB_BUG = True !   [Boolean] default = True
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
+GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 
 DEBUG = False                   !    If true, write out verbose debugging data.
 SEND_LOG_TO_STDOUT = False      !    If true write out log information to stdout.

--- a/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/SIS_input
+++ b/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/SIS_input
@@ -46,6 +46,13 @@ REENTRANT_Y = False             !    If defined, the domain is meridionally
 TRIPOLAR_N = True               !    Use tripolar connectivity at the northern
                                 !  edge of the domain.  With TRIPOLAR_N, NIGLOBAL
                                 !  must be even.
+USE_TRIPOLAR_GEOLONB_BUG = True !   [Boolean] default = True
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
+GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 
 DEBUG = False                   !    If true, write out verbose debugging data.
 SEND_LOG_TO_STDOUT = False      !    If true write out log information to stdout.

--- a/ice_ocean_SIS2/Baltic/SIS_input
+++ b/ice_ocean_SIS2/Baltic/SIS_input
@@ -46,6 +46,10 @@ REENTRANT_Y = False             !    If defined, the domain is meridionally
 TRIPOLAR_N = False              !    Use tripolar connectivity at the northern
                                 !  edge of the domain.  With TRIPOLAR_N, NIGLOBAL
                                 !  must be even.
+GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 
 DEBUG = False                   !    If true, write out verbose debugging data.
 SEND_LOG_TO_STDOUT = False      !    If true write out log information to stdout.

--- a/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/SIS_input
+++ b/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/SIS_input
@@ -41,6 +41,10 @@ REENTRANT_Y = False             !    If defined, the domain is meridionally
 TRIPOLAR_N = False              !    Use tripolar connectivity at the northern
                                 !  edge of the domain.  With TRIPOLAR_N, NIGLOBAL
                                 !  must be even.
+GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 
 DEBUG = False                   !    If true, write out verbose debugging data.
 SEND_LOG_TO_STDOUT = False      !    If true write out log information to stdout.

--- a/ice_ocean_SIS2/Baltic_OM4_025/SIS_input
+++ b/ice_ocean_SIS2/Baltic_OM4_025/SIS_input
@@ -31,6 +31,10 @@ NJGLOBAL = 105                  !
                                 ! The total number of thickness grid points in the
                                 ! y-direction in the physical domain. With STATIC_MEMORY_
                                 ! this is set in SIS2_memory.h at compile time.
+GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 
 ! === module hor_grid ===
 ! Parameters providing information about the lateral grid.

--- a/ice_ocean_SIS2/Baltic_OM4_05/SIS_input
+++ b/ice_ocean_SIS2/Baltic_OM4_05/SIS_input
@@ -52,6 +52,10 @@ GRID_CONFIG = "mosaic"          !
                                 !    cartesian - a Cartesian grid
                                 !    spherical - a spherical grid
                                 !    mercator  - a Mercator grid
+GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 ICE_DELTA_EDD_R_ICE = 1.0       !   [perhaps nondimensional?] default = 0.0
                                 ! A dreadfully documented tuning parameter for the radiative
                                 ! propeties of sea ice with the delta-Eddington radiative

--- a/ice_ocean_SIS2/OM4_025.JRA/SIS_input
+++ b/ice_ocean_SIS2/OM4_025.JRA/SIS_input
@@ -32,6 +32,13 @@ NJGLOBAL = 1080                 !
                                 ! The total number of thickness grid points in the
                                 ! y-direction in the physical domain. With STATIC_MEMORY_
                                 ! this is set in SIS2_memory.h at compile time.
+USE_TRIPOLAR_GEOLONB_BUG = True !   [Boolean] default = True
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
+GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 
 ! === module hor_grid ===
 ! Parameters providing information about the lateral grid.

--- a/ice_ocean_SIS2/OM4_025/SIS_input
+++ b/ice_ocean_SIS2/OM4_025/SIS_input
@@ -32,6 +32,13 @@ NJGLOBAL = 1080                 !
                                 ! The total number of thickness grid points in the
                                 ! y-direction in the physical domain. With STATIC_MEMORY_
                                 ! this is set in SIS2_memory.h at compile time.
+USE_TRIPOLAR_GEOLONB_BUG = True !   [Boolean] default = True
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
+GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 
 ! === module hor_grid ===
 ! Parameters providing information about the lateral grid.

--- a/ice_ocean_SIS2/OM4_05/SIS_input
+++ b/ice_ocean_SIS2/OM4_05/SIS_input
@@ -43,6 +43,13 @@ NJGLOBAL = 576                  !
                                 ! The total number of thickness grid points in the
                                 ! y-direction in the physical domain. With STATIC_MEMORY_
                                 ! this is set in SIS2_memory.h at compile time.
+USE_TRIPOLAR_GEOLONB_BUG = True !   [Boolean] default = True
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
+GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 GRID_FILE = "ocean_hgrid.nc"    !
                                 ! Name of the file from which to read horizontal grid data.
 INPUTDIR = "INPUT"              ! default = "."

--- a/ice_ocean_SIS2/SIS2/SIS_input
+++ b/ice_ocean_SIS2/SIS2/SIS_input
@@ -42,6 +42,13 @@ REENTRANT_Y = False             !    If defined, the domain is meridionally
 TRIPOLAR_N = True               !    Use tripolar connectivity at the northern
                                 !  edge of the domain.  With TRIPOLAR_N, NIGLOBAL
                                 !  must be even.
+USE_TRIPOLAR_GEOLONB_BUG = True !   [Boolean] default = True
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
+GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 
 DEBUG = False                   !    If true, write out verbose debugging data.
 SEND_LOG_TO_STDOUT = False      !    If true write out log information to stdout.

--- a/ice_ocean_SIS2/SIS2_bergs_cgrid/SIS_input
+++ b/ice_ocean_SIS2/SIS2_bergs_cgrid/SIS_input
@@ -52,6 +52,13 @@ REENTRANT_Y = False             !    If defined, the domain is meridionally
 TRIPOLAR_N = True               !    Use tripolar connectivity at the northern
                                 !  edge of the domain.  With TRIPOLAR_N, NIGLOBAL
                                 !  must be even.
+USE_TRIPOLAR_GEOLONB_BUG = True !   [Boolean] default = True
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
+GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 
 DEBUG = False                   !    If true, write out verbose debugging data.
 SEND_LOG_TO_STDOUT = False      !    If true write out log information to stdout.

--- a/ice_ocean_SIS2/SIS2_cgrid/SIS_input
+++ b/ice_ocean_SIS2/SIS2_cgrid/SIS_input
@@ -46,6 +46,13 @@ REENTRANT_Y = False             !    If defined, the domain is meridionally
 TRIPOLAR_N = True               !    Use tripolar connectivity at the northern
                                 !  edge of the domain.  With TRIPOLAR_N, NIGLOBAL
                                 !  must be even.
+USE_TRIPOLAR_GEOLONB_BUG = True !   [Boolean] default = True
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
+GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 
 DEBUG = False                   !    If true, write out verbose debugging data.
 SEND_LOG_TO_STDOUT = False      !    If true write out log information to stdout.

--- a/ice_ocean_SIS2/SIS2_icebergs/SIS_input
+++ b/ice_ocean_SIS2/SIS2_icebergs/SIS_input
@@ -48,6 +48,13 @@ REENTRANT_Y = False             !    If defined, the domain is meridionally
 TRIPOLAR_N = True               !    Use tripolar connectivity at the northern
                                 !  edge of the domain.  With TRIPOLAR_N, NIGLOBAL
                                 !  must be even.
+USE_TRIPOLAR_GEOLONB_BUG = True !   [Boolean] default = True
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
+GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 
 DEBUG = False                   !    If true, write out verbose debugging data.
 SEND_LOG_TO_STDOUT = False      !    If true write out log information to stdout.

--- a/land_ice_ocean_LM3_SIS2/OM_360x320_C180/SIS_input
+++ b/land_ice_ocean_LM3_SIS2/OM_360x320_C180/SIS_input
@@ -44,6 +44,13 @@ REENTRANT_Y = False             !    If defined, the domain is meridionally
 TRIPOLAR_N = True               !    Use tripolar connectivity at the northern
                                 !  edge of the domain.  With TRIPOLAR_N, NIGLOBAL
                                 !  must be even.
+USE_TRIPOLAR_GEOLONB_BUG = True !   [Boolean] default = True
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
+GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
+                                ! If true, use an older algorithm to calculate the sine and cosines needed
+                                ! rotate between grid-oriented directions and true north and east.  Differences
+                                ! arise at the tripolar fold.
 
 DEBUG = False                   !    If true, write out verbose debugging data.
 SEND_LOG_TO_STDOUT = False      !    If true write out log information to stdout.

--- a/ocean_only/CVmix_SCM_tests/common_BML/MOM_input
+++ b/ocean_only/CVmix_SCM_tests/common_BML/MOM_input
@@ -249,6 +249,12 @@ KV = 0.0                        !   [m2 s-1]
 
 ! === module MOM_thickness_diffuse ===
 
+FIX_UNSPLIT_DT_VISC_BUG = False !   [Boolean] default = False
+                                ! If true, use the correct timestep in the viscous terms applied in the first
+                                ! predictor step with the unsplit time stepping scheme, and in the calculation
+                                ! of the turbulent mixed layer properties for viscosity with unsplit or
+                                ! unsplit_RK2. The default should be true.
+
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===
@@ -362,6 +368,9 @@ BULK_RI_ML = 0.05               !   [nondim]
 HMIX_MIN = 2.0                  !   [m] default = 0.0
                                 ! The minimum mixed layer depth if the mixed layer depth is determined
                                 ! dynamically.
+BULKML_CONV_MOMENTUM_BUG = True !   [Boolean] default = True
+                                ! If true, use code with a bug that causes a loss of momentum conservation
+                                ! during mixedlayer convection.
 
 ! === module MOM_regularize_layers ===
 

--- a/ocean_only/CVmix_SCM_tests/common_EPBL/MOM_input
+++ b/ocean_only/CVmix_SCM_tests/common_EPBL/MOM_input
@@ -266,6 +266,12 @@ KV = 0.0                        !   [m2 s-1]
 
 ! === module MOM_thickness_diffuse ===
 
+FIX_UNSPLIT_DT_VISC_BUG = False !   [Boolean] default = False
+                                ! If true, use the correct timestep in the viscous terms applied in the first
+                                ! predictor step with the unsplit time stepping scheme, and in the calculation
+                                ! of the turbulent mixed layer properties for viscosity with unsplit or
+                                ! unsplit_RK2. The default should be true.
+
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===

--- a/ocean_only/CVmix_SCM_tests/common_KPP/MOM_input
+++ b/ocean_only/CVmix_SCM_tests/common_KPP/MOM_input
@@ -266,6 +266,12 @@ KV = 0.0                        !   [m2 s-1]
 
 ! === module MOM_thickness_diffuse ===
 
+FIX_UNSPLIT_DT_VISC_BUG = False !   [Boolean] default = False
+                                ! If true, use the correct timestep in the viscous terms applied in the first
+                                ! predictor step with the unsplit time stepping scheme, and in the calculation
+                                ! of the turbulent mixed layer properties for viscosity with unsplit or
+                                ! unsplit_RK2. The default should be true.
+
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===

--- a/ocean_only/SCM_idealized_hurricane/MOM_input
+++ b/ocean_only/SCM_idealized_hurricane/MOM_input
@@ -269,6 +269,12 @@ KV = 1.0E-04                    !   [m2 s-1]
 
 ! === module MOM_thickness_diffuse ===
 
+FIX_UNSPLIT_DT_VISC_BUG = False !   [Boolean] default = False
+                                ! If true, use the correct timestep in the viscous terms applied in the first
+                                ! predictor step with the unsplit time stepping scheme, and in the calculation
+                                ! of the turbulent mixed layer properties for viscosity with unsplit or
+                                ! unsplit_RK2. The default should be true.
+
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===

--- a/ocean_only/lock_exchange/MOM_input
+++ b/ocean_only/lock_exchange/MOM_input
@@ -46,6 +46,8 @@ C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
                                 ! The heat capacity of sea water, approximated as a constant. This is only used
                                 ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
                                 ! definition of conservative temperature.
+DEFAULT_2018_ANSWERS = True     !   [Boolean] default = True
+                                ! This sets the default value for the various _2018_ANSWERS parameters.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
                                 ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "GOLD_IC"      ! default = "MOM_IC"

--- a/ocean_only/single_column/BML/MOM_input
+++ b/ocean_only/single_column/BML/MOM_input
@@ -204,6 +204,12 @@ KV = 1.0E-04                    !   [m2 s-1]
 
 ! === module MOM_thickness_diffuse ===
 
+FIX_UNSPLIT_DT_VISC_BUG = False !   [Boolean] default = False
+                                ! If true, use the correct timestep in the viscous terms applied in the first
+                                ! predictor step with the unsplit time stepping scheme, and in the calculation
+                                ! of the turbulent mixed layer properties for viscosity with unsplit or
+                                ! unsplit_RK2. The default should be true.
+
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===

--- a/ocean_only/single_column/EPBL/MOM_input
+++ b/ocean_only/single_column/EPBL/MOM_input
@@ -235,6 +235,12 @@ KV = 1.0E-04                    !   [m2 s-1]
 
 ! === module MOM_thickness_diffuse ===
 
+FIX_UNSPLIT_DT_VISC_BUG = False !   [Boolean] default = False
+                                ! If true, use the correct timestep in the viscous terms applied in the first
+                                ! predictor step with the unsplit time stepping scheme, and in the calculation
+                                ! of the turbulent mixed layer properties for viscosity with unsplit or
+                                ! unsplit_RK2. The default should be true.
+
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===

--- a/ocean_only/single_column/KPP/MOM_input
+++ b/ocean_only/single_column/KPP/MOM_input
@@ -235,6 +235,12 @@ KV = 1.0E-04                    !   [m2 s-1]
 
 ! === module MOM_thickness_diffuse ===
 
+FIX_UNSPLIT_DT_VISC_BUG = False !   [Boolean] default = False
+                                ! If true, use the correct timestep in the viscous terms applied in the first
+                                ! predictor step with the unsplit time stepping scheme, and in the calculation
+                                ! of the turbulent mixed layer properties for viscosity with unsplit or
+                                ! unsplit_RK2. The default should be true.
+
 ! === module MOM_continuity ===
 
 ! === module MOM_continuity_PPM ===


### PR DESCRIPTION
  Explicitly set several parameters to their current default values in SIS_input
and MOM_input files, so that answers in the MOM6-examples test suite will not
change when the defaults of these parameters are changed in the MOM6 code.  The
parameters that are set in several files include USE_TRIPOLAR_GEOLONB_BUG,
GRID_ROTATION_ANGLE_BUGS, FIX_UNSPLIT_DT_VISC_BUG and BULKML_CONV_MOMENTUM_BUG.
DEFAULT_2018_ANSWERS is set to true for lock_exchange/MOM_input.  All answers
are bitwise identical.