### PR TITLE
fix for downsampled filenames and test of dims of vmo sym/nonsym

### DIFF
--- a/tools/analysis/MOM6_refineDiag.csh
+++ b/tools/analysis/MOM6_refineDiag.csh
@@ -114,6 +114,9 @@ echo '==== Offline Diagnostics ===='
 if ( -f $yr1.ocean_month.nc ) then
   $script_dir/refineDiag_ocean_month.py -b $basin_codes_file -r $refineDiagDir $yr1.ocean_month.nc
 endif
+if ( -f $yr1.ocean_monthly.nc ) then
+  $script_dir/refineDiag_ocean_month.py -b $basin_codes_file -r $refineDiagDir $yr1.ocean_monthly.nc
+endif
 if ( -f $yr1.ocean_month_z.nc ) then
   $script_dir/refineDiag_ocean_month_z.py -b $basin_codes_file -r $refineDiagDir -s ./ $yr1.ocean_month_z.nc
 endif
@@ -133,6 +136,20 @@ endif
 if ( -f $yr1.ocean_month_rho2_d2.nc ) then
   ncatted -a associated_files,global,c,c,"areacello: $yr1.ocean_static_d2.nc" $yr1.ocean_month_rho2_d2.nc
   $script_dir/refineDiag_ocean_month_rho2.py -b $basin_codes_d2_file -r $refineDiagDir $yr1.ocean_month_rho2_d2.nc
+endif
+
+# New runs use this naming convention as a workaround for frepp
+if ( -f $yr1.D2ocean_month.nc ) then
+  ncatted -a associated_files,global,c,c,"areacello: $yr1.D2ocean_static.nc" $yr1.D2ocean_month.nc
+  $script_dir/refineDiag_ocean_month.py -b $basin_codes_d2_file -r $refineDiagDir $yr1.D2ocean_month.nc
+endif
+if ( -f $yr1.D2ocean_month_z.nc ) then
+  ncatted -a associated_files,global,c,c,"areacello: $yr1.D2ocean_static.nc" $yr1.D2ocean_month_z.nc
+  $script_dir/refineDiag_ocean_month_z.py -b $basin_codes_d2_file -r $refineDiagDir -s ./ $yr1.D2ocean_month_z.nc
+endif
+if ( -f $yr1.D2ocean_month_rho2.nc ) then
+  ncatted -a associated_files,global,c,c,"areacello: $yr1.D2ocean_static.nc" $yr1.D2ocean_month_rho2.nc
+  $script_dir/refineDiag_ocean_month_rho2.py -b $basin_codes_d2_file -r $refineDiagDir $yr1.D2ocean_month_rho2.nc
 endif
 
 

--- a/tools/analysis/refineDiag_ocean_month.py
+++ b/tools/analysis/refineDiag_ocean_month.py
@@ -43,7 +43,7 @@ def heat_trans_by_basin(x,mask=None,lat=None,minlat=None):
         assert len(mask.shape) == 2, 'mask should be 2 dimensions'
         assert len(x.shape) == 2 or len(x.shape) == 3, 'data should be 2 or 3 dimensions'
         # symmetric case
-        if x.shape[-2:][1] == 1+mask.shape[1] and x.shape[-2:][0] == 1+mask.shape[0]:
+        if x.shape[-2:][0] == 1+mask.shape[0]:
             mask=np.append(mask,np.zeros((1,mask.shape[1])),axis=0)
         varmask = np.sum(mask,axis=-1)
         varmask = np.expand_dims(varmask,0)


### PR DESCRIPTION
2 minor fixes for post-processing at GFDL.

* new runs use different naming convention for downsampled files. Add block to handle this.
* test for symmetric array was written for data on h-point, fails to detect symmetric vmo