### PR TITLE
Explicit module loading

### DIFF
--- a/tools/MRS/Makefile.build
+++ b/tools/MRS/Makefile.build
@@ -71,28 +71,39 @@ $(foreach c, $(COMPILERS),$(foreach m,$(MODES),$(eval $(call make-env-dep,$c,$m)
 ifeq ($(SITE),ncrc)
 $(BUILD)/gnu/env:
 	mkdir -p $(@D)
-	echo 'source /opt/modules/default/etc/modules.sh' > $@
-	echo 'module use -a /ncrc/home2/fms/local/modulefiles' >> $@
-	echo 'MODULEPATH=/usw/eslogin/modulefiles-c4:/sw/eslogin-c4/modulefiles:/opt/cray/pe/ari/modulefiles:/opt/cray/ari/modulefiles:/opt/cray/pe/modulefiles:/opt/cray/modulefiles:/opt/modulefiles:/sw/common/modulefiles' >> $@
-	echo 'module unload PrgEnv-pgi PrgEnv-intel PrgEnv-gnu darshan; module load PrgEnv-gnu; module unload netcdf gcc; module load $(shell jq -r '.gnu.version' labels.json 2> /dev/null || echo gcc/7.3.0) cray-hdf5 cray-netcdf' >> $@
+	echo 'module purge' > $@
+	echo 'source /opt/cray/pe/modules/default/etc/modules.sh' >> $@
+	echo 'module use /opt/cray/pe/craype-targets/default/modulefiles' >> $@
+	echo 'module load craype-network-aries eproxy' >> $@
+	echo 'module load PrgEnv-gnu craype-broadwell cray-mpich' >> $@
+	echo 'module unload gcc; module load $(shell jq -r '.gnu.version' labels.json 2> /dev/null || echo gcc/7.3.0)' >> $@
+	echo 'module load cray-hdf5 cray-netcdf' >> $@
 $(BUILD)/intel/env:
 	mkdir -p $(@D)
-	echo 'source /opt/modules/default/etc/modules.sh' > $@
-	echo 'module use -a /ncrc/home2/fms/local/modulefiles' >> $@
-	echo 'MODULEPATH=/usw/eslogin/modulefiles-c4:/sw/eslogin-c4/modulefiles:/opt/cray/pe/ari/modulefiles:/opt/cray/ari/modulefiles:/opt/cray/pe/modulefiles:/opt/cray/modulefiles:/opt/modulefiles:/sw/common/modulefiles' >> $@
-	echo 'module unload PrgEnv-pgi PrgEnv-intel PrgEnv-gnu darshan; module load PrgEnv-intel; module unload netcdf intel; module load $(shell jq -r '.intel.version' labels.json 2> /dev/null || echo intel/18.0.6.288) cray-hdf5 cray-netcdf' >> $@
+	echo 'module purge' > $@
+	echo 'source /opt/cray/pe/modules/default/etc/modules.sh' >> $@
+	echo 'module use /opt/cray/pe/craype-targets/default/modulefiles' >> $@
+	echo 'module load craype-network-aries eproxy' >> $@
+	echo 'module load PrgEnv-intel craype-broadwell cray-mpich' >> $@
+	echo 'module unload intel; module load $(shell jq -r '.intel.version' labels.json 2> /dev/null || echo intel/18.0.6.288)' >> $@
+	echo 'module load cray-hdf5 cray-netcdf' >> $@
 $(BUILD)/pgi/env:
 	mkdir -p $(@D)
-	echo 'source /opt/modules/default/etc/modules.sh' > $@
-	echo 'module use -a /ncrc/home2/fms/local/modulefiles' >> $@
-	echo 'MODULEPATH=/usw/eslogin/modulefiles-c4:/sw/eslogin-c4/modulefiles:/opt/cray/pe/ari/modulefiles:/opt/cray/ari/modulefiles:/opt/cray/pe/modulefiles:/opt/cray/modulefiles:/opt/modulefiles:/sw/common/modulefiles' >> $@
-	echo 'module unload PrgEnv-intel ; module load PrgEnv-pgi darshan; module unload netcdf pgi; module load $(shell jq -r '.pgi.version' labels.json 2> /dev/null || echo pgi/19.10.0) cray-hdf5 cray-netcdf' >> $@
+	echo 'module purge' > $@
+	echo 'source /opt/cray/pe/modules/default/etc/modules.sh' >> $@
+	echo 'module use /opt/cray/pe/craype-targets/default/modulefiles' >> $@
+	echo 'module load craype-network-aries eproxy' >> $@
+	echo 'module load PrgEnv-pgi craype-broadwell cray-mpich' >> $@
+	echo 'module unload pgi; module load $(shell jq -r '.pgi.version' labels.json 2> /dev/null || echo pgi/19.10.0)' >> $@
+	echo 'module load cray-hdf5 cray-netcdf' >> $@
 $(BUILD)/cray/env:
 	mkdir -p $(@D)
-	echo 'source /opt/modules/default/etc/modules.sh' > $@
-	echo 'module use -a /ncrc/home2/fms/local/modulefiles' >> $@
-	echo 'MODULEPATH=/usw/eslogin/modulefiles-c4:/sw/eslogin-c4/modulefiles:/opt/cray/pe/ari/modulefiles:/opt/cray/ari/modulefiles:/opt/cray/pe/modulefiles:/opt/cray/modulefiles:/opt/modulefiles:/sw/common/modulefiles' >> $@
-	echo 'module unload PrgEnv-intel ; module load PrgEnv-cray darshan; module unload netcdf pgi; module load cray-hdf5 cray-netcdf' >> $@
+	echo 'module purge' > $@
+	echo 'source /opt/cray/pe/modules/default/etc/modules.sh' >> $@
+	echo 'module use /opt/cray/pe/craype-targets/default/modulefiles' >> $@
+	echo 'module load craype-network-aries eproxy' >> $@
+	echo 'module load PrgEnv-cray craype-broadwell cray-mpich' >> $@
+	echo 'module load cray-hdf5 cray-netcdf' >> $@
 else
 $(BUILD)/gnu/env:
 	mkdir -p $(@D)


### PR DESCRIPTION
A change to the Gaea module environment was corrupting the user's
environment in the MOM gitlab testing, causing all module commands to
fail and making it impossible to build and run the models.

This may be caused by the introduction of `readonly` variables in the
`/etc/bash.bashrc.local` file, which prevented critical modules from
being loaded (presumably to prevent double `module load` statements).
It is possible these were incorrectly inherited to noninteractive Gaea
sessions.

This patch introduces a more explicit module setup.  The process is
described below in more detail, in case further changes are needed.

1. module purge

   Clear out any existing modules (but not the readonly flags)

2. source /opt/cray/pe/modules/default/etc/modules.sh

   Bootstrap the module system and add and following modulepaths:

     - /opt/modulefiles: Compilers
     - /opt/cray/modulefiles: Lower level filesystem
     - /opt/cray/pe/modulefiles: PrgEnv-* and libraries

3. Load the following modules:

     - craype-network-aries
     - eproxy
     - PrgEnv-${compiler}
     - craype-broadwell
     - cray-mpich

4. Select compiler version and load the version-dependent modules:

     - cray-hdf5
     - cray-netcdf

Much of this process replicates the steps in `/etc/bash.bashrc.local`.

Advantages to this approach:
- It works.
- It creates a more minimal and predictable environment.

Disadvantages:
- Paths to modules.sh and modulefiles are hard-coded and need updates.
- The list of required modules may change over time.