### PR TITLE
Update tides_025/MOM_input and MOM_parameter_doc files

### DIFF
--- a/ocean_only/ISOMIP/layer/MOM_parameter_doc.all
+++ b/ocean_only/ISOMIP/layer/MOM_parameter_doc.all
@@ -1520,11 +1520,14 @@ VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
                                 ! If true, the buoyancy forcing varies in time after the initialization of the
                                 ! model.
 BUOY_CONFIG = "NONE"            ! default = "zero"
-                                ! The character string that indicates how buoyancy forcing is specified. Valid
-                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified.  Valid
+                                ! options include (file), (data_override), (zero), (const), (linear), (MESO),
+                                ! (SCM_CVmix_tests), (BFB), (dumbbell), (USER) and (NONE).
 WIND_CONFIG = "zero"            ! default = "zero"
-                                ! The character string that indicates how wind forcing is specified. Valid
-                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified.  Valid
+                                ! options include (file), (data_override), (2gyre), (1gyre), (gyres), (zero),
+                                ! (const), (Neverworld), (scurves), (ideal_hurr), (SCM_ideal_hurr),
+                                ! (SCM_CVmix_tests) and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
                                 ! If true, the buoyancy fluxes drive the model back toward some specified
                                 ! surface state with a rate given by FLUXCONST.

--- a/ocean_only/ISOMIP/layer/MOM_parameter_doc.layout
+++ b/ocean_only/ISOMIP/layer/MOM_parameter_doc.layout
@@ -16,8 +16,8 @@ GLOBAL_INDEXING = False         !   [Boolean] default = False
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the the width of the halos
-                                ! that are updated with each call.
+                                ! If true, optional arguments may be used to specify the width of the halos that
+                                ! are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
                                 ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
                                 ! statically determined at compile time.  Otherwise the sizes are not determined
@@ -55,6 +55,11 @@ NIBLOCK = 1                     ! default = 1
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 
+! === module MOM_domains min_halo ===
+
+! === module MOM_grid ===
+! Parameters providing information about the lateral grid.
+
 ! === module MOM_barotropic ===
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
                                 ! If true, use wide halos and march in during the barotropic time stepping for
@@ -65,8 +70,3 @@ BTHALO = 0                      ! default = 0
                                 ! The barotropic x-halo size that is actually used.
 !BT y-halo = 0                  !
                                 ! The barotropic y-halo size that is actually used.
-
-! === module MOM_domains min_halo ===
-
-! === module MOM_grid ===
-! Parameters providing information about the lateral grid.

--- a/ocean_only/ISOMIP/layer/MOM_parameter_doc.short
+++ b/ocean_only/ISOMIP/layer/MOM_parameter_doc.short
@@ -429,8 +429,9 @@ VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
                                 ! If true, the buoyancy forcing varies in time after the initialization of the
                                 ! model.
 BUOY_CONFIG = "NONE"            ! default = "zero"
-                                ! The character string that indicates how buoyancy forcing is specified. Valid
-                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified.  Valid
+                                ! options include (file), (data_override), (zero), (const), (linear), (MESO),
+                                ! (SCM_CVmix_tests), (BFB), (dumbbell), (USER) and (NONE).
 GUST_CONST = 0.02               !   [Pa] default = 0.0
                                 ! The background gustiness in the winds.
 

--- a/ocean_only/ISOMIP/rho/MOM_parameter_doc.all
+++ b/ocean_only/ISOMIP/rho/MOM_parameter_doc.all
@@ -1780,11 +1780,14 @@ VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
                                 ! If true, the buoyancy forcing varies in time after the initialization of the
                                 ! model.
 BUOY_CONFIG = "NONE"            ! default = "zero"
-                                ! The character string that indicates how buoyancy forcing is specified. Valid
-                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified.  Valid
+                                ! options include (file), (data_override), (zero), (const), (linear), (MESO),
+                                ! (SCM_CVmix_tests), (BFB), (dumbbell), (USER) and (NONE).
 WIND_CONFIG = "zero"            ! default = "zero"
-                                ! The character string that indicates how wind forcing is specified. Valid
-                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified.  Valid
+                                ! options include (file), (data_override), (2gyre), (1gyre), (gyres), (zero),
+                                ! (const), (Neverworld), (scurves), (ideal_hurr), (SCM_ideal_hurr),
+                                ! (SCM_CVmix_tests) and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
                                 ! If true, the buoyancy fluxes drive the model back toward some specified
                                 ! surface state with a rate given by FLUXCONST.

--- a/ocean_only/ISOMIP/rho/MOM_parameter_doc.layout
+++ b/ocean_only/ISOMIP/rho/MOM_parameter_doc.layout
@@ -16,8 +16,8 @@ GLOBAL_INDEXING = False         !   [Boolean] default = False
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the the width of the halos
-                                ! that are updated with each call.
+                                ! If true, optional arguments may be used to specify the width of the halos that
+                                ! are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
                                 ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
                                 ! statically determined at compile time.  Otherwise the sizes are not determined
@@ -55,6 +55,11 @@ NIBLOCK = 1                     ! default = 1
 NJBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the y-direction on each processor (for openmp).
 
+! === module MOM_domains min_halo ===
+
+! === module MOM_grid ===
+! Parameters providing information about the lateral grid.
+
 ! === module MOM_barotropic ===
 BT_USE_WIDE_HALOS = True        !   [Boolean] default = True
                                 ! If true, use wide halos and march in during the barotropic time stepping for
@@ -65,8 +70,3 @@ BTHALO = 0                      ! default = 0
                                 ! The barotropic x-halo size that is actually used.
 !BT y-halo = 0                  !
                                 ! The barotropic y-halo size that is actually used.
-
-! === module MOM_domains min_halo ===
-
-! === module MOM_grid ===
-! Parameters providing information about the lateral grid.

--- a/ocean_only/ISOMIP/rho/MOM_parameter_doc.short
+++ b/ocean_only/ISOMIP/rho/MOM_parameter_doc.short
@@ -476,8 +476,9 @@ VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
                                 ! If true, the buoyancy forcing varies in time after the initialization of the
                                 ! model.
 BUOY_CONFIG = "NONE"            ! default = "zero"
-                                ! The character string that indicates how buoyancy forcing is specified. Valid
-                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified.  Valid
+                                ! options include (file), (data_override), (zero), (const), (linear), (MESO),
+                                ! (SCM_CVmix_tests), (BFB), (dumbbell), (USER) and (NONE).
 GUST_CONST = 0.02               !   [Pa] default = 0.0
                                 ! The background gustiness in the winds.
 

--- a/ocean_only/MESO_025_23L/MOM_parameter_doc.all
+++ b/ocean_only/MESO_025_23L/MOM_parameter_doc.all
@@ -492,6 +492,8 @@ SPONGE_PTEMP_VAR = "PTEMP"      ! default = "PTEMP"
                                 ! The name of the potential temperature variable in SPONGE_STATE_FILE.
 SPONGE_SALT_VAR = "SALT"        ! default = "SALT"
                                 ! The name of the salinity variable in SPONGE_STATE_FILE.
+SPONGE_UV = False               !   [Boolean] default = False
+                                ! Apply sponges in u and v, in addition to tracers.
 SPONGE_ETA_VAR = "ETA"          ! default = "ETA"
                                 ! The name of the interface height variable in SPONGE_STATE_FILE.
 SPONGE_IDAMP_VAR = "Idamp"      ! default = "Idamp"
@@ -502,25 +504,17 @@ NEW_SPONGES = False             !   [of sponge restoring data.] default = False
 INTERPOLATE_SPONGE_TIME_SPACE = False !   [of sponge restoring data.] default = False
                                 ! Set True if using the newer sponging code which performs on-the-fly regridding
                                 ! in lat-lon-time.
-
-! === module MOM_sponge ===
-SPONGE_UV = False               !   [Boolean] default = False
-                                ! Apply sponges in u and v, in addition to tracers.
-REMAPPING_2018_ANSWERS = False  !   [Boolean] default = False
-                                ! If true, use the order of arithmetic and expressions that recover the answers
-                                ! from the end of 2018.  Otherwise, use updated and more robust forms of the
-                                ! same expressions.
-HOR_REGRID_2018_ANSWERS = False !   [Boolean] default = False
-                                ! If true, use the order of arithmetic for horizonal regridding that recovers
-                                ! the answers from the end of 2018.  Otherwise, use rotationally symmetric forms
-                                ! of the same expressions.
-!Total sponge columns at h points = 19376 !
-                                ! The total number of columns where sponges are applied at h points.
+!Total sponge columns = 19376   !
+                                ! The total number of columns where sponges are applied.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
                                 ! The number of diagnostic vertical coordinates to use. For each coordinate, an
                                 ! entry in DIAG_COORDS must be provided.
+REMAPPING_2018_ANSWERS = False  !   [Boolean] default = False
+                                ! If true, use the order of arithmetic and expressions that recover the answers
+                                ! from the end of 2018.  Otherwise, use updated and more robust forms of the
+                                ! same expressions.
 USE_GRID_SPACE_DIAGNOSTIC_AXES = False !   [Boolean] default = False
                                 ! If true, use a grid index coordinate convention for diagnostic axes.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
@@ -1570,11 +1564,14 @@ VARIABLE_BUOYFORCE = True       !   [Boolean] default = True
                                 ! If true, the buoyancy forcing varies in time after the initialization of the
                                 ! model.
 BUOY_CONFIG = "MESO"            ! default = "zero"
-                                ! The character string that indicates how buoyancy forcing is specified. Valid
-                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified.  Valid
+                                ! options include (file), (data_override), (zero), (const), (linear), (MESO),
+                                ! (SCM_CVmix_tests), (BFB), (dumbbell), (USER) and (NONE).
 WIND_CONFIG = "file"            ! default = "zero"
-                                ! The character string that indicates how wind forcing is specified. Valid
-                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified.  Valid
+                                ! options include (file), (data_override), (2gyre), (1gyre), (gyres), (zero),
+                                ! (const), (Neverworld), (scurves), (ideal_hurr), (SCM_ideal_hurr),
+                                ! (SCM_CVmix_tests) and (USER).
 WIND_FILE = "MESO_str_025.nc"   !
                                 ! The file in which the wind stresses are found in variables STRESS_X and
                                 ! STRESS_Y.

--- a/ocean_only/MESO_025_23L/MOM_parameter_doc.layout
+++ b/ocean_only/MESO_025_23L/MOM_parameter_doc.layout
@@ -16,8 +16,8 @@ GLOBAL_INDEXING = False         !   [Boolean] default = False
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the the width of the halos
-                                ! that are updated with each call.
+                                ! If true, optional arguments may be used to specify the width of the halos that
+                                ! are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
                                 ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
                                 ! statically determined at compile time.  Otherwise the sizes are not determined

--- a/ocean_only/MESO_025_23L/MOM_parameter_doc.short
+++ b/ocean_only/MESO_025_23L/MOM_parameter_doc.short
@@ -194,8 +194,8 @@ SPONGE_DAMPING_FILE = "MESO_Sponge_025mNG.nc" !
                                 ! The name of the file with the sponge damping rates.
 SPONGE_STATE_FILE = "MESO_025_23L_IC.nc" ! default = "MESO_Sponge_025mNG.nc"
                                 ! The name of the file with the state to damp toward.
-
-! === module MOM_sponge ===
+!Total sponge columns = 19376   !
+                                ! The total number of columns where sponges are applied.
 
 ! === module MOM_diag_mediator ===
 
@@ -408,11 +408,14 @@ ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 BUOY_CONFIG = "MESO"            ! default = "zero"
-                                ! The character string that indicates how buoyancy forcing is specified. Valid
-                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified.  Valid
+                                ! options include (file), (data_override), (zero), (const), (linear), (MESO),
+                                ! (SCM_CVmix_tests), (BFB), (dumbbell), (USER) and (NONE).
 WIND_CONFIG = "file"            ! default = "zero"
-                                ! The character string that indicates how wind forcing is specified. Valid
-                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified.  Valid
+                                ! options include (file), (data_override), (2gyre), (1gyre), (gyres), (zero),
+                                ! (const), (Neverworld), (scurves), (ideal_hurr), (SCM_ideal_hurr),
+                                ! (SCM_CVmix_tests) and (USER).
 WIND_FILE = "MESO_str_025.nc"   !
                                 ! The file in which the wind stresses are found in variables STRESS_X and
                                 ! STRESS_Y.

--- a/ocean_only/MESO_025_63L/MOM_parameter_doc.all
+++ b/ocean_only/MESO_025_63L/MOM_parameter_doc.all
@@ -494,6 +494,8 @@ SPONGE_PTEMP_VAR = "PTEMP"      ! default = "PTEMP"
                                 ! The name of the potential temperature variable in SPONGE_STATE_FILE.
 SPONGE_SALT_VAR = "SALT"        ! default = "SALT"
                                 ! The name of the salinity variable in SPONGE_STATE_FILE.
+SPONGE_UV = False               !   [Boolean] default = False
+                                ! Apply sponges in u and v, in addition to tracers.
 SPONGE_ETA_VAR = "ETA"          ! default = "ETA"
                                 ! The name of the interface height variable in SPONGE_STATE_FILE.
 SPONGE_IDAMP_VAR = "Idamp"      ! default = "Idamp"
@@ -504,25 +506,17 @@ NEW_SPONGES = False             !   [of sponge restoring data.] default = False
 INTERPOLATE_SPONGE_TIME_SPACE = False !   [of sponge restoring data.] default = False
                                 ! Set True if using the newer sponging code which performs on-the-fly regridding
                                 ! in lat-lon-time.
-
-! === module MOM_sponge ===
-SPONGE_UV = False               !   [Boolean] default = False
-                                ! Apply sponges in u and v, in addition to tracers.
-REMAPPING_2018_ANSWERS = False  !   [Boolean] default = False
-                                ! If true, use the order of arithmetic and expressions that recover the answers
-                                ! from the end of 2018.  Otherwise, use updated and more robust forms of the
-                                ! same expressions.
-HOR_REGRID_2018_ANSWERS = False !   [Boolean] default = False
-                                ! If true, use the order of arithmetic for horizonal regridding that recovers
-                                ! the answers from the end of 2018.  Otherwise, use rotationally symmetric forms
-                                ! of the same expressions.
-!Total sponge columns at h points = 19167 !
-                                ! The total number of columns where sponges are applied at h points.
+!Total sponge columns = 19167   !
+                                ! The total number of columns where sponges are applied.
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 1             ! default = 1
                                 ! The number of diagnostic vertical coordinates to use. For each coordinate, an
                                 ! entry in DIAG_COORDS must be provided.
+REMAPPING_2018_ANSWERS = False  !   [Boolean] default = False
+                                ! If true, use the order of arithmetic and expressions that recover the answers
+                                ! from the end of 2018.  Otherwise, use updated and more robust forms of the
+                                ! same expressions.
 USE_GRID_SPACE_DIAGNOSTIC_AXES = False !   [Boolean] default = False
                                 ! If true, use a grid index coordinate convention for diagnostic axes.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
@@ -1606,11 +1600,14 @@ VARIABLE_BUOYFORCE = True       !   [Boolean] default = True
                                 ! If true, the buoyancy forcing varies in time after the initialization of the
                                 ! model.
 BUOY_CONFIG = "MESO"            ! default = "zero"
-                                ! The character string that indicates how buoyancy forcing is specified. Valid
-                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified.  Valid
+                                ! options include (file), (data_override), (zero), (const), (linear), (MESO),
+                                ! (SCM_CVmix_tests), (BFB), (dumbbell), (USER) and (NONE).
 WIND_CONFIG = "file"            ! default = "zero"
-                                ! The character string that indicates how wind forcing is specified. Valid
-                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified.  Valid
+                                ! options include (file), (data_override), (2gyre), (1gyre), (gyres), (zero),
+                                ! (const), (Neverworld), (scurves), (ideal_hurr), (SCM_ideal_hurr),
+                                ! (SCM_CVmix_tests) and (USER).
 WIND_FILE = "MESO_str_025.nc"   !
                                 ! The file in which the wind stresses are found in variables STRESS_X and
                                 ! STRESS_Y.

--- a/ocean_only/MESO_025_63L/MOM_parameter_doc.layout
+++ b/ocean_only/MESO_025_63L/MOM_parameter_doc.layout
@@ -16,8 +16,8 @@ GLOBAL_INDEXING = False         !   [Boolean] default = False
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the the width of the halos
-                                ! that are updated with each call.
+                                ! If true, optional arguments may be used to specify the width of the halos that
+                                ! are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
                                 ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
                                 ! statically determined at compile time.  Otherwise the sizes are not determined

--- a/ocean_only/MESO_025_63L/MOM_parameter_doc.short
+++ b/ocean_only/MESO_025_63L/MOM_parameter_doc.short
@@ -207,8 +207,8 @@ SPONGE_DAMPING_FILE = "MESO_Sponge_025mNG.nc" !
                                 ! The name of the file with the sponge damping rates.
 SPONGE_STATE_FILE = "MESO_025_63L_IC.nc" ! default = "MESO_Sponge_025mNG.nc"
                                 ! The name of the file with the state to damp toward.
-
-! === module MOM_sponge ===
+!Total sponge columns = 19167   !
+                                ! The total number of columns where sponges are applied.
 
 ! === module MOM_diag_mediator ===
 
@@ -437,11 +437,14 @@ ENERGYSAVEDAYS = 1.0            !   [hours] default = 24.0
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 BUOY_CONFIG = "MESO"            ! default = "zero"
-                                ! The character string that indicates how buoyancy forcing is specified. Valid
-                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified.  Valid
+                                ! options include (file), (data_override), (zero), (const), (linear), (MESO),
+                                ! (SCM_CVmix_tests), (BFB), (dumbbell), (USER) and (NONE).
 WIND_CONFIG = "file"            ! default = "zero"
-                                ! The character string that indicates how wind forcing is specified. Valid
-                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified.  Valid
+                                ! options include (file), (data_override), (2gyre), (1gyre), (gyres), (zero),
+                                ! (const), (Neverworld), (scurves), (ideal_hurr), (SCM_ideal_hurr),
+                                ! (SCM_CVmix_tests) and (USER).
 WIND_FILE = "MESO_str_025.nc"   !
                                 ! The file in which the wind stresses are found in variables STRESS_X and
                                 ! STRESS_Y.

--- a/ocean_only/buoy_forced_basin/MOM_parameter_doc.all
+++ b/ocean_only/buoy_forced_basin/MOM_parameter_doc.all
@@ -96,6 +96,9 @@ SURFACE_2018_ANSWERS = False    !   [Boolean] default = False
                                 ! If true, use expressions for the surface properties that recover the answers
                                 ! from the end of 2018. Otherwise, use more appropriate expressions that differ
                                 ! at roundoff for non-Boussinesq cases.
+USE_DIABATIC_TIME_BUG = False   !   [Boolean] default = False
+                                ! If true, uses the wrong calendar time for diabatic processes, as was done in
+                                ! MOM6 versions prior to February 2018. This is not recommended.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
                                 ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "MOM_IC"       ! default = "MOM_IC"
@@ -699,6 +702,9 @@ ANALYTIC_FV_PGF = True          !   [Boolean] default = True
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = False !   [Boolean] default = False
                                 ! If true, use mass weighting when interpolating T/S for integrals near the
                                 ! bathymetry in FV pressure gradient calculations.
+USE_INACCURATE_PGF_RHO_ANOM = False !   [Boolean] default = False
+                                ! If true, use a form of the PGF that uses the reference density in an
+                                ! inaccurate way. This is not recommended.
 RECONSTRUCT_FOR_PRESSURE = False !   [Boolean] default = False
                                 ! If True, use vertical reconstruction of T & S within the integrals of the FV
                                 ! pressure gradient calculation. If False, use the constant-by-layer algorithm.
@@ -1265,11 +1271,14 @@ VARIABLE_BUOYFORCE = True       !   [Boolean] default = True
                                 ! If true, the buoyancy forcing varies in time after the initialization of the
                                 ! model.
 BUOY_CONFIG = "BFB"             ! default = "zero"
-                                ! The character string that indicates how buoyancy forcing is specified. Valid
-                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified.  Valid
+                                ! options include (file), (data_override), (zero), (const), (linear), (MESO),
+                                ! (SCM_CVmix_tests), (BFB), (dumbbell), (USER) and (NONE).
 WIND_CONFIG = "zero"            ! default = "zero"
-                                ! The character string that indicates how wind forcing is specified. Valid
-                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified.  Valid
+                                ! options include (file), (data_override), (2gyre), (1gyre), (gyres), (zero),
+                                ! (const), (Neverworld), (scurves), (ideal_hurr), (SCM_ideal_hurr),
+                                ! (SCM_CVmix_tests) and (USER).
 RESTOREBUOY = True              !   [Boolean] default = False
                                 ! If true, the buoyancy fluxes drive the model back toward some specified
                                 ! surface state with a rate given by FLUXCONST.

--- a/ocean_only/buoy_forced_basin/MOM_parameter_doc.layout
+++ b/ocean_only/buoy_forced_basin/MOM_parameter_doc.layout
@@ -16,8 +16,8 @@ GLOBAL_INDEXING = False         !   [Boolean] default = False
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the the width of the halos
-                                ! that are updated with each call.
+                                ! If true, optional arguments may be used to specify the width of the halos that
+                                ! are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
                                 ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
                                 ! statically determined at compile time.  Otherwise the sizes are not determined

--- a/ocean_only/buoy_forced_basin/MOM_parameter_doc.short
+++ b/ocean_only/buoy_forced_basin/MOM_parameter_doc.short
@@ -217,8 +217,9 @@ MAXTRUNC = 400                  !   [truncations save_interval-1] default = 0
 VARIABLE_WINDS = False          !   [Boolean] default = True
                                 ! If true, the winds vary in time after the initialization.
 BUOY_CONFIG = "BFB"             ! default = "zero"
-                                ! The character string that indicates how buoyancy forcing is specified. Valid
-                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified.  Valid
+                                ! options include (file), (data_override), (zero), (const), (linear), (MESO),
+                                ! (SCM_CVmix_tests), (BFB), (dumbbell), (USER) and (NONE).
 RESTOREBUOY = True              !   [Boolean] default = False
                                 ! If true, the buoyancy fluxes drive the model back toward some specified
                                 ! surface state with a rate given by FLUXCONST.

--- a/ocean_only/global/MOM_parameter_doc.all
+++ b/ocean_only/global/MOM_parameter_doc.all
@@ -1896,8 +1896,9 @@ VARIABLE_BUOYFORCE = True       !   [Boolean] default = True
                                 ! If true, the buoyancy forcing varies in time after the initialization of the
                                 ! model.
 BUOY_CONFIG = "file"            ! default = "zero"
-                                ! The character string that indicates how buoyancy forcing is specified. Valid
-                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified.  Valid
+                                ! options include (file), (data_override), (zero), (const), (linear), (MESO),
+                                ! (SCM_CVmix_tests), (BFB), (dumbbell), (USER) and (NONE).
 ARCHAIC_OMIP_FORCING_FILE = False !   [Boolean] default = True
                                 ! If true, use the forcing variable decomposition from the old German OMIP
                                 ! prescription that predated CORE. If false, use the variable groupings
@@ -1955,8 +1956,10 @@ SST_RESTORE_VAR = "SST"         ! default = "SST"
 SSS_RESTORE_VAR = "SSS"         ! default = "SSS"
                                 ! The variable with the SSS toward which to restore.
 WIND_CONFIG = "file"            ! default = "zero"
-                                ! The character string that indicates how wind forcing is specified. Valid
-                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified.  Valid
+                                ! options include (file), (data_override), (2gyre), (1gyre), (gyres), (zero),
+                                ! (const), (Neverworld), (scurves), (ideal_hurr), (SCM_ideal_hurr),
+                                ! (SCM_CVmix_tests) and (USER).
 WIND_FILE = "ocean_forcing_daily.nc" !
                                 ! The file in which the wind stresses are found in variables STRESS_X and
                                 ! STRESS_Y.

--- a/ocean_only/global/MOM_parameter_doc.layout
+++ b/ocean_only/global/MOM_parameter_doc.layout
@@ -16,8 +16,8 @@ GLOBAL_INDEXING = False         !   [Boolean] default = False
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the the width of the halos
-                                ! that are updated with each call.
+                                ! If true, optional arguments may be used to specify the width of the halos that
+                                ! are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
                                 ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
                                 ! statically determined at compile time.  Otherwise the sizes are not determined

--- a/ocean_only/global/MOM_parameter_doc.short
+++ b/ocean_only/global/MOM_parameter_doc.short
@@ -528,8 +528,9 @@ ENERGYSAVEDAYS = 0.5            !   [days] default = 1.0
 
 ! === module MOM_surface_forcing ===
 BUOY_CONFIG = "file"            ! default = "zero"
-                                ! The character string that indicates how buoyancy forcing is specified. Valid
-                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified.  Valid
+                                ! options include (file), (data_override), (zero), (const), (linear), (MESO),
+                                ! (SCM_CVmix_tests), (BFB), (dumbbell), (USER) and (NONE).
 ARCHAIC_OMIP_FORCING_FILE = False !   [Boolean] default = True
                                 ! If true, use the forcing variable decomposition from the old German OMIP
                                 ! prescription that predated CORE. If false, use the variable groupings
@@ -565,8 +566,10 @@ SALINITYRESTORE_FILE = "ocean_forcing_daily.nc" !
                                 ! The file with the surface salinity toward which to restore in the variable
                                 ! given by SSS_RESTORE_VAR.
 WIND_CONFIG = "file"            ! default = "zero"
-                                ! The character string that indicates how wind forcing is specified. Valid
-                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified.  Valid
+                                ! options include (file), (data_override), (2gyre), (1gyre), (gyres), (zero),
+                                ! (const), (Neverworld), (scurves), (ideal_hurr), (SCM_ideal_hurr),
+                                ! (SCM_CVmix_tests) and (USER).
 WIND_FILE = "ocean_forcing_daily.nc" !
                                 ! The file in which the wind stresses are found in variables STRESS_X and
                                 ! STRESS_Y.

--- a/ocean_only/idealized_hurricane/MOM_parameter_doc.all
+++ b/ocean_only/idealized_hurricane/MOM_parameter_doc.all
@@ -1633,14 +1633,17 @@ VARIABLE_BUOYFORCE = True       !   [Boolean] default = True
                                 ! If true, the buoyancy forcing varies in time after the initialization of the
                                 ! model.
 BUOY_CONFIG = "const"           ! default = "zero"
-                                ! The character string that indicates how buoyancy forcing is specified. Valid
-                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified.  Valid
+                                ! options include (file), (data_override), (zero), (const), (linear), (MESO),
+                                ! (SCM_CVmix_tests), (BFB), (dumbbell), (USER) and (NONE).
 SENSIBLE_HEAT_FLUX = 0.0        !   [W/m2]
                                 ! A constant heat forcing (positive into ocean) applied through the sensible
                                 ! heat flux field.
 WIND_CONFIG = "ideal_hurr"      ! default = "zero"
-                                ! The character string that indicates how wind forcing is specified. Valid
-                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified.  Valid
+                                ! options include (file), (data_override), (2gyre), (1gyre), (gyres), (zero),
+                                ! (const), (Neverworld), (scurves), (ideal_hurr), (SCM_ideal_hurr),
+                                ! (SCM_CVmix_tests) and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
                                 ! If true, the buoyancy fluxes drive the model back toward some specified
                                 ! surface state with a rate given by FLUXCONST.

--- a/ocean_only/idealized_hurricane/MOM_parameter_doc.layout
+++ b/ocean_only/idealized_hurricane/MOM_parameter_doc.layout
@@ -16,8 +16,8 @@ GLOBAL_INDEXING = False         !   [Boolean] default = False
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the the width of the halos
-                                ! that are updated with each call.
+                                ! If true, optional arguments may be used to specify the width of the halos that
+                                ! are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
                                 ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
                                 ! statically determined at compile time.  Otherwise the sizes are not determined

--- a/ocean_only/idealized_hurricane/MOM_parameter_doc.short
+++ b/ocean_only/idealized_hurricane/MOM_parameter_doc.short
@@ -287,14 +287,17 @@ ENERGYSAVEDAYS = 0.05           !   [days] default = 1.0
 
 ! === module MOM_surface_forcing ===
 BUOY_CONFIG = "const"           ! default = "zero"
-                                ! The character string that indicates how buoyancy forcing is specified. Valid
-                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified.  Valid
+                                ! options include (file), (data_override), (zero), (const), (linear), (MESO),
+                                ! (SCM_CVmix_tests), (BFB), (dumbbell), (USER) and (NONE).
 SENSIBLE_HEAT_FLUX = 0.0        !   [W/m2]
                                 ! A constant heat forcing (positive into ocean) applied through the sensible
                                 ! heat flux field.
 WIND_CONFIG = "ideal_hurr"      ! default = "zero"
-                                ! The character string that indicates how wind forcing is specified. Valid
-                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified.  Valid
+                                ! options include (file), (data_override), (2gyre), (1gyre), (gyres), (zero),
+                                ! (const), (Neverworld), (scurves), (ideal_hurr), (SCM_ideal_hurr),
+                                ! (SCM_CVmix_tests) and (USER).
 
 ! === module idealized_hurricane ===
 IDL_HURR_MAX_WIND = 50.0        !   [m/s] default = 65.0

--- a/ocean_only/tides_025/MOM_input
+++ b/ocean_only/tides_025/MOM_input
@@ -344,7 +344,7 @@ VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
 DT_FORCING = 3600.0             !   [s] default = 900.0
                                 ! The time step for changing forcing, coupling with other components, or
                                 ! potentially writing certain diagnostics. The default value is given by DT.
-DAYMAX = 10.0                   !   [days]
+DAYMAX = 1.0                    !   [days]
                                 ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
                                 ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.

--- a/ocean_only/tides_025/MOM_parameter_doc.all
+++ b/ocean_only/tides_025/MOM_parameter_doc.all
@@ -1194,11 +1194,14 @@ VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
                                 ! If true, the buoyancy forcing varies in time after the initialization of the
                                 ! model.
 BUOY_CONFIG = "zero"            ! default = "zero"
-                                ! The character string that indicates how buoyancy forcing is specified. Valid
-                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified.  Valid
+                                ! options include (file), (data_override), (zero), (const), (linear), (MESO),
+                                ! (SCM_CVmix_tests), (BFB), (dumbbell), (USER) and (NONE).
 WIND_CONFIG = "zero"            ! default = "zero"
-                                ! The character string that indicates how wind forcing is specified. Valid
-                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
+                                ! The character string that indicates how wind forcing is specified.  Valid
+                                ! options include (file), (data_override), (2gyre), (1gyre), (gyres), (zero),
+                                ! (const), (Neverworld), (scurves), (ideal_hurr), (SCM_ideal_hurr),
+                                ! (SCM_CVmix_tests) and (USER).
 RESTOREBUOY = False             !   [Boolean] default = False
                                 ! If true, the buoyancy fluxes drive the model back toward some specified
                                 ! surface state with a rate given by FLUXCONST.
@@ -1225,7 +1228,7 @@ LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
 DT_FORCING = 3600.0             !   [s] default = 900.0
                                 ! The time step for changing forcing, coupling with other components, or
                                 ! potentially writing certain diagnostics. The default value is given by DT.
-DAYMAX = 10.0                   !   [days]
+DAYMAX = 1.0                    !   [days]
                                 ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
                                 ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.

--- a/ocean_only/tides_025/MOM_parameter_doc.layout
+++ b/ocean_only/tides_025/MOM_parameter_doc.layout
@@ -16,8 +16,8 @@ GLOBAL_INDEXING = False         !   [Boolean] default = False
 NONBLOCKING_UPDATES = False     !   [Boolean] default = False
                                 ! If true, non-blocking halo updates may be used.
 THIN_HALO_UPDATES = True        !   [Boolean] default = True
-                                ! If true, optional arguments may be used to specify the the width of the halos
-                                ! that are updated with each call.
+                                ! If true, optional arguments may be used to specify the width of the halos that
+                                ! are updated with each call.
 !STATIC_MEMORY_ = False         !   [Boolean]
                                 ! If STATIC_MEMORY_ is defined, the principle variables will have sizes that are
                                 ! statically determined at compile time.  Otherwise the sizes are not determined

--- a/ocean_only/tides_025/MOM_parameter_doc.short
+++ b/ocean_only/tides_025/MOM_parameter_doc.short
@@ -335,7 +335,7 @@ VARIABLE_BUOYFORCE = False      !   [Boolean] default = True
 DT_FORCING = 3600.0             !   [s] default = 900.0
                                 ! The time step for changing forcing, coupling with other components, or
                                 ! potentially writing certain diagnostics. The default value is given by DT.
-DAYMAX = 10.0                   !   [days]
+DAYMAX = 1.0                    !   [days]
                                 ! The final time of the whole simulation, in units of TIMEUNIT seconds.  This
                                 ! also sets the potential end time of the present run segment if the end time is
                                 ! not set via ocean_solo_nml in input.nml.


### PR DESCRIPTION
  Updated the MOM_Parameter_doc files in test cases that are in MOM6-examples
but are not routinely run as a part of the MOM6-examples regression tests, to
reflect recent updates to the MOM6 code, and modified the MOM_input file for
the tides_025 test case to shorten it.  All answers are bitwise identical in
the typical test cases, but one of the infrequently used tests is shorter.