### PR TITLE
Set ADD_DIURNAL_SW to False in ice_ocean_SIS2/OM4_025.JRA

### DIFF
--- a/ice_ocean_SIS2/OM4_025.JRA/SIS_input
+++ b/ice_ocean_SIS2/OM4_025.JRA/SIS_input
@@ -17,6 +17,9 @@ CONSTANT_COSZEN_IC = 0.0        !   [nondim] default = -1.0
                                 ! astronomy.
 DO_ICEBERGS = True              !   [Boolean] default = False
                                 ! If true, call the iceberg module.
+! ADD_DIURNAL_SW should only be true if the model is forced with a product that does not include SW forcing!
+ADD_DIURNAL_SW = False          !   [Boolean] default = False
+                                ! If true, add a synthetic diurnal cycle to the shortwave radiation.
 
 ! === module MOM_domains ===
 TRIPOLAR_N = True               !   [Boolean] default = False

--- a/ice_ocean_SIS2/OM4_025.JRA/SIS_override
+++ b/ice_ocean_SIS2/OM4_025.JRA/SIS_override
@@ -1,5 +1,1 @@
 ! Blank file in which we can put "overrides" for parameters
-
-! This must ONLY be used in the ice-ocean mode, NOT fully coupled mode.
-ADD_DIURNAL_SW = True           !   [Boolean] default = False
-                                ! If true, add a synthetic diurnal cycle to the shortwave radiation.


### PR DESCRIPTION
- This flag was flipped to True in SIS_override in JRA mode by mistake, as the JRA forcing product already includes the SW term explicitly.
- This commit fixes this setting by removing this flag from SIS_override and now explicitly setting it to be False in SIS_input.