### PR TITLE
Change SIS_input_nml/input_filename to 'F'

### DIFF
--- a/coupled_AM2_LM3_SIS2/AM2_SIS2B_MOM6i_1deg/input.nml
+++ b/coupled_AM2_LM3_SIS2/AM2_SIS2B_MOM6i_1deg/input.nml
@@ -9,7 +9,7 @@
 
  &SIS_input_nml
         output_directory = './',
-         input_filename = 'n'
+         input_filename = 'F'
          restart_input_dir = 'INPUT/',
          restart_output_dir = 'RESTART/',
          parameter_filename = 'SIS_input',

--- a/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/input.nml
+++ b/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/input.nml
@@ -9,7 +9,7 @@
 
  &SIS_input_nml
         output_directory = './',
-         input_filename = 'n'
+         input_filename = 'F'
          restart_input_dir = 'INPUT/',
          restart_output_dir = 'RESTART/',
          parameter_filename = 'SIS_input',

--- a/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/input.nml
+++ b/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/input.nml
@@ -9,7 +9,7 @@
 
  &SIS_input_nml
         output_directory = './',
-         input_filename = 'n'
+         input_filename = 'F'
          restart_input_dir = 'INPUT/',
          restart_output_dir = 'RESTART/',
          parameter_filename = 'SIS_input',

--- a/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/input.nml
+++ b/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/input.nml
@@ -9,7 +9,7 @@
 
  &SIS_input_nml
         output_directory = './',
-         input_filename = 'n'
+         input_filename = 'F'
          restart_input_dir = 'INPUT/',
          restart_output_dir = 'RESTART/',
          parameter_filename = 'SIS_input',


### PR DESCRIPTION
  Change the values input_filename in the SIS_input_nml files for the SIS2
coupled model test cases to 'F' so that the behavior continues to be unchanged
after the SIS2 code is modified to stop ignoring these values.   All answers
are bitwise identical.

  This PR needs to be merged in before (https://github.com/NOAA-GFDL/SIS2/pull/141) can be merged in without
causing answers to change.