### PR TITLE
Add LND fields to the data_table in OM4_025.JRA

### DIFF
--- a/ice_ocean_SIS2/OM4_025.JRA/data_table
+++ b/ice_ocean_SIS2/OM4_025.JRA/data_table
@@ -18,3 +18,23 @@
  "ICE", "dhdt",               "",         "",                        "none",      80.0
  "ICE", "dedt",               "",         "",                        "none",       2.0e-6
  "ICE", "drdt",               "",         "",                        "none",      10.0
+ "LND", "t_surf",             "",         "",                        "none",     273.0
+ "LND", "t_ca",               "",         "",                        "none",     273.0
+ "LND", "q_ca",               "",         "",                        "none",       0.0
+ "LND", "rough_mom",          "",         "",                        "none",       0.01
+ "LND", "rough_heat",         "",         "",                        "none",       0.1
+ "LND", "albedo",             "",         "",                        "none",       0.1
+ "LND", "sphum_surf",         "",         "",                        "none",       0.0
+ "LND", "sphum_ca",           "",         "",                        "none",       0.0
+ "LND", "t_flux",             "",         "",                        "none",       0.0
+ "LND", "sphum_flux",         "",         "",                        "none",       0.0
+ "LND", "lw_flux",            "",         "",                        "none",       0.0
+ "LND", "sw_flux",            "",         "",                        "none",       0.0
+ "LND", "lprec",              "",         "",                        "none",       0.0
+ "LND", "fprec",              "",         "",                        "none",       0.0
+ "LND", "dhdt",               "",         "",                        "none",       5.0
+ "LND", "dedt",               "",         "",                        "none",       2e-6
+ "LND", "dedq",               "",         "",                        "none",       0.0
+ "LND", "drdt",               "",         "",                        "none",       5.0
+ "LND", "drag_q",             "",         "",                        "none",       0.0
+ "LND", "p_surf",             "",         "",                        "none",       1.e5


### PR DESCRIPTION
 -The OM4_025.JRA data_table did not include land model fields. This was causing roughness elements to be set to "0", which caused the model to fail in the monin obukhov routines in debug mode due to divide by zero errors.
 -The new addition of "LND" module components is copied from the OM4_025 data table and does not change answers, but does allow the configuration to be run with debug compiler options on by eliminating the divide by zero errors in the coupler on land cells.