### PR TITLE
MRS shorter logs

### DIFF
--- a/tools/MRS/Makefile.coverage
+++ b/tools/MRS/Makefile.coverage
@@ -48,7 +48,7 @@ $(CONFIGS)/$(2)/%/ocean.stats.$(1): $(BUILD)/$(1)/$$(MODE)/$$(MEMORY)/$(2)/MOM6 
 	cd $$(@D) && rm -rf Depth_list.nc CPU_stats.$(1) time_stamp.out $$(@F) RESTART FAIL && mkdir RESTART
 	cd $$(@D) && tic=$$$$(date +%s) && \
 	(OMP_NUM_THREADS=1 KMP_STACKSIZE=512m NC_BLKSZ=1M time $(MPIRUN) -n $$(NPES) $$(call rel_path,$$(@D))$(BUILD)/$(1)/$$(MODE)/$$(MEMORY)/$(2)/MOM6 > log.$(1).out || touch FAIL;) \
-	2>&1 | egrep -v "ing coupler_init| initializ|ing " | sed 's,^,$$@: ,' ; toc=$$$$(date +%s) ; echo $$$$(($$$$toc-$$$$tic)) > walltime.$(1).out
+	2>&1 | egrep -v 'ing coupler_init| initializ|ing |CHECKSUM::|^ *$$$$' | sed 's,^,$$@: ,' ; toc=$$$$(date +%s) ; echo $$$$(($$$$toc-$$$$tic)) > walltime.$(1).out
 	cd $$(@D); (time $$(call rel_path,$$(@D))$(BUILD)/lcov/bin/lcov -q -t $$(call test_name,$$@) -c -d $$(call rel_path,$$(@D))$(BUILD)/$(1)/$$(MODE)/$$(MEMORY)/$$(call mom6_objects,$(2)) -o lcov.info &> /dev/null) &> lcov.log
 	@test -f $$(@D)/FAIL && exit 9 || true
 endef

--- a/tools/MRS/Makefile.restart
+++ b/tools/MRS/Makefile.restart
@@ -54,14 +54,14 @@ $(CONFIGS)/$(2)/%/02.ignore/ocean.stats.$(1): $(BUILD)/$(1)/$$(MODE)/$$(MEMORY)/
 	cd $$(@D) && rm -rf Depth_list.nc CPU_stats.$(1) time_stamp.out $$(@F) RESTART FAIL && mkdir RESTART
 	cd $$(@D) && tic=$$$$(date +%s) && \
 	(OMP_NUM_THREADS=1 KMP_STACKSIZE=512m NC_BLKSZ=1M time $(MPIRUN) -n $$(NPES) $$(call rel_path,$$(@D))$(BUILD)/$(1)/$$(MODE)/$$(MEMORY)/$(2)/MOM6 > log.$(1).out || touch FAIL;) \
-	2>&1 | tee std.err |  egrep -v "ing coupler_init| initializ|ing " | sed 's,^,$$@: ,' && toc=$$$$(date +%s) && echo $$$$(($$$$toc-$$$$tic)) > walltime.$(1).out
+	2>&1 | tee std.err |  egrep -v 'ing coupler_init| initializ|ing |CHECKSUM::|^ *$$$$' | sed 's,^,$$@: ,' && toc=$$$$(date +%s) && echo $$$$(($$$$toc-$$$$tic)) > walltime.$(1).out
 	@test -f $$(@D)/FAIL && exit 9 || true
 $(CONFIGS)/$(2)/%/01.ignore/ocean.stats.$(1): $(BUILD)/$(1)/$$(MODE)/$$(MEMORY)/$(2)/MOM6 $(CONFIGS)/$(2)/%/01.ignore/input.nml $(CONFIGS)/$(2)/%/01.ignore/MOM_input $(CONFIGS)/$(2)/%/01.ignore/MOM_override
 	echo $(BUILD)/$(1)/$$(MODE)/$$(MEMORY)/$(2)/MOM6"("$$(NPES)")" "=>" $$@
 	cd $$(@D) && rm -rf Depth_list.nc CPU_stats.$(1) time_stamp.out $$(@F) RESTART FAIL && mkdir RESTART
 	cd $$(@D) && tic=$$$$(date +%s) && \
 	(OMP_NUM_THREADS=1 KMP_STACKSIZE=512m NC_BLKSZ=1M time $(MPIRUN) -n $$(NPES) $$(call rel_path,$$(@D))$(BUILD)/$(1)/$$(MODE)/$$(MEMORY)/$(2)/MOM6 > log.$(1).out || touch FAIL;) \
-	2>&1 | tee std.err |  egrep -v "ing coupler_init| initializ|ing " | sed 's,^,$$@: ,' && toc=$$$$(date +%s) && echo $$$$(($$$$toc-$$$$tic)) > walltime.$(1).out
+	2>&1 | tee std.err |  egrep -v 'ing coupler_init| initializ|ing |CHECKSUM::|^ *$$$$' | sed 's,^,$$@: ,' && toc=$$$$(date +%s) && echo $$$$(($$$$toc-$$$$tic)) > walltime.$(1).out
 	@test -f $$(@D)/FAIL && exit 9 || true
 $(CONFIGS)/$(2)/%/12.ignore/ocean.stats.$(1): $(BUILD)/$(1)/$$(MODE)/$$(MEMORY)/$(2)/MOM6 $(CONFIGS)/$(2)/%/12.ignore/input.nml $(CONFIGS)/$(2)/%/12.ignore/MOM_input $(CONFIGS)/$(2)/%/12.ignore/MOM_override $(CONFIGS)/$(2)/%/01.ignore/ocean.stats.$(1)
 	echo $(BUILD)/$(1)/$$(MODE)/$$(MEMORY)/$(2)/MOM6"("$$(NPES)")" "=>" $$@
@@ -69,7 +69,7 @@ $(CONFIGS)/$(2)/%/12.ignore/ocean.stats.$(1): $(BUILD)/$(1)/$$(MODE)/$$(MEMORY)/
 	cd $$(@D) && mkdir -p INPUT ; cd INPUT && ln -sf ../../01.ignore/RESTART/* .
 	cd $$(@D) && tic=$$$$(date +%s) && \
 	(OMP_NUM_THREADS=1 KMP_STACKSIZE=512m NC_BLKSZ=1M time $(MPIRUN) -n $$(NPES) $$(call rel_path,$$(@D))$(BUILD)/$(1)/$$(MODE)/$$(MEMORY)/$(2)/MOM6 > log.$(1).out || touch FAIL;) \
-	2>&1 | tee std.err | egrep -v "ing coupler_init| initializ|ing " | sed 's,^,$$@: ,' && toc=$$$$(date +%s) && echo $$$$(($$$$toc-$$$$tic)) > walltime.$(1).out
+	2>&1 | tee std.err | egrep -v 'ing coupler_init| initializ|ing |CHECKSUM::|^ *$$$$' | sed 's,^,$$@: ,' && toc=$$$$(date +%s) && echo $$$$(($$$$toc-$$$$tic)) > walltime.$(1).out
 	@test -f $$(@D)/FAIL && exit 9 || true
 endef
 $(foreach c,gnu intel pgi,$(foreach o,ocean_only ice_ocean_SIS2 land_ice_ocean_LM3_SIS2 coupled_AM2_LM3_SIS coupled_AM2_LM3_SIS2,$(eval $(call run-dynamic-model,$(c),$(o)))))

--- a/tools/MRS/Makefile.run
+++ b/tools/MRS/Makefile.run
@@ -47,7 +47,7 @@ $(CONFIGS)/%/ocean.stats.$(1): $(CONFIGS)/%/input.nml $(CONFIGS)/%/MOM_input $(C
 	cd $$(@D) && rm -rf Depth_list.nc CPU_stats.$(1) time_stamp.out $$(@F) RESTART FAIL U_velocity_truncations V_velocity_truncations && mkdir RESTART
 	cd $$(@D) && tic=$$$$(date +%s) && \
 	(OMP_NUM_THREADS=1 KMP_STACKSIZE=512m NC_BLKSZ=1M time $(MPIRUN) -n $$(STATIC_NPES) $$(call rel_path,$$(@D))$(BUILD)/$(1)/$$(MODE)/static/$$*/MOM6 > log.$(1).out || touch FAIL;) \
-	2>&1 | egrep -v "ing coupler_init| initializ|ing " | sed 's,^,$$@: ,' ; toc=$$$$(date +%s) ; echo $$$$(($$$$toc-$$$$tic)) > walltime.$(1).out
+	2>&1 | egrep -v 'ing coupler_init| initializ|ing |CHECKSUM::|^ *$$$$' | sed 's,^,$$@: ,' ; toc=$$$$(date +%s) ; echo $$$$(($$$$toc-$$$$tic)) > walltime.$(1).out
 	@test -f $$(@D)/FAIL && exit 9 || true
 endef
 $(foreach c,$(COMPILERS),$(eval $(call run-static-model,$(c))))
@@ -67,7 +67,7 @@ $(CONFIGS)/$(2)/%/ocean.stats.$(1): $(BUILD)/$(1)/$$(MODE)/$$(MEMORY)/$(2)/MOM6 
 	cd $$(@D) && rm -rf Depth_list.nc CPU_stats.$(1) time_stamp.out $$(@F) RESTART FAIL U_velocity_truncations V_velocity_truncations && mkdir RESTART
 	cd $$(@D) && tic=$$$$(date +%s) && \
 	(OMP_NUM_THREADS=1 KMP_STACKSIZE=512m NC_BLKSZ=1M time $(MPIRUN) -n $$(ALT_NPES) $$(call rel_path,$$(@D))$(BUILD)/$(1)/$$(MODE)/$$(MEMORY)/$(2)/MOM6 > log.$(1).out || touch FAIL;) \
-	2>&1 | egrep -v "ing coupler_init| initializ|ing " | sed 's,^,$$@: ,' ; toc=$$$$(date +%s) ; echo $$$$(($$$$toc-$$$$tic)) > walltime.$(1).out
+	2>&1 | egrep -v 'ing coupler_init| initializ|ing |CHECKSUM::|^ *$$$$' | sed 's,^,$$@: ,' ; toc=$$$$(date +%s) ; echo $$$$(($$$$toc-$$$$tic)) > walltime.$(1).out
 	@test -f $$(@D)/FAIL && exit 9 || true
 endef
 $(foreach c,$(COMPILERS),$(foreach o,ocean_only ice_ocean_SIS2 land_ice_ocean_LM3_SIS2 coupled_AM2_LM3_SIS coupled_AM2_LM3_SIS2,$(eval $(call run-dynamic-model,$(c),$(o)))))
@@ -83,7 +83,7 @@ $(CONFIGS)/$(2)/%/ocean.stats.$(1): $(BUILD)/$(1)/$$(MODE)/$$(MEMORY)/$(2)/MOM6 
 	cd $$(@D) && rm -rf Depth_list.nc CPU_stats.$(1) time_stamp.out $$(@F) RESTART FAIL U_velocity_truncations V_velocity_truncations && mkdir RESTART
 	cd $$(@D) && tic=$$$$(date +%s) && \
 	(OMP_NUM_THREADS=1 KMP_STACKSIZE=512m NC_BLKSZ=1M time $(MPIRUN) -n $$(NPES) $$(call rel_path,$$(@D))$(BUILD)/$(1)/$$(MODE)/$$(MEMORY)/$(2)/MOM6 > log.$(1).out || touch FAIL;) \
-	2>&1 | egrep -v "ing coupler_init| initializ|ing " | sed 's,^,$$@: ,' ; toc=$$$$(date +%s) ; echo $$$$(($$$$toc-$$$$tic)) > walltime.$(1).out
+	2>&1 | egrep -v 'ing coupler_init| initializ|ing |CHECKSUM::|^ *$$$$' | sed 's,^,$$@: ,' ; toc=$$$$(date +%s) ; echo $$$$(($$$$toc-$$$$tic)) > walltime.$(1).out
 	@test -f $$(@D)/FAIL && exit 9 || true
 endef
 $(foreach c,$(COMPILERS),$(foreach o,ocean_only ice_ocean_SIS2 land_ice_ocean_LM3_SIS2 coupled_AM2_LM3_SIS coupled_AM2_LM3_SIS2,$(eval $(call run-dynamic-model,$(c),$(o)))))


### PR DESCRIPTION
Filters out additional lines from model stdout, such as blank links and the CHECKSUMS, to help highlight the meaningful output