### PR TITLE
Update MOM_parameter_files for less-tested cases

### DIFF
--- a/ocean_only/ISOMIP/layer/MOM_input
+++ b/ocean_only/ISOMIP/layer/MOM_input
@@ -42,10 +42,8 @@ SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
                                 ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "ISOMIP_IC"    ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
-ICE_THICKNESS_FILE = "Ocean1_3D.nc" !
-                                ! The file from which the ice bathymetry and area are read.
-ICE_AREA_VARNAME = "area"       !
-                                ! The name of the area variable in ICE_THICKNESS_FILE.
+ICE_SHELF = True                !   [Boolean] default = False
+                                ! If true, enables the ice shelf model.
 
 ! === module MOM_fixed_initialization ===
 INPUTDIR = "INPUT"              ! default = "."
@@ -171,6 +169,45 @@ LIGHTEST_DENSITY = 1027.1524    !   [kg m-3] default = 1027.0
 DENSITY_RANGE = 0.7438856       !   [kg m-3] default = 2.0
                                 ! The range of reference potential densities across all interfaces.
 
+! === module MOM_domains min_halo ===
+
+! === module MOM_grid_init ===
+
+! === module ISOMIP_initialize_topography ===
+
+! === module MOM_ice_shelf ===
+SHELF_THREE_EQN = False         !   [Boolean] default = True
+                                ! If true, use the three equation expression of consistency to calculate the
+                                ! fluxes at the ice-ocean interface.
+SHELF_2EQ_GAMMA_T = 1.0E-04     !   [m s-1]
+                                ! If SHELF_THREE_EQN is false, this the fixed turbulent exchange velocity at the
+                                ! ice-ocean interface.
+ICE_SHELF_FLUX_FACTOR = 0.0     !   [none] default = 1.0
+                                ! Non-dimensional factor applied to shelf thermodynamic fluxes.
+ICE_SHELF_TEMPERATURE = -20.0   !   [degC] default = -15.0
+                                ! The temperature at the center of the ice shelf.
+DT_FORCING = 300.0              !   [s] default = 0.0
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
+COL_THICK_MELT_THRESHOLD = 1.0  !   [m] default = 0.0
+                                ! The minimum ocean column thickness where melting is allowed.
+
+! === module MOM_EOS ===
+USTAR_SHELF_BG = 0.001          !   [m s-1] default = 0.0
+                                ! The minimum value of ustar under ice shelves.
+CDRAG_SHELF = 0.0025            !   [nondim] default = 0.003
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the surface stress.
+ICE_PROFILE_CONFIG = "FILE"     !
+                                ! This specifies how the initial ice profile is specified. Valid values are:
+                                ! CHANNEL, FILE, and USER.
+ICE_THICKNESS_FILE = "Ocean1_3D.nc" ! default = "ice_shelf_h.nc"
+                                ! The file from which the ice bathymetry and area are read.
+ICE_THICKNESS_VARNAME = "thick" ! default = "h_shelf"
+                                ! The name of the thickness variable in ICE_THICKNESS_FILE.
+ICE_AREA_VARNAME = "area"       ! default = "area_shelf_h"
+                                ! The name of the area variable in ICE_THICKNESS_FILE.
+
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "ISOMIP"     ! default = "uniform"
                                 ! A string that determines how the initial layer thicknesses are specified for a
@@ -250,7 +287,8 @@ HBBL = 10.0                     !   [m]
                                 ! LINEAR_DRAG is not.
 BBL_USE_EOS = True              !   [Boolean] default = False
                                 ! If true, use the equation of state in determining the properties of the bottom
-                                ! boundary layer.  Otherwise use the layer target potential densities.
+                                ! boundary layer.  Otherwise use the layer target potential densities.  The
+                                ! default of this is determined by USE_REGRIDDING.
 BBL_THICK_MIN = 2.0             !   [m] default = 0.0
                                 ! The minimum bottom boundary layer thickness that can be used with
                                 ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
@@ -404,43 +442,6 @@ BUOY_CONFIG = "NONE"            ! default = "zero"
                                 ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 GUST_CONST = 0.02               !   [Pa] default = 0.0
                                 ! The background gustiness in the winds.
-ICE_SHELF = True                !   [Boolean] default = False
-                                ! If true, enables the ice shelf model.
-
-! === module MOM_domains min_halo ===
-
-! === module MOM_grid_init ===
-
-! === module MOM_ice_shelf ===
-SHELF_THREE_EQN = False         !   [Boolean] default = True
-                                ! If true, use the three equation expression of consistency to calculate the
-                                ! fluxes at the ice-ocean interface.
-SHELF_2EQ_GAMMA_T = 1.0E-04     !   [m s-1]
-                                ! If SHELF_THREE_EQN is false, this the fixed turbulent exchange velocity at the
-                                ! ice-ocean interface.
-ICE_SHELF_FLUX_FACTOR = 0.0     !   [none] default = 1.0
-                                ! Non-dimensional factor applied to shelf thermodynamic fluxes.
-ICE_SHELF_TEMPERATURE = -20.0   !   [degC] default = -15.0
-                                ! The temperature at the center of the ice shelf.
-DT_FORCING = 300.0              !   [s] default = 0.0
-                                ! The time step for changing forcing, coupling with other components, or
-                                ! potentially writing certain diagnostics. The default value is given by DT.
-COL_THICK_MELT_THRESHOLD = 1.0  !   [m] default = 0.0
-                                ! The minimum ocean column thickness where melting is allowed.
-
-! === module MOM_EOS ===
-USTAR_SHELF_BG = 0.001          !   [m s-1] default = 0.0
-                                ! The minimum value of ustar under ice shelves.
-CDRAG_SHELF = 0.0025            !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
-                                ! the surface stress.
-
-! === module ISOMIP_initialize_topography ===
-ICE_PROFILE_CONFIG = "FILE"     !
-                                ! This specifies how the initial ice profile is specified. Valid values are:
-                                ! CHANNEL, FILE, and USER.
-ICE_THICKNESS_VARNAME = "thick" ! default = "h_shelf"
-                                ! The name of the thickness variable in ICE_THICKNESS_FILE.
 
 ! === module MOM_main (MOM_driver) ===
 DAYMAX = 10.0                   !   [days]

--- a/ocean_only/ISOMIP/layer/MOM_parameter_doc.all
+++ b/ocean_only/ISOMIP/layer/MOM_parameter_doc.all
@@ -124,10 +124,8 @@ WRITE_GEOM = 1                  ! default = 1
                                 ! If =0, never write the geometry and vertical grid files. If =1, write the
                                 ! geometry and vertical grid files only for a new simulation. If =2, always
                                 ! write the geometry and vertical grid files. Other values are invalid.
-ICE_THICKNESS_FILE = "Ocean1_3D.nc" !
-                                ! The file from which the ice bathymetry and area are read.
-ICE_AREA_VARNAME = "area"       !
-                                ! The name of the area variable in ICE_THICKNESS_FILE.
+ICE_SHELF = True                !   [Boolean] default = False
+                                ! If true, enables the ice shelf model.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
                                 ! If False, The model is being run in serial mode as a single realization. If
                                 ! True, The current model realization is part of a larger ensemble and at the
@@ -374,6 +372,108 @@ GFS = 9.8                       !   [m s-2] default = 9.8
 REFERENCE_HEIGHT = 0.0          !   [m] default = 0.0
                                 ! A reference value for geometric height fields, such as bathyT.
 
+! === module MOM_domains min_halo ===
+
+! === module MOM_grid ===
+! Parameters providing information about the lateral grid.
+
+! === module MOM_hor_index ===
+! Sets the horizontal array index types.
+
+! === module MOM_grid_init ===
+
+! === module ISOMIP_initialize_topography ===
+MOM_ICESHELF_AVAILABLE_DIAGS_FILE = "MOM_IceShelf.available_diags" ! default = "MOM_IceShelf.available_diags"
+                                ! A file into which to write a list of all available ice shelf diagnostics that
+                                ! can be included in a diag_table.
+
+! === module MOM_ice_shelf ===
+DEBUG_IS = False                !   [Boolean] default = False
+                                ! If true, write verbose debugging messages for the ice shelf.
+DYNAMIC_SHELF_MASS = False      !   [Boolean] default = False
+                                ! If true, the ice sheet mass can evolve with time.
+SHELF_THERMO = False            !   [Boolean] default = False
+                                ! If true, use a thermodynamically interactive ice shelf.
+LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
+                                ! The latent heat of fusion.
+SHELF_THREE_EQN = False         !   [Boolean] default = True
+                                ! If true, use the three equation expression of consistency to calculate the
+                                ! fluxes at the ice-ocean interface.
+SHELF_INSULATOR = False         !   [Boolean] default = False
+                                ! If true, the ice shelf is a perfect insulatior (no conduction).
+MELTING_CUTOFF_DEPTH = 0.0      !   [m] default = 0.0
+                                ! Depth above which the melt is set to zero (it must be >= 0) Default value
+                                ! won't affect the solution.
+CONST_SEA_LEVEL = False         !   [Boolean] default = False
+                                ! If true, apply evaporative, heat and salt fluxes in the sponge region. This
+                                ! will avoid a large increase in sea level. This option is needed for some of
+                                ! the ISOMIP+ experiments (Ocean3 and Ocean4). IMPORTANT: it is not currently
+                                ! possible to do prefect restarts using this flag.
+SHELF_3EQ_GAMMA = False         !   [Boolean] default = False
+                                ! If true, user specifies a constant nondimensional heat-transfer coefficient
+                                ! (GAMMA_T_3EQ), from which the default salt-transfer coefficient is set as
+                                ! GAMMA_T_3EQ/35. This is used with SHELF_THREE_EQN.
+SHELF_2EQ_GAMMA_T = 1.0E-04     !   [m s-1]
+                                ! If SHELF_THREE_EQN is false, this the fixed turbulent exchange velocity at the
+                                ! ice-ocean interface.
+ICE_SHELF_MASS_FROM_FILE = False !   [Boolean] default = False
+                                ! Read the mass of the ice shelf (every time step) from a file.
+C_P_ICE = 2100.0                !   [J kg-1 K-1] default = 2100.0
+                                ! The heat capacity of ice.
+ICE_SHELF_FLUX_FACTOR = 0.0     !   [none] default = 1.0
+                                ! Non-dimensional factor applied to shelf thermodynamic fluxes.
+KV_ICE = 1.0E+10                !   [m2 s-1] default = 1.0E+10
+                                ! The viscosity of the ice.
+KV_MOLECULAR = 1.95E-06         !   [m2 s-1] default = 1.95E-06
+                                ! The molecular kinimatic viscosity of sea water at the freezing temperature.
+ICE_SHELF_SALINITY = 0.0        !   [psu] default = 0.0
+                                ! The salinity of the ice inside the ice shelf.
+ICE_SHELF_TEMPERATURE = -20.0   !   [degC] default = -15.0
+                                ! The temperature at the center of the ice shelf.
+KD_SALT_MOLECULAR = 8.02E-10    !   [m2 s-1] default = 8.02E-10
+                                ! The molecular diffusivity of salt in sea water at the freezing point.
+KD_TEMP_MOLECULAR = 1.41E-07    !   [m2 s-1] default = 1.41E-07
+                                ! The molecular diffusivity of heat in sea water at the freezing point.
+DT_FORCING = 300.0              !   [s] default = 0.0
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
+COL_THICK_MELT_THRESHOLD = 1.0  !   [m] default = 0.0
+                                ! The minimum ocean column thickness where melting is allowed.
+READ_TIDEAMP = False            !   [Boolean] default = False
+                                ! If true, read a file (given by TIDEAMP_FILE) containing the tidal amplitude
+                                ! with INT_TIDE_DISSIPATION.
+UTIDE = 0.0                     !   [m s-1] default = 0.0
+                                ! The constant tidal amplitude used with INT_TIDE_DISSIPATION.
+
+! === module MOM_EOS ===
+DENSITY_ICE = 900.0             !   [kg m-3] default = 900.0
+                                ! A typical density of ice.
+MIN_THICKNESS_SIMPLE_CALVE = 0.0 !   [m] default = 0.0
+                                ! Min thickness rule for the very simple calving law
+USTAR_SHELF_BG = 0.001          !   [m s-1] default = 0.0
+                                ! The minimum value of ustar under ice shelves.
+CDRAG_SHELF = 0.0025            !   [nondim] default = 0.003
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the surface stress.
+USTAR_SHELF_FROM_VEL = True     !   [Boolean] default = True
+                                ! If true, use the surface velocities to set the friction velocity under ice
+                                ! shelves instead of using the previous values of the stresses.
+ICE_PROFILE_CONFIG = "FILE"     !
+                                ! This specifies how the initial ice profile is specified. Valid values are:
+                                ! CHANNEL, FILE, and USER.
+ICE_THICKNESS_FILE = "Ocean1_3D.nc" ! default = "ice_shelf_h.nc"
+                                ! The file from which the bathymetry is read.
+LEN_SIDE_STRESS = 0.0           !   [axis_units] default = 0.0
+                                ! position past which shelf sides are stress free.
+ICE_THICKNESS_VARNAME = "thick" ! default = "h_shelf"
+                                ! The name of the thickness variable in ICE_THICKNESS_FILE.
+ICE_AREA_VARNAME = "area"       ! default = "area_shelf_h"
+                                ! The name of the area variable in ICE_THICKNESS_FILE.
+
+! === module MOM_restart ===
+SHELF_IC_OUTPUT_FILE = "MOM_Shelf_IC" ! default = "MOM_Shelf_IC"
+                                ! The name-root of the output file for the ice shelf initial conditions.
+
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
                                 ! If true, initialize the layer thicknesses, temperatures, and salinities from a
@@ -485,6 +585,8 @@ REMAPPING_2018_ANSWERS = False  !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use updated and more robust forms of the
                                 ! same expressions.
+USE_GRID_SPACE_DIAGNOSTIC_AXES = False !   [Boolean] default = False
+                                ! If true, use a grid index coordinate convention for diagnostic axes.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
                                 ! A list of string tuples associating diag_table modules to a coordinate
                                 ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
@@ -577,9 +679,6 @@ CHANNEL_DRAG = False            !   [Boolean] default = False
 LINEAR_DRAG = False             !   [Boolean] default = False
                                 ! If LINEAR_DRAG and BOTTOMDRAGLAW are defined the drag law is
                                 ! cdrag*DRAG_BG_VEL*u.
-DOUBLE_DIFFUSION = False        !   [Boolean] default = False
-                                ! If true, increase diffusivites for temperature or salt based on
-                                ! double-diffusive parameterization from MOM4/KPP.
 PRANDTL_TURB = 1.0              !   [nondim] default = 1.0
                                 ! The turbulent Prandtl number applied to shear instability.
 DYNAMIC_VISCOUS_ML = False      !   [Boolean] default = False
@@ -606,7 +705,8 @@ DRAG_BG_VEL = 0.0               !   [m s-1] default = 0.0
                                 ! defined.
 BBL_USE_EOS = True              !   [Boolean] default = False
                                 ! If true, use the equation of state in determining the properties of the bottom
-                                ! boundary layer.  Otherwise use the layer target potential densities.
+                                ! boundary layer.  Otherwise use the layer target potential densities.  The
+                                ! default of this is determined by USE_REGRIDDING.
 BBL_THICK_MIN = 2.0             !   [m] default = 0.0
                                 ! The minimum bottom boundary layer thickness that can be used with
                                 ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
@@ -625,6 +725,9 @@ KV_BBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the bottom boundary layer.
 KV_TBL_MIN = 0.01               !   [m2 s-1] default = 1.0E-04
                                 ! The minimum viscosities in the top boundary layer.
+CORRECT_BBL_BOUNDS = False      !   [Boolean] default = False
+                                ! If true, uses the correct bounds on the BBL thickness and viscosity so that
+                                ! the bottom layer feels the intended drag.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 0.0                      !   [m2 s-1] default = 0.0
@@ -866,6 +969,9 @@ BOUND_AH = True                 !   [Boolean] default = True
 BETTER_BOUND_AH = True          !   [Boolean] default = True
                                 ! If true, the biharmonic coefficient is locally limited to be stable with a
                                 ! better bounding than just BOUND_AH.
+RE_AH = 0.0                     !   [nondim] default = 0.0
+                                ! If nonzero, the biharmonic coefficient is scaled so that the biharmonic
+                                ! Reynolds number is equal to this.
 SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
                                 ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 BOUND_CORIOLIS_BIHARM = True    !   [Boolean] default = True
@@ -1117,6 +1223,9 @@ EVAP_CFL_LIMIT = 0.8            !   [nondim] default = 0.8
                                 ! The largest fraction of a layer than can be lost to forcing (e.g. evaporation,
                                 ! sea-ice formation) in one time-step. The unused mass loss is passed down
                                 ! through the column.
+MLD_EN_VALS = 3*0.0             !   [J/m2] default = 0.0
+                                ! The energy values used to compute MLDs.  If not set (or all set to 0.), the
+                                ! default will overwrite to 25., 2500., 250000.
 DIAG_MLD_DENSITY_DIFF = 0.1     !   [kg/m3] default = 0.1
                                 ! The density difference used to determine a diagnostic mixed layer depth,
                                 ! MLD_user, following the definition of Levitus 1982. The MLD is the depth at
@@ -1131,14 +1240,6 @@ DIAG_DEPTH_SUBML_N2 = 50.0      !   [m] default = 50.0
 USE_KPP = False                 !   [Boolean] default = False
                                 ! If true, turns on the [CVMix] KPP scheme of Large et al., 1994, to calculate
                                 ! diffusivities and non-local transport in the OBL.
-
-! === module MOM_tidal_mixing ===
-! Vertical Tidal Mixing Parameterization
-USE_CVMix_TIDAL = False         !   [Boolean] default = False
-                                ! If true, turns on tidal mixing via CVMix
-INT_TIDE_DISSIPATION = False    !   [Boolean] default = False
-                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
-                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 
 ! === module MOM_CVMix_conv ===
 ! Parameterization of enhanced mixing due to convection via CVMix
@@ -1163,6 +1264,14 @@ SET_DIFF_2018_ANSWERS = False   !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use updated and more robust forms of the
                                 ! same expressions.
+
+! === module MOM_tidal_mixing ===
+! Vertical Tidal Mixing Parameterization
+USE_CVMix_TIDAL = False         !   [Boolean] default = False
+                                ! If true, turns on tidal mixing via CVMix
+INT_TIDE_DISSIPATION = False    !   [Boolean] default = False
+                                ! If true, use an internal tidal dissipation scheme to drive diapycnal mixing,
+                                ! along the lines of St. Laurent et al. (2002) and Simmons et al. (2004).
 ML_RADIATION = False            !   [Boolean] default = False
                                 ! If true, allow a fraction of TKE available from wind work to penetrate below
                                 ! the base of the mixed layer with a vertical decay scale determined by the
@@ -1235,6 +1344,9 @@ DISSIPATION_N1 = 0.0            !   [J m-3] default = 0.0
                                 ! = A + B*N
 DISSIPATION_KD_MIN = 0.0        !   [m2 s-1] default = 0.0
                                 ! The minimum vertical diffusivity applied as a floor.
+DOUBLE_DIFFUSION = False        !   [Boolean] default = False
+                                ! If true, increase diffusivites for temperature or salinity based on the
+                                ! double-diffusive parameterization described in Large et al. (1994).
 
 ! === module MOM_kappa_shear ===
 ! Parameterization of shear-driven turbulence following Jackson, Hallberg and Legg, JPO 2008
@@ -1410,8 +1522,6 @@ WIND_CONFIG = "zero"            ! default = "zero"
 RESTOREBUOY = False             !   [Boolean] default = False
                                 ! If true, the buoyancy fluxes drive the model back toward some specified
                                 ! surface state with a rate given by FLUXCONST.
-LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
-                                ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
                                 ! The latent heat of fusion.
 GUST_CONST = 0.02               !   [Pa] default = 0.0
@@ -1423,98 +1533,6 @@ READ_GUST_2D = False            !   [Boolean] default = False
                                 ! If true, use a 2-dimensional gustiness supplied from an input file
 
 ! === module MOM_restart ===
-ICE_SHELF = True                !   [Boolean] default = False
-                                ! If true, enables the ice shelf model.
-
-! === module MOM_domains min_halo ===
-
-! === module MOM_grid ===
-! Parameters providing information about the lateral grid.
-
-! === module MOM_hor_index ===
-! Sets the horizontal array index types.
-
-! === module MOM_grid_init ===
-
-! === module MOM_ice_shelf ===
-DEBUG_IS = False                !   [Boolean] default = False
-                                ! If true, write verbose debugging messages for the ice shelf.
-DYNAMIC_SHELF_MASS = False      !   [Boolean] default = False
-                                ! If true, the ice sheet mass can evolve with time.
-SHELF_THERMO = False            !   [Boolean] default = False
-                                ! If true, use a thermodynamically interactive ice shelf.
-SHELF_THREE_EQN = False         !   [Boolean] default = True
-                                ! If true, use the three equation expression of consistency to calculate the
-                                ! fluxes at the ice-ocean interface.
-SHELF_INSULATOR = False         !   [Boolean] default = False
-                                ! If true, the ice shelf is a perfect insulatior (no conduction).
-MELTING_CUTOFF_DEPTH = 0.0      !   [m] default = 0.0
-                                ! Depth above which the melt is set to zero (it must be >= 0) Default value
-                                ! won't affect the solution.
-CONST_SEA_LEVEL = False         !   [Boolean] default = False
-                                ! If true, apply evaporative, heat and salt fluxes in the sponge region. This
-                                ! will avoid a large increase in sea level. This option is needed for some of
-                                ! the ISOMIP+ experiments (Ocean3 and Ocean4). IMPORTANT: it is not currently
-                                ! possible to do prefect restarts using this flag.
-SHELF_3EQ_GAMMA = False         !   [Boolean] default = False
-                                ! If true, user specifies a constant nondimensional heat-transfer coefficient
-                                ! (GAMMA_T_3EQ), from which the default salt-transfer coefficient is set as
-                                ! GAMMA_T_3EQ/35. This is used with SHELF_THREE_EQN.
-SHELF_2EQ_GAMMA_T = 1.0E-04     !   [m s-1]
-                                ! If SHELF_THREE_EQN is false, this the fixed turbulent exchange velocity at the
-                                ! ice-ocean interface.
-ICE_SHELF_MASS_FROM_FILE = False !   [Boolean] default = False
-                                ! Read the mass of the ice shelf (every time step) from a file.
-C_P_ICE = 2100.0                !   [J kg-1 K-1] default = 2100.0
-                                ! The heat capacity of ice.
-ICE_SHELF_FLUX_FACTOR = 0.0     !   [none] default = 1.0
-                                ! Non-dimensional factor applied to shelf thermodynamic fluxes.
-KV_ICE = 1.0E+10                !   [m2 s-1] default = 1.0E+10
-                                ! The viscosity of the ice.
-KV_MOLECULAR = 1.95E-06         !   [m2 s-1] default = 1.95E-06
-                                ! The molecular kinimatic viscosity of sea water at the freezing temperature.
-ICE_SHELF_SALINITY = 0.0        !   [psu] default = 0.0
-                                ! The salinity of the ice inside the ice shelf.
-ICE_SHELF_TEMPERATURE = -20.0   !   [degC] default = -15.0
-                                ! The temperature at the center of the ice shelf.
-KD_SALT_MOLECULAR = 8.02E-10    !   [m2 s-1] default = 8.02E-10
-                                ! The molecular diffusivity of salt in sea water at the freezing point.
-KD_TEMP_MOLECULAR = 1.41E-07    !   [m2 s-1] default = 1.41E-07
-                                ! The molecular diffusivity of heat in sea water at the freezing point.
-DT_FORCING = 300.0              !   [s] default = 0.0
-                                ! The time step for changing forcing, coupling with other components, or
-                                ! potentially writing certain diagnostics. The default value is given by DT.
-COL_THICK_MELT_THRESHOLD = 1.0  !   [m] default = 0.0
-                                ! The minimum ocean column thickness where melting is allowed.
-READ_TIDEAMP = False            !   [Boolean] default = False
-                                ! If true, read a file (given by TIDEAMP_FILE) containing the tidal amplitude
-                                ! with INT_TIDE_DISSIPATION.
-UTIDE = 0.0                     !   [m s-1] default = 0.0
-                                ! The constant tidal amplitude used with INT_TIDE_DISSIPATION.
-
-! === module MOM_EOS ===
-DENSITY_ICE = 900.0             !   [kg m-3] default = 900.0
-                                ! A typical density of ice.
-MIN_THICKNESS_SIMPLE_CALVE = 0.0 !   [m] default = 0.0
-                                ! Min thickness rule for the very simple calving law
-USTAR_SHELF_BG = 0.001          !   [m s-1] default = 0.0
-                                ! The minimum value of ustar under ice shelves.
-CDRAG_SHELF = 0.0025            !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
-                                ! the surface stress.
-
-! === module ISOMIP_initialize_topography ===
-
-! === module MOM_restart ===
-ICE_PROFILE_CONFIG = "FILE"     !
-                                ! This specifies how the initial ice profile is specified. Valid values are:
-                                ! CHANNEL, FILE, and USER.
-LEN_SIDE_STRESS = 0.0           !   [axis_units] default = 0.0
-                                ! position past which shelf sides are stress free.
-ICE_THICKNESS_VARNAME = "thick" ! default = "h_shelf"
-                                ! The name of the thickness variable in ICE_THICKNESS_FILE.
-SHELF_IC_OUTPUT_FILE = "MOM_Shelf_IC" ! default = "MOM_Shelf_IC"
-                                ! The name-root of the output file for the ice shelf initial conditions.
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04

--- a/ocean_only/ISOMIP/layer/MOM_parameter_doc.short
+++ b/ocean_only/ISOMIP/layer/MOM_parameter_doc.short
@@ -23,10 +23,8 @@ SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
                                 ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "ISOMIP_IC"    ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
-ICE_THICKNESS_FILE = "Ocean1_3D.nc" !
-                                ! The file from which the ice bathymetry and area are read.
-ICE_AREA_VARNAME = "area"       !
-                                ! The name of the area variable in ICE_THICKNESS_FILE.
+ICE_SHELF = True                !   [Boolean] default = False
+                                ! If true, enables the ice shelf model.
 
 ! === module MOM_domains ===
 REENTRANT_X = False             !   [Boolean] default = True
@@ -161,6 +159,45 @@ LIGHTEST_DENSITY = 1027.1524    !   [kg m-3] default = 1027.0
                                 ! The reference potential density used for the surface interface.
 DENSITY_RANGE = 0.7438856       !   [kg m-3] default = 2.0
                                 ! The range of reference potential densities across all interfaces.
+
+! === module MOM_domains min_halo ===
+
+! === module MOM_grid_init ===
+
+! === module ISOMIP_initialize_topography ===
+
+! === module MOM_ice_shelf ===
+SHELF_THREE_EQN = False         !   [Boolean] default = True
+                                ! If true, use the three equation expression of consistency to calculate the
+                                ! fluxes at the ice-ocean interface.
+SHELF_2EQ_GAMMA_T = 1.0E-04     !   [m s-1]
+                                ! If SHELF_THREE_EQN is false, this the fixed turbulent exchange velocity at the
+                                ! ice-ocean interface.
+ICE_SHELF_FLUX_FACTOR = 0.0     !   [none] default = 1.0
+                                ! Non-dimensional factor applied to shelf thermodynamic fluxes.
+ICE_SHELF_TEMPERATURE = -20.0   !   [degC] default = -15.0
+                                ! The temperature at the center of the ice shelf.
+DT_FORCING = 300.0              !   [s] default = 0.0
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
+COL_THICK_MELT_THRESHOLD = 1.0  !   [m] default = 0.0
+                                ! The minimum ocean column thickness where melting is allowed.
+
+! === module MOM_EOS ===
+USTAR_SHELF_BG = 0.001          !   [m s-1] default = 0.0
+                                ! The minimum value of ustar under ice shelves.
+CDRAG_SHELF = 0.0025            !   [nondim] default = 0.003
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the surface stress.
+ICE_PROFILE_CONFIG = "FILE"     !
+                                ! This specifies how the initial ice profile is specified. Valid values are:
+                                ! CHANNEL, FILE, and USER.
+ICE_THICKNESS_FILE = "Ocean1_3D.nc" ! default = "ice_shelf_h.nc"
+                                ! The file from which the bathymetry is read.
+ICE_THICKNESS_VARNAME = "thick" ! default = "h_shelf"
+                                ! The name of the thickness variable in ICE_THICKNESS_FILE.
+ICE_AREA_VARNAME = "area"       ! default = "area_shelf_h"
+                                ! The name of the area variable in ICE_THICKNESS_FILE.
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "ISOMIP"     ! default = "uniform"
@@ -396,43 +433,6 @@ BUOY_CONFIG = "NONE"            ! default = "zero"
                                 ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 GUST_CONST = 0.02               !   [Pa] default = 0.0
                                 ! The background gustiness in the winds.
-ICE_SHELF = True                !   [Boolean] default = False
-                                ! If true, enables the ice shelf model.
-
-! === module MOM_domains min_halo ===
-
-! === module MOM_grid_init ===
-
-! === module MOM_ice_shelf ===
-SHELF_THREE_EQN = False         !   [Boolean] default = True
-                                ! If true, use the three equation expression of consistency to calculate the
-                                ! fluxes at the ice-ocean interface.
-SHELF_2EQ_GAMMA_T = 1.0E-04     !   [m s-1]
-                                ! If SHELF_THREE_EQN is false, this the fixed turbulent exchange velocity at the
-                                ! ice-ocean interface.
-ICE_SHELF_FLUX_FACTOR = 0.0     !   [none] default = 1.0
-                                ! Non-dimensional factor applied to shelf thermodynamic fluxes.
-ICE_SHELF_TEMPERATURE = -20.0   !   [degC] default = -15.0
-                                ! The temperature at the center of the ice shelf.
-DT_FORCING = 300.0              !   [s] default = 0.0
-                                ! The time step for changing forcing, coupling with other components, or
-                                ! potentially writing certain diagnostics. The default value is given by DT.
-COL_THICK_MELT_THRESHOLD = 1.0  !   [m] default = 0.0
-                                ! The minimum ocean column thickness where melting is allowed.
-
-! === module MOM_EOS ===
-USTAR_SHELF_BG = 0.001          !   [m s-1] default = 0.0
-                                ! The minimum value of ustar under ice shelves.
-CDRAG_SHELF = 0.0025            !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
-                                ! the surface stress.
-
-! === module ISOMIP_initialize_topography ===
-ICE_PROFILE_CONFIG = "FILE"     !
-                                ! This specifies how the initial ice profile is specified. Valid values are:
-                                ! CHANNEL, FILE, and USER.
-ICE_THICKNESS_VARNAME = "thick" ! default = "h_shelf"
-                                ! The name of the thickness variable in ICE_THICKNESS_FILE.
 
 ! === module MOM_main (MOM_driver) ===
 DAYMAX = 10.0                   !   [days]

--- a/ocean_only/ISOMIP/rho/MOM_input
+++ b/ocean_only/ISOMIP/rho/MOM_input
@@ -40,10 +40,8 @@ SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
                                 ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "ISOMIP_IC"    ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
-ICE_THICKNESS_FILE = "Ocean1_3D.nc" !
-                                ! The file from which the ice bathymetry and area are read.
-ICE_AREA_VARNAME = "area"       !
-                                ! The name of the area variable in ICE_THICKNESS_FILE.
+ICE_SHELF = True                !   [Boolean] default = False
+                                ! If true, enables the ice shelf model.
 
 ! === module MOM_fixed_initialization ===
 INPUTDIR = "INPUT"              ! default = "."
@@ -219,10 +217,52 @@ REMAP_AFTER_INITIALIZATION = False !   [Boolean] default = True
                                 ! If true, applies regridding and remapping immediately after initialization so
                                 ! that the state is ALE consistent. This is a legacy step and should not be
                                 ! needed if the initialization is consistent with the coordinate mode.
+
 REGRID_USE_OLD_DIRECTION = False ! [Boolean] default = True
                                 ! If true, the regridding integrates upwards from the bottom for interface
                                 ! positions, much as the main model does. If false regridding integrates
                                 ! downward, consistant with the remapping code.
+
+! === module MOM_domains min_halo ===
+
+! === module MOM_grid_init ===
+
+! === module ISOMIP_initialize_topography ===
+
+! === module MOM_ice_shelf ===
+SHELF_THERMO = True             !   [Boolean] default = False
+                                ! If true, use a thermodynamically interactive ice shelf.
+SHELF_3EQ_GAMMA = True          !   [Boolean] default = False
+                                ! If true, user specifies a constant nondimensional heat-transfer coefficient
+                                ! (GAMMA_T_3EQ), from which the default salt-transfer coefficient is set as
+                                ! GAMMA_T_3EQ/35. This is used with SHELF_THREE_EQN.
+SHELF_S_ROOT = True             !   [Boolean] default = False
+                                ! If SHELF_S_ROOT = True, salinity at the ice/ocean interface (Sbdry) is
+                                ! computed from a quadratic equation. Otherwise, the previous interactive method
+                                ! to estimate Sbdry is used.
+ICE_SHELF_TEMPERATURE = -20.0   !   [degC] default = -15.0
+                                ! The temperature at the center of the ice shelf.
+DT_FORCING = 300.0              !   [s] default = 0.0
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
+COL_THICK_MELT_THRESHOLD = 1.0  !   [m] default = 0.0
+                                ! The minimum ocean column thickness where melting is allowed.
+
+! === module MOM_EOS ===
+USTAR_SHELF_BG = 0.001          !   [m s-1] default = 0.0
+                                ! The minimum value of ustar under ice shelves.
+CDRAG_SHELF = 0.0025            !   [nondim] default = 0.003
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the surface stress.
+ICE_PROFILE_CONFIG = "FILE"     !
+                                ! This specifies how the initial ice profile is specified. Valid values are:
+                                ! CHANNEL, FILE, and USER.
+ICE_THICKNESS_FILE = "Ocean1_3D.nc" ! default = "ice_shelf_h.nc"
+                                ! The file from which the ice bathymetry and area are read.
+ICE_THICKNESS_VARNAME = "thick" ! default = "h_shelf"
+                                ! The name of the thickness variable in ICE_THICKNESS_FILE.
+ICE_AREA_VARNAME = "area"       ! default = "area_shelf_h"
+                                ! The name of the area variable in ICE_THICKNESS_FILE.
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "ISOMIP"     ! default = "uniform"
@@ -294,9 +334,6 @@ HBBL = 10.0                     !   [m]
                                 ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
                                 ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
                                 ! LINEAR_DRAG is not.
-BBL_USE_EOS = True              !   [Boolean] default = False
-                                ! If true, use the equation of state in determining the properties of the bottom
-                                ! boundary layer.  Otherwise use the layer target potential densities.
 BBL_THICK_MIN = 2.0             !   [m] default = 0.0
                                 ! The minimum bottom boundary layer thickness that can be used with
                                 ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
@@ -460,45 +497,6 @@ WIND_CONFIG = "zero"            ! default = "zero"
                                 ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
 GUST_CONST = 0.02               !   [Pa] default = 0.0
                                 ! The background gustiness in the winds.
-ICE_SHELF = True                !   [Boolean] default = False
-                                ! If true, enables the ice shelf model.
-
-! === module MOM_domains min_halo ===
-
-! === module MOM_grid_init ===
-
-! === module MOM_ice_shelf ===
-SHELF_THERMO = True             !   [Boolean] default = False
-                                ! If true, use a thermodynamically interactive ice shelf.
-SHELF_3EQ_GAMMA = True          !   [Boolean] default = False
-                                ! If true, user specifies a constant nondimensional heat-transfer coefficient
-                                ! (GAMMA_T_3EQ), from which the default salt-transfer coefficient is set as
-                                ! GAMMA_T_3EQ/35. This is used with SHELF_THREE_EQN.
-SHELF_S_ROOT = True             !   [Boolean] default = False
-                                ! If SHELF_S_ROOT = True, salinity at the ice/ocean interface (Sbdry) is
-                                ! computed from a quadratic equation. Otherwise, the previous interactive method
-                                ! to estimate Sbdry is used.
-ICE_SHELF_TEMPERATURE = -20.0   !   [degC] default = -15.0
-                                ! The temperature at the center of the ice shelf.
-DT_FORCING = 300.0              !   [s] default = 0.0
-                                ! The time step for changing forcing, coupling with other components, or
-                                ! potentially writing certain diagnostics. The default value is given by DT.
-COL_THICK_MELT_THRESHOLD = 1.0  !   [m] default = 0.0
-                                ! The minimum ocean column thickness where melting is allowed.
-
-! === module MOM_EOS ===
-USTAR_SHELF_BG = 0.001          !   [m s-1] default = 0.0
-                                ! The minimum value of ustar under ice shelves.
-CDRAG_SHELF = 0.0025            !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
-                                ! the surface stress.
-
-! === module ISOMIP_initialize_topography ===
-ICE_PROFILE_CONFIG = "FILE"     !
-                                ! This specifies how the initial ice profile is specified. Valid values are:
-                                ! CHANNEL, FILE, and USER.
-ICE_THICKNESS_VARNAME = "thick" ! default = "h_shelf"
-                                ! The name of the thickness variable in ICE_THICKNESS_FILE.
 
 ! === module MOM_main (MOM_driver) ===
 DAYMAX = 10.0                   !   [days]

--- a/ocean_only/ISOMIP/rho/MOM_parameter_doc.all
+++ b/ocean_only/ISOMIP/rho/MOM_parameter_doc.all
@@ -124,10 +124,8 @@ WRITE_GEOM = 1                  ! default = 1
                                 ! If =0, never write the geometry and vertical grid files. If =1, write the
                                 ! geometry and vertical grid files only for a new simulation. If =2, always
                                 ! write the geometry and vertical grid files. Other values are invalid.
-ICE_THICKNESS_FILE = "Ocean1_3D.nc" !
-                                ! The file from which the ice bathymetry and area are read.
-ICE_AREA_VARNAME = "area"       !
-                                ! The name of the area variable in ICE_THICKNESS_FILE.
+ICE_SHELF = True                !   [Boolean] default = False
+                                ! If true, enables the ice shelf model.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
                                 ! If False, The model is being run in serial mode as a single realization. If
                                 ! True, The current model realization is part of a larger ensemble and at the
@@ -493,6 +491,113 @@ REGRID_FILTER_DEEP_DEPTH = 0.0  !   [m] default = 0.0
 ! Parameters providing information about the lateral grid.
 REFERENCE_HEIGHT = 0.0          !   [m] default = 0.0
                                 ! A reference value for geometric height fields, such as bathyT.
+
+! === module MOM_domains min_halo ===
+
+! === module MOM_grid ===
+! Parameters providing information about the lateral grid.
+
+! === module MOM_hor_index ===
+! Sets the horizontal array index types.
+
+! === module MOM_grid_init ===
+
+! === module ISOMIP_initialize_topography ===
+MOM_ICESHELF_AVAILABLE_DIAGS_FILE = "MOM_IceShelf.available_diags" ! default = "MOM_IceShelf.available_diags"
+                                ! A file into which to write a list of all available ice shelf diagnostics that
+                                ! can be included in a diag_table.
+
+! === module MOM_ice_shelf ===
+DEBUG_IS = False                !   [Boolean] default = False
+                                ! If true, write verbose debugging messages for the ice shelf.
+DYNAMIC_SHELF_MASS = False      !   [Boolean] default = False
+                                ! If true, the ice sheet mass can evolve with time.
+SHELF_THERMO = True             !   [Boolean] default = False
+                                ! If true, use a thermodynamically interactive ice shelf.
+LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
+                                ! The latent heat of fusion.
+SHELF_THREE_EQN = True          !   [Boolean] default = True
+                                ! If true, use the three equation expression of consistency to calculate the
+                                ! fluxes at the ice-ocean interface.
+SHELF_INSULATOR = False         !   [Boolean] default = False
+                                ! If true, the ice shelf is a perfect insulatior (no conduction).
+MELTING_CUTOFF_DEPTH = 0.0      !   [m] default = 0.0
+                                ! Depth above which the melt is set to zero (it must be >= 0) Default value
+                                ! won't affect the solution.
+CONST_SEA_LEVEL = False         !   [Boolean] default = False
+                                ! If true, apply evaporative, heat and salt fluxes in the sponge region. This
+                                ! will avoid a large increase in sea level. This option is needed for some of
+                                ! the ISOMIP+ experiments (Ocean3 and Ocean4). IMPORTANT: it is not currently
+                                ! possible to do prefect restarts using this flag.
+SHELF_3EQ_GAMMA = True          !   [Boolean] default = False
+                                ! If true, user specifies a constant nondimensional heat-transfer coefficient
+                                ! (GAMMA_T_3EQ), from which the default salt-transfer coefficient is set as
+                                ! GAMMA_T_3EQ/35. This is used with SHELF_THREE_EQN.
+SHELF_S_ROOT = True             !   [Boolean] default = False
+                                ! If SHELF_S_ROOT = True, salinity at the ice/ocean interface (Sbdry) is
+                                ! computed from a quadratic equation. Otherwise, the previous interactive method
+                                ! to estimate Sbdry is used.
+SHELF_3EQ_GAMMA_T = 0.022       !   [nondim] default = 0.022
+                                ! Nondimensional heat-transfer coefficient.
+SHELF_3EQ_GAMMA_S = 6.285714285714285E-04 !   [nondim] default = 6.285714285714285E-04
+                                ! Nondimensional salt-transfer coefficient.
+ICE_SHELF_MASS_FROM_FILE = False !   [Boolean] default = False
+                                ! Read the mass of the ice shelf (every time step) from a file.
+C_P_ICE = 2100.0                !   [J kg-1 K-1] default = 2100.0
+                                ! The heat capacity of ice.
+ICE_SHELF_FLUX_FACTOR = 1.0     !   [none] default = 1.0
+                                ! Non-dimensional factor applied to shelf thermodynamic fluxes.
+KV_ICE = 1.0E+10                !   [m2 s-1] default = 1.0E+10
+                                ! The viscosity of the ice.
+KV_MOLECULAR = 1.95E-06         !   [m2 s-1] default = 1.95E-06
+                                ! The molecular kinimatic viscosity of sea water at the freezing temperature.
+ICE_SHELF_SALINITY = 0.0        !   [psu] default = 0.0
+                                ! The salinity of the ice inside the ice shelf.
+ICE_SHELF_TEMPERATURE = -20.0   !   [degC] default = -15.0
+                                ! The temperature at the center of the ice shelf.
+KD_SALT_MOLECULAR = 8.02E-10    !   [m2 s-1] default = 8.02E-10
+                                ! The molecular diffusivity of salt in sea water at the freezing point.
+KD_TEMP_MOLECULAR = 1.41E-07    !   [m2 s-1] default = 1.41E-07
+                                ! The molecular diffusivity of heat in sea water at the freezing point.
+DT_FORCING = 300.0              !   [s] default = 0.0
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
+COL_THICK_MELT_THRESHOLD = 1.0  !   [m] default = 0.0
+                                ! The minimum ocean column thickness where melting is allowed.
+READ_TIDEAMP = False            !   [Boolean] default = False
+                                ! If true, read a file (given by TIDEAMP_FILE) containing the tidal amplitude
+                                ! with INT_TIDE_DISSIPATION.
+UTIDE = 0.0                     !   [m s-1] default = 0.0
+                                ! The constant tidal amplitude used with INT_TIDE_DISSIPATION.
+
+! === module MOM_EOS ===
+DENSITY_ICE = 900.0             !   [kg m-3] default = 900.0
+                                ! A typical density of ice.
+MIN_THICKNESS_SIMPLE_CALVE = 0.0 !   [m] default = 0.0
+                                ! Min thickness rule for the very simple calving law
+USTAR_SHELF_BG = 0.001          !   [m s-1] default = 0.0
+                                ! The minimum value of ustar under ice shelves.
+CDRAG_SHELF = 0.0025            !   [nondim] default = 0.003
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the surface stress.
+USTAR_SHELF_FROM_VEL = True     !   [Boolean] default = True
+                                ! If true, use the surface velocities to set the friction velocity under ice
+                                ! shelves instead of using the previous values of the stresses.
+ICE_PROFILE_CONFIG = "FILE"     !
+                                ! This specifies how the initial ice profile is specified. Valid values are:
+                                ! CHANNEL, FILE, and USER.
+ICE_THICKNESS_FILE = "Ocean1_3D.nc" ! default = "ice_shelf_h.nc"
+                                ! The file from which the bathymetry is read.
+LEN_SIDE_STRESS = 0.0           !   [axis_units] default = 0.0
+                                ! position past which shelf sides are stress free.
+ICE_THICKNESS_VARNAME = "thick" ! default = "h_shelf"
+                                ! The name of the thickness variable in ICE_THICKNESS_FILE.
+ICE_AREA_VARNAME = "area"       ! default = "area_shelf_h"
+                                ! The name of the area variable in ICE_THICKNESS_FILE.
+
+! === module MOM_restart ===
+SHELF_IC_OUTPUT_FILE = "MOM_Shelf_IC" ! default = "MOM_Shelf_IC"
+                                ! The name-root of the output file for the ice shelf initial conditions.
 
 ! === module MOM_state_initialization ===
 INIT_LAYERS_FROM_Z_FILE = False !   [Boolean] default = False
@@ -1219,6 +1324,9 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at the bottom into the
                                 ! interior as though a diffusivity of KD_MIN_TR were operating.
+MIX_BOUNDARY_TRACER_ALE = False !   [Boolean] default = False
+                                ! If true and in ALE mode, mix the passive tracers in massless layers at the
+                                ! bottom into the interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 0.0                 !   [m2 s-1] default = 0.0
                                 ! A minimal diffusivity that should always be applied to tracers, especially in
                                 ! massless layers near the bottom. The default is 0.1*KD.
@@ -1674,8 +1782,6 @@ WIND_CONFIG = "zero"            ! default = "zero"
 RESTOREBUOY = False             !   [Boolean] default = False
                                 ! If true, the buoyancy fluxes drive the model back toward some specified
                                 ! surface state with a rate given by FLUXCONST.
-LATENT_HEAT_FUSION = 3.34E+05   !   [J/kg] default = 3.34E+05
-                                ! The latent heat of fusion.
 LATENT_HEAT_VAPORIZATION = 2.5E+06 !   [J/kg] default = 2.5E+06
                                 ! The latent heat of fusion.
 GUST_CONST = 0.02               !   [Pa] default = 0.0
@@ -1687,103 +1793,6 @@ READ_GUST_2D = False            !   [Boolean] default = False
                                 ! If true, use a 2-dimensional gustiness supplied from an input file
 
 ! === module MOM_restart ===
-ICE_SHELF = True                !   [Boolean] default = False
-                                ! If true, enables the ice shelf model.
-
-! === module MOM_domains min_halo ===
-
-! === module MOM_grid ===
-! Parameters providing information about the lateral grid.
-
-! === module MOM_hor_index ===
-! Sets the horizontal array index types.
-
-! === module MOM_grid_init ===
-
-! === module MOM_ice_shelf ===
-DEBUG_IS = False                !   [Boolean] default = False
-                                ! If true, write verbose debugging messages for the ice shelf.
-DYNAMIC_SHELF_MASS = False      !   [Boolean] default = False
-                                ! If true, the ice sheet mass can evolve with time.
-SHELF_THERMO = True             !   [Boolean] default = False
-                                ! If true, use a thermodynamically interactive ice shelf.
-SHELF_THREE_EQN = True          !   [Boolean] default = True
-                                ! If true, use the three equation expression of consistency to calculate the
-                                ! fluxes at the ice-ocean interface.
-SHELF_INSULATOR = False         !   [Boolean] default = False
-                                ! If true, the ice shelf is a perfect insulatior (no conduction).
-MELTING_CUTOFF_DEPTH = 0.0      !   [m] default = 0.0
-                                ! Depth above which the melt is set to zero (it must be >= 0) Default value
-                                ! won't affect the solution.
-CONST_SEA_LEVEL = False         !   [Boolean] default = False
-                                ! If true, apply evaporative, heat and salt fluxes in the sponge region. This
-                                ! will avoid a large increase in sea level. This option is needed for some of
-                                ! the ISOMIP+ experiments (Ocean3 and Ocean4). IMPORTANT: it is not currently
-                                ! possible to do prefect restarts using this flag.
-SHELF_3EQ_GAMMA = True          !   [Boolean] default = False
-                                ! If true, user specifies a constant nondimensional heat-transfer coefficient
-                                ! (GAMMA_T_3EQ), from which the default salt-transfer coefficient is set as
-                                ! GAMMA_T_3EQ/35. This is used with SHELF_THREE_EQN.
-SHELF_S_ROOT = True             !   [Boolean] default = False
-                                ! If SHELF_S_ROOT = True, salinity at the ice/ocean interface (Sbdry) is
-                                ! computed from a quadratic equation. Otherwise, the previous interactive method
-                                ! to estimate Sbdry is used.
-SHELF_3EQ_GAMMA_T = 0.022       !   [nondim] default = 0.022
-                                ! Nondimensional heat-transfer coefficient.
-SHELF_3EQ_GAMMA_S = 6.285714285714285E-04 !   [nondim] default = 6.285714285714285E-04
-                                ! Nondimensional salt-transfer coefficient.
-ICE_SHELF_MASS_FROM_FILE = False !   [Boolean] default = False
-                                ! Read the mass of the ice shelf (every time step) from a file.
-C_P_ICE = 2100.0                !   [J kg-1 K-1] default = 2100.0
-                                ! The heat capacity of ice.
-ICE_SHELF_FLUX_FACTOR = 1.0     !   [none] default = 1.0
-                                ! Non-dimensional factor applied to shelf thermodynamic fluxes.
-KV_ICE = 1.0E+10                !   [m2 s-1] default = 1.0E+10
-                                ! The viscosity of the ice.
-KV_MOLECULAR = 1.95E-06         !   [m2 s-1] default = 1.95E-06
-                                ! The molecular kinimatic viscosity of sea water at the freezing temperature.
-ICE_SHELF_SALINITY = 0.0        !   [psu] default = 0.0
-                                ! The salinity of the ice inside the ice shelf.
-ICE_SHELF_TEMPERATURE = -20.0   !   [degC] default = -15.0
-                                ! The temperature at the center of the ice shelf.
-KD_SALT_MOLECULAR = 8.02E-10    !   [m2 s-1] default = 8.02E-10
-                                ! The molecular diffusivity of salt in sea water at the freezing point.
-KD_TEMP_MOLECULAR = 1.41E-07    !   [m2 s-1] default = 1.41E-07
-                                ! The molecular diffusivity of heat in sea water at the freezing point.
-DT_FORCING = 300.0              !   [s] default = 0.0
-                                ! The time step for changing forcing, coupling with other components, or
-                                ! potentially writing certain diagnostics. The default value is given by DT.
-COL_THICK_MELT_THRESHOLD = 1.0  !   [m] default = 0.0
-                                ! The minimum ocean column thickness where melting is allowed.
-READ_TIDEAMP = False            !   [Boolean] default = False
-                                ! If true, read a file (given by TIDEAMP_FILE) containing the tidal amplitude
-                                ! with INT_TIDE_DISSIPATION.
-UTIDE = 0.0                     !   [m s-1] default = 0.0
-                                ! The constant tidal amplitude used with INT_TIDE_DISSIPATION.
-
-! === module MOM_EOS ===
-DENSITY_ICE = 900.0             !   [kg m-3] default = 900.0
-                                ! A typical density of ice.
-MIN_THICKNESS_SIMPLE_CALVE = 0.0 !   [m] default = 0.0
-                                ! Min thickness rule for the very simple calving law
-USTAR_SHELF_BG = 0.001          !   [m s-1] default = 0.0
-                                ! The minimum value of ustar under ice shelves.
-CDRAG_SHELF = 0.0025            !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
-                                ! the surface stress.
-
-! === module ISOMIP_initialize_topography ===
-
-! === module MOM_restart ===
-ICE_PROFILE_CONFIG = "FILE"     !
-                                ! This specifies how the initial ice profile is specified. Valid values are:
-                                ! CHANNEL, FILE, and USER.
-LEN_SIDE_STRESS = 0.0           !   [axis_units] default = 0.0
-                                ! position past which shelf sides are stress free.
-ICE_THICKNESS_VARNAME = "thick" ! default = "h_shelf"
-                                ! The name of the thickness variable in ICE_THICKNESS_FILE.
-SHELF_IC_OUTPUT_FILE = "MOM_Shelf_IC" ! default = "MOM_Shelf_IC"
-                                ! The name-root of the output file for the ice shelf initial conditions.
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04

--- a/ocean_only/ISOMIP/rho/MOM_parameter_doc.short
+++ b/ocean_only/ISOMIP/rho/MOM_parameter_doc.short
@@ -21,10 +21,8 @@ SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
                                 ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "ISOMIP_IC"    ! default = "MOM_IC"
                                 ! The file into which to write the initial conditions.
-ICE_THICKNESS_FILE = "Ocean1_3D.nc" !
-                                ! The file from which the ice bathymetry and area are read.
-ICE_AREA_VARNAME = "area"       !
-                                ! The name of the area variable in ICE_THICKNESS_FILE.
+ICE_SHELF = True                !   [Boolean] default = False
+                                ! If true, enables the ice shelf model.
 
 ! === module MOM_domains ===
 REENTRANT_X = False             !   [Boolean] default = True
@@ -210,6 +208,47 @@ REMAP_AFTER_INITIALIZATION = False !   [Boolean] default = True
                                 ! If true, applies regridding and remapping immediately after initialization so
                                 ! that the state is ALE consistent. This is a legacy step and should not be
                                 ! needed if the initialization is consistent with the coordinate mode.
+
+! === module MOM_domains min_halo ===
+
+! === module MOM_grid_init ===
+
+! === module ISOMIP_initialize_topography ===
+
+! === module MOM_ice_shelf ===
+SHELF_THERMO = True             !   [Boolean] default = False
+                                ! If true, use a thermodynamically interactive ice shelf.
+SHELF_3EQ_GAMMA = True          !   [Boolean] default = False
+                                ! If true, user specifies a constant nondimensional heat-transfer coefficient
+                                ! (GAMMA_T_3EQ), from which the default salt-transfer coefficient is set as
+                                ! GAMMA_T_3EQ/35. This is used with SHELF_THREE_EQN.
+SHELF_S_ROOT = True             !   [Boolean] default = False
+                                ! If SHELF_S_ROOT = True, salinity at the ice/ocean interface (Sbdry) is
+                                ! computed from a quadratic equation. Otherwise, the previous interactive method
+                                ! to estimate Sbdry is used.
+ICE_SHELF_TEMPERATURE = -20.0   !   [degC] default = -15.0
+                                ! The temperature at the center of the ice shelf.
+DT_FORCING = 300.0              !   [s] default = 0.0
+                                ! The time step for changing forcing, coupling with other components, or
+                                ! potentially writing certain diagnostics. The default value is given by DT.
+COL_THICK_MELT_THRESHOLD = 1.0  !   [m] default = 0.0
+                                ! The minimum ocean column thickness where melting is allowed.
+
+! === module MOM_EOS ===
+USTAR_SHELF_BG = 0.001          !   [m s-1] default = 0.0
+                                ! The minimum value of ustar under ice shelves.
+CDRAG_SHELF = 0.0025            !   [nondim] default = 0.003
+                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
+                                ! the surface stress.
+ICE_PROFILE_CONFIG = "FILE"     !
+                                ! This specifies how the initial ice profile is specified. Valid values are:
+                                ! CHANNEL, FILE, and USER.
+ICE_THICKNESS_FILE = "Ocean1_3D.nc" ! default = "ice_shelf_h.nc"
+                                ! The file from which the bathymetry is read.
+ICE_THICKNESS_VARNAME = "thick" ! default = "h_shelf"
+                                ! The name of the thickness variable in ICE_THICKNESS_FILE.
+ICE_AREA_VARNAME = "area"       ! default = "area_shelf_h"
+                                ! The name of the area variable in ICE_THICKNESS_FILE.
 
 ! === module MOM_state_initialization ===
 THICKNESS_CONFIG = "ISOMIP"     ! default = "uniform"
@@ -441,45 +480,6 @@ BUOY_CONFIG = "NONE"            ! default = "zero"
                                 ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
 GUST_CONST = 0.02               !   [Pa] default = 0.0
                                 ! The background gustiness in the winds.
-ICE_SHELF = True                !   [Boolean] default = False
-                                ! If true, enables the ice shelf model.
-
-! === module MOM_domains min_halo ===
-
-! === module MOM_grid_init ===
-
-! === module MOM_ice_shelf ===
-SHELF_THERMO = True             !   [Boolean] default = False
-                                ! If true, use a thermodynamically interactive ice shelf.
-SHELF_3EQ_GAMMA = True          !   [Boolean] default = False
-                                ! If true, user specifies a constant nondimensional heat-transfer coefficient
-                                ! (GAMMA_T_3EQ), from which the default salt-transfer coefficient is set as
-                                ! GAMMA_T_3EQ/35. This is used with SHELF_THREE_EQN.
-SHELF_S_ROOT = True             !   [Boolean] default = False
-                                ! If SHELF_S_ROOT = True, salinity at the ice/ocean interface (Sbdry) is
-                                ! computed from a quadratic equation. Otherwise, the previous interactive method
-                                ! to estimate Sbdry is used.
-ICE_SHELF_TEMPERATURE = -20.0   !   [degC] default = -15.0
-                                ! The temperature at the center of the ice shelf.
-DT_FORCING = 300.0              !   [s] default = 0.0
-                                ! The time step for changing forcing, coupling with other components, or
-                                ! potentially writing certain diagnostics. The default value is given by DT.
-COL_THICK_MELT_THRESHOLD = 1.0  !   [m] default = 0.0
-                                ! The minimum ocean column thickness where melting is allowed.
-
-! === module MOM_EOS ===
-USTAR_SHELF_BG = 0.001          !   [m s-1] default = 0.0
-                                ! The minimum value of ustar under ice shelves.
-CDRAG_SHELF = 0.0025            !   [nondim] default = 0.003
-                                ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
-                                ! the surface stress.
-
-! === module ISOMIP_initialize_topography ===
-ICE_PROFILE_CONFIG = "FILE"     !
-                                ! This specifies how the initial ice profile is specified. Valid values are:
-                                ! CHANNEL, FILE, and USER.
-ICE_THICKNESS_VARNAME = "thick" ! default = "h_shelf"
-                                ! The name of the thickness variable in ICE_THICKNESS_FILE.
 
 ! === module MOM_main (MOM_driver) ===
 DAYMAX = 10.0                   !   [days]

--- a/ocean_only/MESO_025_23L/MOM_parameter_doc.all
+++ b/ocean_only/MESO_025_23L/MOM_parameter_doc.all
@@ -121,6 +121,8 @@ WRITE_GEOM = 1                  ! default = 1
                                 ! If =0, never write the geometry and vertical grid files. If =1, write the
                                 ! geometry and vertical grid files only for a new simulation. If =2, always
                                 ! write the geometry and vertical grid files. Other values are invalid.
+ICE_SHELF = False               !   [Boolean] default = False
+                                ! If true, enables the ice shelf model.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
                                 ! If False, The model is being run in serial mode as a single realization. If
                                 ! True, The current model realization is part of a larger ensemble and at the
@@ -497,17 +499,25 @@ NEW_SPONGES = False             !   [of sponge restoring data.] default = False
 INTERPOLATE_SPONGE_TIME_SPACE = False !   [of sponge restoring data.] default = False
                                 ! Set True if using the newer sponging code which performs on-the-fly regridding
                                 ! in lat-lon-time.
-!Total sponge columns = 19376   !
-                                ! The total number of columns where sponges are applied.
+
+! === module MOM_sponge ===
+SPONGE_UV = False               !   [Boolean] default = False
+                                ! Apply sponges in u and v, in addition to tracers.
+REMAPPING_2018_ANSWERS = False  !   [Boolean] default = False
+                                ! If true, use the order of arithmetic and expressions that recover the answers
+                                ! from the end of 2018.  Otherwise, use updated and more robust forms of the
+                                ! same expressions.
+HOR_REGRID_2018_ANSWERS = False !   [Boolean] default = False
+                                ! If true, use the order of arithmetic for horizonal regridding that recovers
+                                ! the answers from the end of 2018.  Otherwise, use rotationally symmetric forms
+                                ! of the same expressions.
+!Total sponge columns at h points = 19376 !
+                                ! The total number of columns where sponges are applied at h points.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
                                 ! The number of diagnostic vertical coordinates to use. For each coordinate, an
                                 ! entry in DIAG_COORDS must be provided.
-REMAPPING_2018_ANSWERS = False  !   [Boolean] default = False
-                                ! If true, use the order of arithmetic and expressions that recover the answers
-                                ! from the end of 2018.  Otherwise, use updated and more robust forms of the
-                                ! same expressions.
 USE_GRID_SPACE_DIAGNOSTIC_AXES = False !   [Boolean] default = False
                                 ! If true, use a grid index coordinate convention for diagnostic axes.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
@@ -1611,8 +1621,6 @@ SHORTWAVE_FILE = "MESO_Solar_025.nc" !
                                 ! The file with the shortwave heat flux in variable NET_SOL.
 
 ! === module MOM_restart ===
-ICE_SHELF = False               !   [Boolean] default = False
-                                ! If true, enables the ice shelf model.
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04

--- a/ocean_only/MESO_025_23L/MOM_parameter_doc.short
+++ b/ocean_only/MESO_025_23L/MOM_parameter_doc.short
@@ -194,8 +194,8 @@ SPONGE_DAMPING_FILE = "MESO_Sponge_025mNG.nc" !
                                 ! The name of the file with the sponge damping rates.
 SPONGE_STATE_FILE = "MESO_025_23L_IC.nc" ! default = "MESO_Sponge_025mNG.nc"
                                 ! The name of the file with the state to damp toward.
-!Total sponge columns = 19376   !
-                                ! The total number of columns where sponges are applied.
+
+! === module MOM_sponge ===
 
 ! === module MOM_diag_mediator ===
 

--- a/ocean_only/MESO_025_63L/MOM_parameter_doc.all
+++ b/ocean_only/MESO_025_63L/MOM_parameter_doc.all
@@ -121,6 +121,8 @@ WRITE_GEOM = 1                  ! default = 1
                                 ! If =0, never write the geometry and vertical grid files. If =1, write the
                                 ! geometry and vertical grid files only for a new simulation. If =2, always
                                 ! write the geometry and vertical grid files. Other values are invalid.
+ICE_SHELF = False               !   [Boolean] default = False
+                                ! If true, enables the ice shelf model.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
                                 ! If False, The model is being run in serial mode as a single realization. If
                                 ! True, The current model realization is part of a larger ensemble and at the
@@ -499,17 +501,25 @@ NEW_SPONGES = False             !   [of sponge restoring data.] default = False
 INTERPOLATE_SPONGE_TIME_SPACE = False !   [of sponge restoring data.] default = False
                                 ! Set True if using the newer sponging code which performs on-the-fly regridding
                                 ! in lat-lon-time.
-!Total sponge columns = 19167   !
-                                ! The total number of columns where sponges are applied.
+
+! === module MOM_sponge ===
+SPONGE_UV = False               !   [Boolean] default = False
+                                ! Apply sponges in u and v, in addition to tracers.
+REMAPPING_2018_ANSWERS = False  !   [Boolean] default = False
+                                ! If true, use the order of arithmetic and expressions that recover the answers
+                                ! from the end of 2018.  Otherwise, use updated and more robust forms of the
+                                ! same expressions.
+HOR_REGRID_2018_ANSWERS = False !   [Boolean] default = False
+                                ! If true, use the order of arithmetic for horizonal regridding that recovers
+                                ! the answers from the end of 2018.  Otherwise, use rotationally symmetric forms
+                                ! of the same expressions.
+!Total sponge columns at h points = 19167 !
+                                ! The total number of columns where sponges are applied at h points.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
                                 ! The number of diagnostic vertical coordinates to use. For each coordinate, an
                                 ! entry in DIAG_COORDS must be provided.
-REMAPPING_2018_ANSWERS = False  !   [Boolean] default = False
-                                ! If true, use the order of arithmetic and expressions that recover the answers
-                                ! from the end of 2018.  Otherwise, use updated and more robust forms of the
-                                ! same expressions.
 USE_GRID_SPACE_DIAGNOSTIC_AXES = False !   [Boolean] default = False
                                 ! If true, use a grid index coordinate convention for diagnostic axes.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
@@ -1647,8 +1657,6 @@ SHORTWAVE_FILE = "MESO_Solar_025.nc" !
                                 ! The file with the shortwave heat flux in variable NET_SOL.
 
 ! === module MOM_restart ===
-ICE_SHELF = False               !   [Boolean] default = False
-                                ! If true, enables the ice shelf model.
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04

--- a/ocean_only/MESO_025_63L/MOM_parameter_doc.short
+++ b/ocean_only/MESO_025_63L/MOM_parameter_doc.short
@@ -207,8 +207,8 @@ SPONGE_DAMPING_FILE = "MESO_Sponge_025mNG.nc" !
                                 ! The name of the file with the sponge damping rates.
 SPONGE_STATE_FILE = "MESO_025_63L_IC.nc" ! default = "MESO_Sponge_025mNG.nc"
                                 ! The name of the file with the state to damp toward.
-!Total sponge columns = 19167   !
-                                ! The total number of columns where sponges are applied.
+
+! === module MOM_sponge ===
 
 ! === module MOM_diag_mediator ===
 

--- a/ocean_only/buoy_forced_basin/MOM_parameter_doc.all
+++ b/ocean_only/buoy_forced_basin/MOM_parameter_doc.all
@@ -104,6 +104,8 @@ WRITE_GEOM = 1                  ! default = 1
                                 ! If =0, never write the geometry and vertical grid files. If =1, write the
                                 ! geometry and vertical grid files only for a new simulation. If =2, always
                                 ! write the geometry and vertical grid files. Other values are invalid.
+ICE_SHELF = False               !   [Boolean] default = False
+                                ! If true, enables the ice shelf model.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
                                 ! If False, The model is being run in serial mode as a single realization. If
                                 ! True, The current model realization is part of a larger ensemble and at the
@@ -1295,8 +1297,6 @@ SST_N = 10.0                    !   [C] default = 10.0
                                 ! SST at the northern edge of the linear forcing ramp.
 
 ! === module MOM_restart ===
-ICE_SHELF = False               !   [Boolean] default = False
-                                ! If true, enables the ice shelf model.
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04

--- a/ocean_only/global/MOM_parameter_doc.all
+++ b/ocean_only/global/MOM_parameter_doc.all
@@ -123,6 +123,8 @@ WRITE_GEOM = 1                  ! default = 1
                                 ! If =0, never write the geometry and vertical grid files. If =1, write the
                                 ! geometry and vertical grid files only for a new simulation. If =2, always
                                 ! write the geometry and vertical grid files. Other values are invalid.
+ICE_SHELF = False               !   [Boolean] default = False
+                                ! If true, enables the ice shelf model.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
                                 ! If False, The model is being run in serial mode as a single realization. If
                                 ! True, The current model realization is part of a larger ensemble and at the
@@ -1991,8 +1993,6 @@ GUST_2D_FILE = "gustiness_qscat.nc" !
                                 ! The file in which the wind gustiness is found in variable gustiness.
 
 ! === module MOM_restart ===
-ICE_SHELF = False               !   [Boolean] default = False
-                                ! If true, enables the ice shelf model.
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04

--- a/ocean_only/idealized_hurricane/MOM_parameter_doc.all
+++ b/ocean_only/idealized_hurricane/MOM_parameter_doc.all
@@ -124,6 +124,8 @@ WRITE_GEOM = 1                  ! default = 1
                                 ! If =0, never write the geometry and vertical grid files. If =1, write the
                                 ! geometry and vertical grid files only for a new simulation. If =2, always
                                 ! write the geometry and vertical grid files. Other values are invalid.
+ICE_SHELF = False               !   [Boolean] default = False
+                                ! If true, enables the ice shelf model.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
                                 ! If False, The model is being run in serial mode as a single realization. If
                                 ! True, The current model realization is part of a larger ensemble and at the
@@ -1155,6 +1157,9 @@ AGGREGATE_FW_FORCING = True     !   [Boolean] default = True
 MIX_BOUNDARY_TRACERS = True     !   [Boolean] default = True
                                 ! If true, mix the passive tracers in massless layers at the bottom into the
                                 ! interior as though a diffusivity of KD_MIN_TR were operating.
+MIX_BOUNDARY_TRACER_ALE = False !   [Boolean] default = False
+                                ! If true and in ALE mode, mix the passive tracers in massless layers at the
+                                ! bottom into the interior as though a diffusivity of KD_MIN_TR were operating.
 KD_MIN_TR = 1.0E-08             !   [m2 s-1] default = 1.0E-08
                                 ! A minimal diffusivity that should always be applied to tracers, especially in
                                 ! massless layers near the bottom. The default is 0.1*KD.
@@ -1680,8 +1685,6 @@ IDL_HURR_2018_ANSWERS = False   !   [Boolean] default = False
                                 ! rescalable and respect rotational symmetry.
 
 ! === module MOM_restart ===
-ICE_SHELF = False               !   [Boolean] default = False
-                                ! If true, enables the ice shelf model.
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04

--- a/ocean_only/tides_025/MOM_parameter_doc.all
+++ b/ocean_only/tides_025/MOM_parameter_doc.all
@@ -119,6 +119,8 @@ WRITE_GEOM = 1                  ! default = 1
                                 ! If =0, never write the geometry and vertical grid files. If =1, write the
                                 ! geometry and vertical grid files only for a new simulation. If =2, always
                                 ! write the geometry and vertical grid files. Other values are invalid.
+ICE_SHELF = False               !   [Boolean] default = False
+                                ! If true, enables the ice shelf model.
 ENSEMBLE_OCEAN = False          !   [Boolean] default = False
                                 ! If False, The model is being run in serial mode as a single realization. If
                                 ! True, The current model realization is part of a larger ensemble and at the
@@ -232,6 +234,9 @@ CHANNEL_LIST_FILE = "MOM_channels_global_025" ! default = "MOM_channel_list"
 CHANNEL_LIST_360_LON_CHECK = True !   [Boolean] default = True
                                 ! If true, the channel configuration list works for any longitudes in the range
                                 ! of -360 to 360.
+FATAL_UNUSED_CHANNEL_WIDTHS = False !   [Boolean] default = False
+                                ! If true, trigger a fatal error if there are any channel widths in
+                                ! CHANNEL_LIST_FILE that do not cause any open face widths to change.
 ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -1204,8 +1209,6 @@ READ_GUST_2D = False            !   [Boolean] default = False
                                 ! If true, use a 2-dimensional gustiness supplied from an input file
 
 ! === module MOM_restart ===
-ICE_SHELF = False               !   [Boolean] default = False
-                                ! If true, enables the ice shelf model.
 USE_WAVES = False               !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04


### PR DESCRIPTION
  Updated the MOM_parameter_doc files for 8 test cases in MOM6-examples that are
not routinely run in the gitlab pipelines, mostly to reflect a different
position for the parameter ICE_SHELF in these files and some new parameters
arising from recent commits.  Also updated the MOM_input files for the
ISOMIP/layer and ISOMIP/rho test cases to be more consistent with the order of
parameters in the MOM_parameter_doc files associated with the repositioning of
the code that initializes the ice shelves.  All answers are bitwise identical.