### PR TITLE
*Avoid using buggy or deprecated options in tests

### DIFF
--- a/coupled_AM2_LM3_SIS2/AM2_SIS2B_MOM6i_1deg/MOM_input
+++ b/coupled_AM2_LM3_SIS2/AM2_SIS2B_MOM6i_1deg/MOM_input
@@ -217,6 +217,10 @@ Z_INIT_SEPARATE_MIXED_LAYER = True !   [Boolean] default = False
                                 ! If true, distribute the topmost Z_INIT_HMIX_DEPTH of water over NKML layers,
                                 ! and do not correct the density of the topmost NKML+NKBL layers.  Otherwise all
                                 ! layers are initialized based on the depths of their target densities.
+LAYER_Z_INIT_IC_EXTRAP_BUG = False !   [Boolean] default = True
+                                ! If true use an expression with a vertical indexing bug for extrapolating the
+                                ! densities at the bottom of unstable profiles from data when finding the
+                                ! initial interface locations in layered mode from a dataset of T and S.
 
 ! === module MOM_diag_mediator ===
 

--- a/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/MOM_input
+++ b/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/MOM_input
@@ -217,6 +217,10 @@ Z_INIT_SEPARATE_MIXED_LAYER = True !   [Boolean] default = False
                                 ! If true, distribute the topmost Z_INIT_HMIX_DEPTH of water over NKML layers,
                                 ! and do not correct the density of the topmost NKML+NKBL layers.  Otherwise all
                                 ! layers are initialized based on the depths of their target densities.
+LAYER_Z_INIT_IC_EXTRAP_BUG = False !   [Boolean] default = True
+                                ! If true use an expression with a vertical indexing bug for extrapolating the
+                                ! densities at the bottom of unstable profiles from data when finding the
+                                ! initial interface locations in layered mode from a dataset of T and S.
 
 ! === module MOM_diag_mediator ===
 

--- a/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/MOM_parameter_doc.all
+++ b/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/MOM_parameter_doc.all
@@ -543,7 +543,7 @@ Z_INIT_SEPARATE_MIXED_LAYER = True !   [Boolean] default = False
 Z_INIT_HMIX_DEPTH = 0.5         !   [m] default = 0.5
                                 ! The mixed layer depth in the initial conditions when
                                 ! Z_INIT_SEPARATE_MIXED_LAYER is set to true.
-LAYER_Z_INIT_IC_EXTRAP_BUG = True !   [Boolean] default = True
+LAYER_Z_INIT_IC_EXTRAP_BUG = False !   [Boolean] default = True
                                 ! If true use an expression with a vertical indexing bug for extrapolating the
                                 ! densities at the bottom of unstable profiles from data when finding the
                                 ! initial interface locations in layered mode from a dataset of T and S.

--- a/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/MOM_parameter_doc.short
+++ b/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/MOM_parameter_doc.short
@@ -177,6 +177,10 @@ Z_INIT_SEPARATE_MIXED_LAYER = True !   [Boolean] default = False
                                 ! If true, distribute the topmost Z_INIT_HMIX_DEPTH of water over NKML layers,
                                 ! and do not correct the density of the topmost NKML+NKBL layers.  Otherwise all
                                 ! layers are initialized based on the depths of their target densities.
+LAYER_Z_INIT_IC_EXTRAP_BUG = False !   [Boolean] default = True
+                                ! If true use an expression with a vertical indexing bug for extrapolating the
+                                ! densities at the bottom of unstable profiles from data when finding the
+                                ! initial interface locations in layered mode from a dataset of T and S.
 
 ! === module MOM_diag_mediator ===
 

--- a/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/MOM_input
+++ b/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/MOM_input
@@ -179,6 +179,10 @@ Z_INIT_SEPARATE_MIXED_LAYER = True !   [Boolean] default = False
                                 ! If true, distribute the topmost Z_INIT_HMIX_DEPTH of water over NKML layers,
                                 ! and do not correct the density of the topmost NKML+NKBL layers.  Otherwise all
                                 ! layers are initialized based on the depths of their target densities.
+LAYER_Z_INIT_IC_EXTRAP_BUG = False !   [Boolean] default = True
+                                ! If true use an expression with a vertical indexing bug for extrapolating the
+                                ! densities at the bottom of unstable profiles from data when finding the
+                                ! initial interface locations in layered mode from a dataset of T and S.
 
 ! === module MOM_diag_mediator ===
 

--- a/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/MOM_parameter_doc.all
+++ b/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/MOM_parameter_doc.all
@@ -543,7 +543,7 @@ Z_INIT_SEPARATE_MIXED_LAYER = True !   [Boolean] default = False
 Z_INIT_HMIX_DEPTH = 0.5         !   [m] default = 0.5
                                 ! The mixed layer depth in the initial conditions when
                                 ! Z_INIT_SEPARATE_MIXED_LAYER is set to true.
-LAYER_Z_INIT_IC_EXTRAP_BUG = True !   [Boolean] default = True
+LAYER_Z_INIT_IC_EXTRAP_BUG = False !   [Boolean] default = True
                                 ! If true use an expression with a vertical indexing bug for extrapolating the
                                 ! densities at the bottom of unstable profiles from data when finding the
                                 ! initial interface locations in layered mode from a dataset of T and S.

--- a/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/MOM_parameter_doc.short
+++ b/coupled_AM2_LM3_SIS2/Concurrent_ice_1deg/MOM_parameter_doc.short
@@ -170,6 +170,10 @@ Z_INIT_SEPARATE_MIXED_LAYER = True !   [Boolean] default = False
                                 ! If true, distribute the topmost Z_INIT_HMIX_DEPTH of water over NKML layers,
                                 ! and do not correct the density of the topmost NKML+NKBL layers.  Otherwise all
                                 ! layers are initialized based on the depths of their target densities.
+LAYER_Z_INIT_IC_EXTRAP_BUG = False !   [Boolean] default = True
+                                ! If true use an expression with a vertical indexing bug for extrapolating the
+                                ! densities at the bottom of unstable profiles from data when finding the
+                                ! initial interface locations in layered mode from a dataset of T and S.
 
 ! === module MOM_diag_mediator ===
 

--- a/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/MOM_input
+++ b/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/MOM_input
@@ -182,6 +182,10 @@ Z_INIT_SEPARATE_MIXED_LAYER = True !   [Boolean] default = False
                                 ! If true, distribute the topmost Z_INIT_HMIX_DEPTH of water over NKML layers,
                                 ! and do not correct the density of the topmost NKML+NKBL layers.  Otherwise all
                                 ! layers are initialized based on the depths of their target densities.
+LAYER_Z_INIT_IC_EXTRAP_BUG = False !   [Boolean] default = True
+                                ! If true use an expression with a vertical indexing bug for extrapolating the
+                                ! densities at the bottom of unstable profiles from data when finding the
+                                ! initial interface locations in layered mode from a dataset of T and S.
 
 ! === module MOM_diag_mediator ===
 

--- a/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/MOM_parameter_doc.all
+++ b/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/MOM_parameter_doc.all
@@ -543,7 +543,7 @@ Z_INIT_SEPARATE_MIXED_LAYER = True !   [Boolean] default = False
 Z_INIT_HMIX_DEPTH = 0.5         !   [m] default = 0.5
                                 ! The mixed layer depth in the initial conditions when
                                 ! Z_INIT_SEPARATE_MIXED_LAYER is set to true.
-LAYER_Z_INIT_IC_EXTRAP_BUG = True !   [Boolean] default = True
+LAYER_Z_INIT_IC_EXTRAP_BUG = False !   [Boolean] default = True
                                 ! If true use an expression with a vertical indexing bug for extrapolating the
                                 ! densities at the bottom of unstable profiles from data when finding the
                                 ! initial interface locations in layered mode from a dataset of T and S.

--- a/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/MOM_parameter_doc.short
+++ b/coupled_AM2_LM3_SIS2/Intersperse_ice_1deg/MOM_parameter_doc.short
@@ -173,6 +173,10 @@ Z_INIT_SEPARATE_MIXED_LAYER = True !   [Boolean] default = False
                                 ! If true, distribute the topmost Z_INIT_HMIX_DEPTH of water over NKML layers,
                                 ! and do not correct the density of the topmost NKML+NKBL layers.  Otherwise all
                                 ! layers are initialized based on the depths of their target densities.
+LAYER_Z_INIT_IC_EXTRAP_BUG = False !   [Boolean] default = True
+                                ! If true use an expression with a vertical indexing bug for extrapolating the
+                                ! densities at the bottom of unstable profiles from data when finding the
+                                ! initial interface locations in layered mode from a dataset of T and S.
 
 ! === module MOM_diag_mediator ===
 

--- a/ice_ocean_SIS2/Baltic/MOM_input
+++ b/ice_ocean_SIS2/Baltic/MOM_input
@@ -176,6 +176,10 @@ Z_INIT_SEPARATE_MIXED_LAYER = True !   [Boolean] default = False
                                 ! If true, distribute the topmost Z_INIT_HMIX_DEPTH of water over NKML layers,
                                 ! and do not correct the density of the topmost NKML+NKBL layers.  Otherwise all
                                 ! layers are initialized based on the depths of their target densities.
+LAYER_Z_INIT_IC_EXTRAP_BUG = False !   [Boolean] default = True
+                                ! If true use an expression with a vertical indexing bug for extrapolating the
+                                ! densities at the bottom of unstable profiles from data when finding the
+                                ! initial interface locations in layered mode from a dataset of T and S.
 
 ! === module MOM_diag_mediator ===
 DIAG_COORD_DEF_Z = "FILE:OM3_zgrid.nc,interfaces=zw" ! default = "WOA09"

--- a/ice_ocean_SIS2/Baltic/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/Baltic/MOM_parameter_doc.all
@@ -543,7 +543,7 @@ Z_INIT_SEPARATE_MIXED_LAYER = True !   [Boolean] default = False
 Z_INIT_HMIX_DEPTH = 0.5         !   [m] default = 0.5
                                 ! The mixed layer depth in the initial conditions when
                                 ! Z_INIT_SEPARATE_MIXED_LAYER is set to true.
-LAYER_Z_INIT_IC_EXTRAP_BUG = True !   [Boolean] default = True
+LAYER_Z_INIT_IC_EXTRAP_BUG = False !   [Boolean] default = True
                                 ! If true use an expression with a vertical indexing bug for extrapolating the
                                 ! densities at the bottom of unstable profiles from data when finding the
                                 ! initial interface locations in layered mode from a dataset of T and S.

--- a/ice_ocean_SIS2/Baltic/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/Baltic/MOM_parameter_doc.short
@@ -167,6 +167,10 @@ Z_INIT_SEPARATE_MIXED_LAYER = True !   [Boolean] default = False
                                 ! If true, distribute the topmost Z_INIT_HMIX_DEPTH of water over NKML layers,
                                 ! and do not correct the density of the topmost NKML+NKBL layers.  Otherwise all
                                 ! layers are initialized based on the depths of their target densities.
+LAYER_Z_INIT_IC_EXTRAP_BUG = False !   [Boolean] default = True
+                                ! If true use an expression with a vertical indexing bug for extrapolating the
+                                ! densities at the bottom of unstable profiles from data when finding the
+                                ! initial interface locations in layered mode from a dataset of T and S.
 
 ! === module MOM_diag_mediator ===
 DIAG_COORD_DEF_Z = "FILE:OM3_zgrid.nc,interfaces=zw" ! default = "WOA09"

--- a/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/MOM_input
+++ b/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/MOM_input
@@ -375,6 +375,10 @@ BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! use a predictor continuity step to find the pressure field, and then to do a
                                 ! corrector continuity step using a weighted average of the old and new
                                 ! velocities, with weights of (1-BEBT) and BEBT.
+BAROTROPIC_TIDAL_SAL_BUG = False !   [Boolean] default = True
+                                ! If true, the tidal self-attraction and loading anomaly in the barotropic
+                                ! solver has the wrong sign, replicating a long-standing bug with a scalar
+                                ! self-attraction and loading term or the SAL term from a previous simulation.
 BEBT = 0.2                      !   [nondim] default = 0.1
                                 ! BEBT determines whether the barotropic time stepping uses the forward-backward
                                 ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range

--- a/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/MOM_input
+++ b/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/MOM_input
@@ -359,6 +359,9 @@ SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
 HMIX_FIXED = 0.5                !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity components are truncated.
 CFL_TRUNCATE_RAMP_TIME = 7200.0 !   [s] default = 0.0

--- a/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/MOM_parameter_doc.all
@@ -1364,7 +1364,7 @@ HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
 HMIX_FIXED = 0.5                !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVML = 1.0E-04                  !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08

--- a/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/MOM_parameter_doc.all
@@ -1443,7 +1443,7 @@ BAROTROPIC_ANSWER_DATE = 99991231 ! default = 99991231
                                 ! recover the answers from the end of 2018, while higher values uuse more
                                 ! efficient or general expressions.  If both BAROTROPIC_2018_ANSWERS and
                                 ! BAROTROPIC_ANSWER_DATE are specified, the latter takes precedence.
-BAROTROPIC_TIDAL_SAL_BUG = True !   [Boolean] default = True
+BAROTROPIC_TIDAL_SAL_BUG = False !   [Boolean] default = True
                                 ! If true, the tidal self-attraction and loading anomaly in the barotropic
                                 ! solver has the wrong sign, replicating a long-standing bug with a scalar
                                 ! self-attraction and loading term or the SAL term from a previous simulation.

--- a/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/MOM_parameter_doc.short
@@ -353,6 +353,9 @@ SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
 HMIX_FIXED = 0.5                !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity components are truncated.
 CFL_TRUNCATE_RAMP_TIME = 7200.0 !   [s] default = 0.0

--- a/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/Baltic_ALE_z_offline_tracers/MOM_parameter_doc.short
@@ -369,6 +369,10 @@ BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! use a predictor continuity step to find the pressure field, and then to do a
                                 ! corrector continuity step using a weighted average of the old and new
                                 ! velocities, with weights of (1-BEBT) and BEBT.
+BAROTROPIC_TIDAL_SAL_BUG = False !   [Boolean] default = True
+                                ! If true, the tidal self-attraction and loading anomaly in the barotropic
+                                ! solver has the wrong sign, replicating a long-standing bug with a scalar
+                                ! self-attraction and loading term or the SAL term from a previous simulation.
 BEBT = 0.2                      !   [nondim] default = 0.1
                                 ! BEBT determines whether the barotropic time stepping uses the forward-backward
                                 ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range

--- a/ice_ocean_SIS2/Baltic_OM4_025/MOM_input
+++ b/ice_ocean_SIS2/Baltic_OM4_025/MOM_input
@@ -484,6 +484,9 @@ USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
 HMIX_FIXED = 0.5                !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
+KVML = 1.0E-04                  !   [m2 s-1] default = 1.0E-04
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity components are truncated.
 

--- a/ice_ocean_SIS2/Baltic_OM4_05/MOM_input
+++ b/ice_ocean_SIS2/Baltic_OM4_05/MOM_input
@@ -505,6 +505,9 @@ USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
 HMIX_FIXED = 0.5                !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
+KVML = 1.0E-04                  !   [m2 s-1] default = 1.0E-04
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity components are truncated.
 

--- a/ice_ocean_SIS2/OM4_025.JRA/MOM_input
+++ b/ice_ocean_SIS2/OM4_025.JRA/MOM_input
@@ -482,6 +482,9 @@ USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
 HMIX_FIXED = 0.5                !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
+KVML = 1.0E-04                  !   [m2 s-1] default = 1.0E-04
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity components are truncated.
 

--- a/ice_ocean_SIS2/OM4_025/MOM_input
+++ b/ice_ocean_SIS2/OM4_025/MOM_input
@@ -490,6 +490,9 @@ USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
 HMIX_FIXED = 0.5                !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
+KVML = 1.0E-04                  !   [m2 s-1] default = 1.0E-04
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity components are truncated.
 

--- a/ice_ocean_SIS2/OM4_05/MOM_input
+++ b/ice_ocean_SIS2/OM4_05/MOM_input
@@ -516,6 +516,9 @@ USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
 HMIX_FIXED = 0.5                !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
+KVML = 1.0E-04                  !   [m2 s-1] default = 1.0E-04
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity components are truncated.
 

--- a/ice_ocean_SIS2/OM_1deg/MOM_input
+++ b/ice_ocean_SIS2/OM_1deg/MOM_input
@@ -494,6 +494,9 @@ USE_KH_BG_2D = True             !   [Boolean] default = False
 HMIX_FIXED = 0.5                !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
+KVML = 1.0E-04                  !   [m2 s-1] default = 1.0E-04
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity components are truncated.
 

--- a/ice_ocean_SIS2/SIS2_bergs_cgrid/MOM_input
+++ b/ice_ocean_SIS2/SIS2_bergs_cgrid/MOM_input
@@ -466,6 +466,10 @@ VERTEX_SHEAR = True             !   [Boolean] default = False
 MAX_RINO_IT = 25                !   [nondim] default = 50
                                 ! The maximum number of iterations that may be used to estimate the Richardson
                                 ! number driven mixing.
+KAPPA_SHEAR_VERTEX_PSURF_BUG = False !   [Boolean] default = True
+                                ! If true, do a simple average of the cell surface pressures to get a pressure
+                                ! at the corner if VERTEX_SHEAR=True.  Otherwise mask out any land points in the
+                                ! average.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.

--- a/ice_ocean_SIS2/SIS2_bergs_cgrid/MOM_parameter_doc.all
+++ b/ice_ocean_SIS2/SIS2_bergs_cgrid/MOM_parameter_doc.all
@@ -1616,7 +1616,7 @@ KAPPA_SHEAR_MAX_KAP_SRC_CHG = 10.0 !   [nondim] default = 10.0
                                 ! relative to the local source; this must be greater than 1.  The lower limit
                                 ! for the permitted fractional decrease is (1 - 0.5/kappa_src_max_chg).  These
                                 ! limits could perhaps be made dynamic with an improved iterative solver.
-KAPPA_SHEAR_VERTEX_PSURF_BUG = True !   [Boolean] default = True
+KAPPA_SHEAR_VERTEX_PSURF_BUG = False !   [Boolean] default = True
                                 ! If true, do a simple average of the cell surface pressures to get a pressure
                                 ! at the corner if VERTEX_SHEAR=True.  Otherwise mask out any land points in the
                                 ! average.

--- a/ice_ocean_SIS2/SIS2_bergs_cgrid/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/SIS2_bergs_cgrid/MOM_parameter_doc.short
@@ -459,6 +459,10 @@ VERTEX_SHEAR = True             !   [Boolean] default = False
 MAX_RINO_IT = 25                !   [nondim] default = 50
                                 ! The maximum number of iterations that may be used to estimate the Richardson
                                 ! number driven mixing.
+KAPPA_SHEAR_VERTEX_PSURF_BUG = False !   [Boolean] default = True
+                                ! If true, do a simple average of the cell surface pressures to get a pressure
+                                ! at the corner if VERTEX_SHEAR=True.  Otherwise mask out any land points in the
+                                ! average.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.

--- a/ocean_only/CVmix_SCM_tests/common_EPBL/MOM_input
+++ b/ocean_only/CVmix_SCM_tests/common_EPBL/MOM_input
@@ -274,6 +274,9 @@ HARMONIC_VISC = True            !   [Boolean] default = False
 HMIX_FIXED = 0.01               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity components are truncated.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0

--- a/ocean_only/CVmix_SCM_tests/common_KPP/MOM_input
+++ b/ocean_only/CVmix_SCM_tests/common_KPP/MOM_input
@@ -274,6 +274,9 @@ HARMONIC_VISC = True            !   [Boolean] default = False
 HMIX_FIXED = 0.01               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity components are truncated.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0

--- a/ocean_only/DOME/MOM_input
+++ b/ocean_only/DOME/MOM_input
@@ -300,7 +300,7 @@ HARMONIC_VISC = True            !   [Boolean] default = False
 HMIX_FIXED = 20.0               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08

--- a/ocean_only/DOME/MOM_parameter_doc.all
+++ b/ocean_only/DOME/MOM_parameter_doc.all
@@ -970,7 +970,7 @@ HMIX_FIXED = 20.0               !   [m]
                                 ! elevated when the bulk mixed layer is not used.
 HMIX_STRESS = 20.0              !   [m] default = 20.0
                                 ! The depth over which the wind stress is applied if DIRECT_STRESS is true.
-KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08

--- a/ocean_only/DOME/MOM_parameter_doc.short
+++ b/ocean_only/DOME/MOM_parameter_doc.short
@@ -291,7 +291,7 @@ HARMONIC_VISC = True            !   [Boolean] default = False
 HMIX_FIXED = 20.0               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08

--- a/ocean_only/ISOMIP/layer/MOM_input
+++ b/ocean_only/ISOMIP/layer/MOM_input
@@ -357,7 +357,7 @@ HARMONIC_BL_SCALE = 1.0         !   [nondim] default = 0.0
 HMIX_FIXED = 20.0               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08

--- a/ocean_only/ISOMIP/layer/MOM_parameter_doc.all
+++ b/ocean_only/ISOMIP/layer/MOM_parameter_doc.all
@@ -45,6 +45,9 @@ THICKNESSDIFFUSE = False        !   [Boolean] default = False
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
                                 ! If true, do thickness diffusion before dynamics. This is only used if
                                 ! THICKNESSDIFFUSE is true.
+USE_POROUS_BARRIER = True       !   [Boolean] default = True
+                                ! If true, use porous barrier to constrain the widths and face areas at the
+                                ! edges of the grid cells.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
                                 ! If true, there are separate values for the basin depths at velocity points.
                                 ! Otherwise the effects of topography are entirely determined from thickness
@@ -93,6 +96,11 @@ DO_GEOTHERMAL = False           !   [Boolean] default = False
 BOUND_SALINITY = False          !   [Boolean] default = False
                                 ! If true, limit salinity to being positive. (The sea-ice model may ask for more
                                 ! salt than is available and drive the salinity negative otherwise.)
+SALINITY_UNDERFLOW = 0.0        !   [PPT] default = 0.0
+                                ! A tiny value of salinity below which the it is set to 0.  For reference, one
+                                ! molecule of salt per square meter of ocean is of order 1e-29 ppt.
+TEMPERATURE_UNDERFLOW = 0.0     !   [degC] default = 0.0
+                                ! A tiny magnitude of temperatures below which they are set to 0.
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
                                 ! The heat capacity of sea water, approximated as a constant. This is only used
                                 ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
@@ -115,12 +123,20 @@ ALTERNATE_FIRST_DIRECTION = False !   [Boolean] default = False
                                 ! first direction can not be found in the restart file.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
+DEFAULT_ANSWER_DATE = 99991231  ! default = 99991231
+                                ! This sets the default value for the various _ANSWER_DATE parameters.
 DEFAULT_2018_ANSWERS = False    !   [Boolean] default = False
                                 ! This sets the default value for the various _2018_ANSWERS parameters.
 SURFACE_2018_ANSWERS = False    !   [Boolean] default = False
                                 ! If true, use expressions for the surface properties that recover the answers
                                 ! from the end of 2018. Otherwise, use more appropriate expressions that differ
                                 ! at roundoff for non-Boussinesq cases.
+SURFACE_ANSWER_DATE = 99991231  ! default = 99991231
+                                ! The vintage of the expressions for the surface properties.  Values below
+                                ! 20190101 recover the answers from the end of 2018, while higher values use
+                                ! updated and more robust forms of the same expressions.  If both
+                                ! SURFACE_2018_ANSWERS and SURFACE_ANSWER_DATE are specified, the latter takes
+                                ! precedence.
 USE_DIABATIC_TIME_BUG = False   !   [Boolean] default = False
                                 ! If true, uses the wrong calendar time for diabatic processes, as was done in
                                 ! MOM6 versions prior to February 2018. This is not recommended.
@@ -132,6 +148,9 @@ WRITE_GEOM = 1                  ! default = 1
                                 ! If =0, never write the geometry and vertical grid files. If =1, write the
                                 ! geometry and vertical grid files only for a new simulation. If =2, always
                                 ! write the geometry and vertical grid files. Other values are invalid.
+USE_DBCLIENT = False            !   [Boolean] default = False
+                                ! If true, initialize a client to a remote database that can be used for online
+                                ! analysis and machine-learning inference.
 ICE_SHELF = True                !   [Boolean] default = False
                                 ! If true, enables the ice shelf model.
 USE_PARTICLES = False           !   [Boolean] default = False
@@ -258,6 +277,8 @@ CHANNEL_CONFIG = "none"         ! default = "none"
                                 !       test case.
                                 !     file - Read open face widths everywhere from a
                                 !       NetCDF file on the model grid.
+SUBGRID_TOPO_AT_VEL = False     !   [Boolean] default = False
+                                ! If true, use variables from TOPO_AT_VEL_FILE as parameters for porous barrier.
 ROTATION = "beta"               ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -607,6 +628,13 @@ REMAPPING_2018_ANSWERS = False  !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use updated and more robust forms of the
                                 ! same expressions.
+REMAPPING_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the expressions and order of arithmetic to use for remapping.
+                                ! Values below 20190101 result in the use of older, less accurate expressions
+                                ! that were in use at the end of 2018.  Higher values result in the use of more
+                                ! robust and accurate forms of mathematically equivalent expressions.  If both
+                                ! REMAPPING_2018_ANSWERS and REMAPPING_ANSWER_DATE are specified, the latter
+                                ! takes precedence.
 USE_GRID_SPACE_DIAGNOSTIC_AXES = False !   [Boolean] default = False
                                 ! If true, use a grid index coordinate convention for diagnostic axes.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
@@ -683,6 +711,9 @@ USE_STORED_SLOPES = False       !   [Boolean] default = False
 VERY_SMALL_FREQUENCY = 1.0E-17  !   [s-1] default = 1.0E-17
                                 ! A miniscule frequency that is used to avoid division by 0.  The default value
                                 ! is roughly (pi / (the age of the universe)).
+USE_STANLEY_ISO = False         !   [Boolean] default = False
+                                ! If true, turn on Stanley SGS T variance parameterization in isopycnal slope
+                                ! code.
 USE_QG_LEITH_GM = False         !   [Boolean] default = False
                                 ! If true, use the QG Leith viscosity as the GM coefficient.
 
@@ -691,10 +722,21 @@ SET_VISC_2018_ANSWERS = False   !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use updated and more robust forms of the
                                 ! same expressions.
+SET_VISC_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the order of arithmetic and expressions in the set viscosity
+                                ! calculations.  Values below 20190101 recover the answers from the end of 2018,
+                                ! while higher values use updated and more robust forms of the same expressions.
+                                ! If both SET_VISC_2018_ANSWERS and SET_VISC_ANSWER_DATE are specified, the
+                                ! latter takes precedence.
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
                                 ! If true, the bottom stress is calculated with a drag law of the form
                                 ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
                                 ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
+DRAG_AS_BODY_FORCE = False      !   [Boolean] default = False
+                                ! If true, the bottom stress is imposed as an explicit body force applied over a
+                                ! fixed distance from the bottom, rather than as an implicit calculation based
+                                ! on an enhanced near-bottom viscosity. The thickness of the bottom boundary
+                                ! layer is HBBL.
 CHANNEL_DRAG = False            !   [Boolean] default = False
                                 ! If true, the bottom drag is exerted directly on each layer proportional to the
                                 ! fraction of the bottom it overlies.
@@ -784,10 +826,8 @@ KD_SMOOTH = 1.0E-06             !   [m2 s-1] default = 1.0E-06
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
                                 ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
                                 ! effectively emphasizes graver vertical modes by smoothing in the vertical.
-STANLEY_PRM_DET_COEFF = -1.0    !   [nondim] default = -1.0
-                                ! The coefficient correlating SGS temperature variance with the mean temperature
-                                ! gradient in the deterministic part of the Stanley parameterization. Negative
-                                ! values disable the scheme.
+USE_STANLEY_GM = False          !   [Boolean] default = False
+                                ! If true, turn on Stanley SGS T variance parameterization in GM code.
 MEKE_GM_SRC_ALT = False         !   [Boolean] default = False
                                 ! If true, use the GM energy conversion form S^2*N^2*kappa rather than the
                                 ! streamfunction for the GM source term.
@@ -802,6 +842,30 @@ USE_GME = False                 !   [Boolean] default = False
 USE_GM_WORK_BUG = False         !   [Boolean] default = False
                                 ! If true, compute the top-layer work tendency on the u-grid with the incorrect
                                 ! sign, for legacy reproducibility.
+STOCH_EOS = False               !   [Boolean] default = False
+                                ! If true, stochastic perturbations are applied to the EOS in the PGF.
+STANLEY_COEFF = -1.0            !   [not defined] default = -1.0
+                                ! Coefficient correlating the temperature gradient and SGS T variance.
+STANLEY_A = 1.0                 !   [not defined] default = 1.0
+                                ! Coefficient a which scales chi in stochastic perturbation of the SGS T
+                                ! variance.
+
+! === module MOM_porous_barriers ===
+PORBAR_ANSWER_DATE = 99991231   ! default = 99991231
+                                ! The vintage of the porous barrier weight function calculations.  Values below
+                                ! 20220806 recover the old answers in which the layer averaged weights are not
+                                ! strictly limited by an upper-bound of 1.0 .
+PORBAR_MASKING_DEPTH = 0.0      !   [m] default = 0.0
+                                ! If the effective average depth at the velocity cell is shallower than this
+                                ! number, then porous barrier is not applied at that location.
+                                ! PORBAR_MASKING_DEPTH is assumed to be positive below the sea surface.
+PORBAR_ETA_INTERP = "MAX"       ! default = "MAX"
+                                ! A string describing the method that decicdes how the interface heights at the
+                                ! velocity points are calculated. Valid values are:
+                                !    MAX (the default) - maximum of the adjacent cells
+                                !    MIN - minimum of the adjacent cells
+                                !    ARITHMETIC - arithmetic mean of the adjacent cells
+                                !    HARMOINIC - harmonic mean of the adjacent cells
 
 ! === module MOM_dynamics_split_RK2 ===
 TIDES = False                   !   [Boolean] default = False
@@ -933,16 +997,20 @@ BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
                                 ! If true, the reconstruction of T & S for pressure in boundary cells is
                                 ! extrapolated, rather than using PCM in these cells. If true, the same order
                                 ! polynomial is used as is used for the interior cells.
-PGF_STANLEY_T2_DET_COEFF = -1.0 !   [nondim] default = -1.0
-                                ! The coefficient correlating SGS temperature variance with the mean temperature
-                                ! gradient in the deterministic part of the Stanley form of the Brankart
-                                ! correction. Negative values disable the scheme.
+USE_STANLEY_PGF = False         !   [Boolean] default = False
+                                ! If true, turn on Stanley SGS T variance parameterization in PGF code.
 
 ! === module MOM_hor_visc ===
 HOR_VISC_2018_ANSWERS = False   !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use updated and more robust forms of the
                                 ! same expressions.
+HOR_VISC_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the order of arithmetic and expressions in the horizontal
+                                ! viscosity calculations.  Values below 20190101 recover the answers from the
+                                ! end of 2018, while higher values use updated and more robust forms of the same
+                                ! expressions.  If both HOR_VISC_2018_ANSWERS and HOR_VISC_ANSWER_DATE are
+                                ! specified, the latter takes precedence.
 LAPLACIAN = True                !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 KH = 0.0                        !   [m2 s-1] default = 0.0
@@ -1023,6 +1091,13 @@ VERT_FRICTION_2018_ANSWERS = False !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use expressions that do not use an arbitrary
                                 ! hard-coded maximum viscous coupling coefficient between layers.
+VERT_FRICTION_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the order of arithmetic and expressions in the viscous
+                                ! calculations.  Values below 20190101 recover the answers from the end of 2018,
+                                ! while higher values use expressions that do not use an arbitrary hard-coded
+                                ! maximum viscous coupling coefficient  between layers.  If both
+                                ! VERT_FRICTION_2018_ANSWERS and VERT_FRICTION_ANSWER_DATE are specified, the
+                                ! latter takes precedence.
 DIRECT_STRESS = False           !   [Boolean] default = False
                                 ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
                                 ! (like in HYCOM), and KVML may be set to a very small value.
@@ -1120,6 +1195,11 @@ BT_CORIOLIS_SCALE = 1.0         !   [nondim] default = 1.0
 BAROTROPIC_2018_ANSWERS = False !   [Boolean] default = False
                                 ! If true, use expressions for the barotropic solver that recover the answers
                                 ! from the end of 2018.  Otherwise, use more efficient or general expressions.
+BAROTROPIC_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the expressions in the barotropic solver. Values below 20190101
+                                ! recover the answers from the end of 2018, while higher values uuse more
+                                ! efficient or general expressions.  If both BAROTROPIC_2018_ANSWERS and
+                                ! BAROTROPIC_ANSWER_DATE are specified, the latter takes precedence.
 SADOURNY = True                 !   [Boolean] default = True
                                 ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
                                 ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
@@ -1287,6 +1367,12 @@ SET_DIFF_2018_ANSWERS = False   !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use updated and more robust forms of the
                                 ! same expressions.
+SET_DIFF_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the order of arithmetic and expressions in the set diffusivity
+                                ! calculations.  Values below 20190101 recover the answers from the end of 2018,
+                                ! while higher values use updated and more robust forms of the same expressions.
+                                ! If both SET_DIFF_2018_ANSWERS and SET_DIFF_ANSWER_DATE are specified, the
+                                ! latter takes precedence.
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
@@ -1438,6 +1524,12 @@ OPTICS_2018_ANSWERS = False     !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use updated expressions for handling the
                                 ! absorption of small remaining shortwave fluxes.
+OPTICS_ANSWER_DATE = 99991231   ! default = 99991231
+                                ! The vintage of the order of arithmetic and expressions in the optics
+                                ! calculations.  Values below 20190101 recover the answers from the end of 2018,
+                                ! while higher values use updated and more robust forms of the same expressions.
+                                ! If both OPTICS_2018_ANSWERS and OPTICS_ANSWER_DATE are specified, the latter
+                                ! takes precedence.
 PEN_SW_FLUX_ABSORB = 2.5E-11    !   [degC m s-1] default = 2.5E-11
                                 ! A minimum remaining shortwave heating rate that will be simply absorbed in the
                                 ! next sufficiently thick layers for computational efficiency, instead of

--- a/ocean_only/ISOMIP/layer/MOM_parameter_doc.all
+++ b/ocean_only/ISOMIP/layer/MOM_parameter_doc.all
@@ -1111,7 +1111,7 @@ HARMONIC_BL_SCALE = 1.0         !   [nondim] default = 0.0
 HMIX_FIXED = 20.0               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08

--- a/ocean_only/ISOMIP/layer/MOM_parameter_doc.short
+++ b/ocean_only/ISOMIP/layer/MOM_parameter_doc.short
@@ -346,7 +346,7 @@ HARMONIC_BL_SCALE = 1.0         !   [nondim] default = 0.0
 HMIX_FIXED = 20.0               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08

--- a/ocean_only/ISOMIP/layer/MOM_parameter_doc.short
+++ b/ocean_only/ISOMIP/layer/MOM_parameter_doc.short
@@ -288,6 +288,8 @@ KV_TBL_MIN = 0.01               !   [m2 s-1] default = 1.0E-04
 
 ! === module MOM_thickness_diffuse ===
 
+! === module MOM_porous_barriers ===
+
 ! === module MOM_dynamics_split_RK2 ===
 BE = 0.7                        !   [nondim] default = 0.6
                                 ! If SPLIT is true, BE determines the relative weighting of a  2nd-order

--- a/ocean_only/ISOMIP/rho/MOM_input
+++ b/ocean_only/ISOMIP/rho/MOM_input
@@ -402,7 +402,7 @@ HARMONIC_BL_SCALE = 1.0         !   [nondim] default = 0.0
 HMIX_FIXED = 20.0               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08

--- a/ocean_only/ISOMIP/rho/MOM_parameter_doc.all
+++ b/ocean_only/ISOMIP/rho/MOM_parameter_doc.all
@@ -45,6 +45,9 @@ THICKNESSDIFFUSE = False        !   [Boolean] default = False
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
                                 ! If true, do thickness diffusion before dynamics. This is only used if
                                 ! THICKNESSDIFFUSE is true.
+USE_POROUS_BARRIER = True       !   [Boolean] default = True
+                                ! If true, use porous barrier to constrain the widths and face areas at the
+                                ! edges of the grid cells.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
                                 ! If true, there are separate values for the basin depths at velocity points.
                                 ! Otherwise the effects of topography are entirely determined from thickness
@@ -93,6 +96,11 @@ DO_GEOTHERMAL = False           !   [Boolean] default = False
 BOUND_SALINITY = False          !   [Boolean] default = False
                                 ! If true, limit salinity to being positive. (The sea-ice model may ask for more
                                 ! salt than is available and drive the salinity negative otherwise.)
+SALINITY_UNDERFLOW = 0.0        !   [PPT] default = 0.0
+                                ! A tiny value of salinity below which the it is set to 0.  For reference, one
+                                ! molecule of salt per square meter of ocean is of order 1e-29 ppt.
+TEMPERATURE_UNDERFLOW = 0.0     !   [degC] default = 0.0
+                                ! A tiny magnitude of temperatures below which they are set to 0.
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
                                 ! The heat capacity of sea water, approximated as a constant. This is only used
                                 ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
@@ -115,12 +123,20 @@ ALTERNATE_FIRST_DIRECTION = False !   [Boolean] default = False
                                 ! first direction can not be found in the restart file.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
+DEFAULT_ANSWER_DATE = 99991231  ! default = 99991231
+                                ! This sets the default value for the various _ANSWER_DATE parameters.
 DEFAULT_2018_ANSWERS = False    !   [Boolean] default = False
                                 ! This sets the default value for the various _2018_ANSWERS parameters.
 SURFACE_2018_ANSWERS = False    !   [Boolean] default = False
                                 ! If true, use expressions for the surface properties that recover the answers
                                 ! from the end of 2018. Otherwise, use more appropriate expressions that differ
                                 ! at roundoff for non-Boussinesq cases.
+SURFACE_ANSWER_DATE = 99991231  ! default = 99991231
+                                ! The vintage of the expressions for the surface properties.  Values below
+                                ! 20190101 recover the answers from the end of 2018, while higher values use
+                                ! updated and more robust forms of the same expressions.  If both
+                                ! SURFACE_2018_ANSWERS and SURFACE_ANSWER_DATE are specified, the latter takes
+                                ! precedence.
 USE_DIABATIC_TIME_BUG = False   !   [Boolean] default = False
                                 ! If true, uses the wrong calendar time for diabatic processes, as was done in
                                 ! MOM6 versions prior to February 2018. This is not recommended.
@@ -132,6 +148,9 @@ WRITE_GEOM = 1                  ! default = 1
                                 ! If =0, never write the geometry and vertical grid files. If =1, write the
                                 ! geometry and vertical grid files only for a new simulation. If =2, always
                                 ! write the geometry and vertical grid files. Other values are invalid.
+USE_DBCLIENT = False            !   [Boolean] default = False
+                                ! If true, initialize a client to a remote database that can be used for online
+                                ! analysis and machine-learning inference.
 ICE_SHELF = True                !   [Boolean] default = False
                                 ! If true, enables the ice shelf model.
 USE_PARTICLES = False           !   [Boolean] default = False
@@ -258,6 +277,8 @@ CHANNEL_CONFIG = "none"         ! default = "none"
                                 !       test case.
                                 !     file - Read open face widths everywhere from a
                                 !       NetCDF file on the model grid.
+SUBGRID_TOPO_AT_VEL = False     !   [Boolean] default = False
+                                ! If true, use variables from TOPO_AT_VEL_FILE as parameters for porous barrier.
 ROTATION = "beta"               ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -422,6 +443,13 @@ REMAPPING_2018_ANSWERS = False  !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use updated and more robust forms of the
                                 ! same expressions.
+REMAPPING_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the expressions and order of arithmetic to use for remapping.
+                                ! Values below 20190101 result in the use of older, less accurate expressions
+                                ! that were in use at the end of 2018.  Higher values result in the use of more
+                                ! robust and accurate forms of mathematically equivalent expressions.  If both
+                                ! REMAPPING_2018_ANSWERS and REMAPPING_ANSWER_DATE are specified, the latter
+                                ! takes precedence.
 BOUNDARY_EXTRAPOLATION = True   !   [Boolean] default = False
                                 ! When defined, a proper high-order reconstruction scheme is used within
                                 ! boundary cells rather than PCM. E.g., if PPM is used for remapping, a PPM
@@ -823,6 +851,9 @@ USE_STORED_SLOPES = False       !   [Boolean] default = False
 VERY_SMALL_FREQUENCY = 1.0E-17  !   [s-1] default = 1.0E-17
                                 ! A miniscule frequency that is used to avoid division by 0.  The default value
                                 ! is roughly (pi / (the age of the universe)).
+USE_STANLEY_ISO = False         !   [Boolean] default = False
+                                ! If true, turn on Stanley SGS T variance parameterization in isopycnal slope
+                                ! code.
 USE_QG_LEITH_GM = False         !   [Boolean] default = False
                                 ! If true, use the QG Leith viscosity as the GM coefficient.
 
@@ -831,10 +862,21 @@ SET_VISC_2018_ANSWERS = False   !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use updated and more robust forms of the
                                 ! same expressions.
+SET_VISC_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the order of arithmetic and expressions in the set viscosity
+                                ! calculations.  Values below 20190101 recover the answers from the end of 2018,
+                                ! while higher values use updated and more robust forms of the same expressions.
+                                ! If both SET_VISC_2018_ANSWERS and SET_VISC_ANSWER_DATE are specified, the
+                                ! latter takes precedence.
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
                                 ! If true, the bottom stress is calculated with a drag law of the form
                                 ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
                                 ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
+DRAG_AS_BODY_FORCE = False      !   [Boolean] default = False
+                                ! If true, the bottom stress is imposed as an explicit body force applied over a
+                                ! fixed distance from the bottom, rather than as an implicit calculation based
+                                ! on an enhanced near-bottom viscosity. The thickness of the bottom boundary
+                                ! layer is HBBL.
 CHANNEL_DRAG = False            !   [Boolean] default = False
                                 ! If true, the bottom drag is exerted directly on each layer proportional to the
                                 ! fraction of the bottom it overlies.
@@ -924,10 +966,8 @@ KD_SMOOTH = 1.0E-06             !   [m2 s-1] default = 1.0E-06
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
                                 ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
                                 ! effectively emphasizes graver vertical modes by smoothing in the vertical.
-STANLEY_PRM_DET_COEFF = -1.0    !   [nondim] default = -1.0
-                                ! The coefficient correlating SGS temperature variance with the mean temperature
-                                ! gradient in the deterministic part of the Stanley parameterization. Negative
-                                ! values disable the scheme.
+USE_STANLEY_GM = False          !   [Boolean] default = False
+                                ! If true, turn on Stanley SGS T variance parameterization in GM code.
 MEKE_GM_SRC_ALT = False         !   [Boolean] default = False
                                 ! If true, use the GM energy conversion form S^2*N^2*kappa rather than the
                                 ! streamfunction for the GM source term.
@@ -942,6 +982,30 @@ USE_GME = False                 !   [Boolean] default = False
 USE_GM_WORK_BUG = False         !   [Boolean] default = False
                                 ! If true, compute the top-layer work tendency on the u-grid with the incorrect
                                 ! sign, for legacy reproducibility.
+STOCH_EOS = False               !   [Boolean] default = False
+                                ! If true, stochastic perturbations are applied to the EOS in the PGF.
+STANLEY_COEFF = -1.0            !   [not defined] default = -1.0
+                                ! Coefficient correlating the temperature gradient and SGS T variance.
+STANLEY_A = 1.0                 !   [not defined] default = 1.0
+                                ! Coefficient a which scales chi in stochastic perturbation of the SGS T
+                                ! variance.
+
+! === module MOM_porous_barriers ===
+PORBAR_ANSWER_DATE = 99991231   ! default = 99991231
+                                ! The vintage of the porous barrier weight function calculations.  Values below
+                                ! 20220806 recover the old answers in which the layer averaged weights are not
+                                ! strictly limited by an upper-bound of 1.0 .
+PORBAR_MASKING_DEPTH = 0.0      !   [m] default = 0.0
+                                ! If the effective average depth at the velocity cell is shallower than this
+                                ! number, then porous barrier is not applied at that location.
+                                ! PORBAR_MASKING_DEPTH is assumed to be positive below the sea surface.
+PORBAR_ETA_INTERP = "MAX"       ! default = "MAX"
+                                ! A string describing the method that decicdes how the interface heights at the
+                                ! velocity points are calculated. Valid values are:
+                                !    MAX (the default) - maximum of the adjacent cells
+                                !    MIN - minimum of the adjacent cells
+                                !    ARITHMETIC - arithmetic mean of the adjacent cells
+                                !    HARMOINIC - harmonic mean of the adjacent cells
 
 ! === module MOM_dynamics_split_RK2 ===
 TIDES = False                   !   [Boolean] default = False
@@ -1073,16 +1137,20 @@ BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
                                 ! If true, the reconstruction of T & S for pressure in boundary cells is
                                 ! extrapolated, rather than using PCM in these cells. If true, the same order
                                 ! polynomial is used as is used for the interior cells.
-PGF_STANLEY_T2_DET_COEFF = -1.0 !   [nondim] default = -1.0
-                                ! The coefficient correlating SGS temperature variance with the mean temperature
-                                ! gradient in the deterministic part of the Stanley form of the Brankart
-                                ! correction. Negative values disable the scheme.
+USE_STANLEY_PGF = False         !   [Boolean] default = False
+                                ! If true, turn on Stanley SGS T variance parameterization in PGF code.
 
 ! === module MOM_hor_visc ===
 HOR_VISC_2018_ANSWERS = False   !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use updated and more robust forms of the
                                 ! same expressions.
+HOR_VISC_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the order of arithmetic and expressions in the horizontal
+                                ! viscosity calculations.  Values below 20190101 recover the answers from the
+                                ! end of 2018, while higher values use updated and more robust forms of the same
+                                ! expressions.  If both HOR_VISC_2018_ANSWERS and HOR_VISC_ANSWER_DATE are
+                                ! specified, the latter takes precedence.
 LAPLACIAN = True                !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 KH = 0.0                        !   [m2 s-1] default = 0.0
@@ -1163,6 +1231,13 @@ VERT_FRICTION_2018_ANSWERS = False !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use expressions that do not use an arbitrary
                                 ! hard-coded maximum viscous coupling coefficient between layers.
+VERT_FRICTION_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the order of arithmetic and expressions in the viscous
+                                ! calculations.  Values below 20190101 recover the answers from the end of 2018,
+                                ! while higher values use expressions that do not use an arbitrary hard-coded
+                                ! maximum viscous coupling coefficient  between layers.  If both
+                                ! VERT_FRICTION_2018_ANSWERS and VERT_FRICTION_ANSWER_DATE are specified, the
+                                ! latter takes precedence.
 DIRECT_STRESS = False           !   [Boolean] default = False
                                 ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
                                 ! (like in HYCOM), and KVML may be set to a very small value.
@@ -1260,6 +1335,11 @@ BT_CORIOLIS_SCALE = 1.0         !   [nondim] default = 1.0
 BAROTROPIC_2018_ANSWERS = False !   [Boolean] default = False
                                 ! If true, use expressions for the barotropic solver that recover the answers
                                 ! from the end of 2018.  Otherwise, use more efficient or general expressions.
+BAROTROPIC_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the expressions in the barotropic solver. Values below 20190101
+                                ! recover the answers from the end of 2018, while higher values uuse more
+                                ! efficient or general expressions.  If both BAROTROPIC_2018_ANSWERS and
+                                ! BAROTROPIC_ANSWER_DATE are specified, the latter takes precedence.
 SADOURNY = True                 !   [Boolean] default = True
                                 ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
                                 ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
@@ -1426,6 +1506,12 @@ SET_DIFF_2018_ANSWERS = False   !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use updated and more robust forms of the
                                 ! same expressions.
+SET_DIFF_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the order of arithmetic and expressions in the set diffusivity
+                                ! calculations.  Values below 20190101 recover the answers from the end of 2018,
+                                ! while higher values use updated and more robust forms of the same expressions.
+                                ! If both SET_DIFF_2018_ANSWERS and SET_DIFF_ANSWER_DATE are specified, the
+                                ! latter takes precedence.
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
@@ -1638,6 +1724,12 @@ EPBL_2018_ANSWERS = False       !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use updated and more robust forms of the
                                 ! same expressions.
+EPBL_ANSWER_DATE = 99991231     ! default = 99991231
+                                ! The vintage of the order of arithmetic and expressions in the energetic PBL
+                                ! calculations.  Values below 20190101 recover the answers from the end of 2018,
+                                ! while higher values use updated and more robust forms of the same expressions.
+                                ! If both EPBL_2018_ANSWERS and EPBL_ANSWER_DATE are specified, the latter takes
+                                ! precedence.
 EPBL_ORIGINAL_PE_CALC = True    !   [Boolean] default = True
                                 ! If true, the ePBL code uses the original form of the potential energy change
                                 ! code.  Otherwise, the newer version that can work with successive increments
@@ -1722,6 +1814,12 @@ OPTICS_2018_ANSWERS = False     !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use updated expressions for handling the
                                 ! absorption of small remaining shortwave fluxes.
+OPTICS_ANSWER_DATE = 99991231   ! default = 99991231
+                                ! The vintage of the order of arithmetic and expressions in the optics
+                                ! calculations.  Values below 20190101 recover the answers from the end of 2018,
+                                ! while higher values use updated and more robust forms of the same expressions.
+                                ! If both OPTICS_2018_ANSWERS and OPTICS_ANSWER_DATE are specified, the latter
+                                ! takes precedence.
 PEN_SW_FLUX_ABSORB = 2.5E-11    !   [degC m s-1] default = 2.5E-11
                                 ! A minimum remaining shortwave heating rate that will be simply absorbed in the
                                 ! next sufficiently thick layers for computational efficiency, instead of

--- a/ocean_only/ISOMIP/rho/MOM_parameter_doc.all
+++ b/ocean_only/ISOMIP/rho/MOM_parameter_doc.all
@@ -1251,7 +1251,7 @@ HARMONIC_BL_SCALE = 1.0         !   [nondim] default = 0.0
 HMIX_FIXED = 20.0               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08

--- a/ocean_only/ISOMIP/rho/MOM_parameter_doc.short
+++ b/ocean_only/ISOMIP/rho/MOM_parameter_doc.short
@@ -394,7 +394,7 @@ HARMONIC_BL_SCALE = 1.0         !   [nondim] default = 0.0
 HMIX_FIXED = 20.0               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08

--- a/ocean_only/ISOMIP/rho/MOM_parameter_doc.short
+++ b/ocean_only/ISOMIP/rho/MOM_parameter_doc.short
@@ -336,6 +336,8 @@ KV_TBL_MIN = 0.01               !   [m2 s-1] default = 1.0E-04
 
 ! === module MOM_thickness_diffuse ===
 
+! === module MOM_porous_barriers ===
+
 ! === module MOM_dynamics_split_RK2 ===
 BE = 0.7                        !   [nondim] default = 0.6
                                 ! If SPLIT is true, BE determines the relative weighting of a  2nd-order

--- a/ocean_only/MESO_025_23L/MOM_parameter_doc.all
+++ b/ocean_only/MESO_025_23L/MOM_parameter_doc.all
@@ -45,6 +45,9 @@ THICKNESSDIFFUSE = False        !   [Boolean] default = False
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
                                 ! If true, do thickness diffusion before dynamics. This is only used if
                                 ! THICKNESSDIFFUSE is true.
+USE_POROUS_BARRIER = True       !   [Boolean] default = True
+                                ! If true, use porous barrier to constrain the widths and face areas at the
+                                ! edges of the grid cells.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
                                 ! If true, there are separate values for the basin depths at velocity points.
                                 ! Otherwise the effects of topography are entirely determined from thickness
@@ -85,6 +88,11 @@ DO_GEOTHERMAL = False           !   [Boolean] default = False
 BOUND_SALINITY = False          !   [Boolean] default = False
                                 ! If true, limit salinity to being positive. (The sea-ice model may ask for more
                                 ! salt than is available and drive the salinity negative otherwise.)
+SALINITY_UNDERFLOW = 0.0        !   [PPT] default = 0.0
+                                ! A tiny value of salinity below which the it is set to 0.  For reference, one
+                                ! molecule of salt per square meter of ocean is of order 1e-29 ppt.
+TEMPERATURE_UNDERFLOW = 0.0     !   [degC] default = 0.0
+                                ! A tiny magnitude of temperatures below which they are set to 0.
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
                                 ! The heat capacity of sea water, approximated as a constant. This is only used
                                 ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
@@ -112,12 +120,20 @@ ALTERNATE_FIRST_DIRECTION = False !   [Boolean] default = False
                                 ! first direction can not be found in the restart file.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
+DEFAULT_ANSWER_DATE = 99991231  ! default = 99991231
+                                ! This sets the default value for the various _ANSWER_DATE parameters.
 DEFAULT_2018_ANSWERS = False    !   [Boolean] default = False
                                 ! This sets the default value for the various _2018_ANSWERS parameters.
 SURFACE_2018_ANSWERS = False    !   [Boolean] default = False
                                 ! If true, use expressions for the surface properties that recover the answers
                                 ! from the end of 2018. Otherwise, use more appropriate expressions that differ
                                 ! at roundoff for non-Boussinesq cases.
+SURFACE_ANSWER_DATE = 99991231  ! default = 99991231
+                                ! The vintage of the expressions for the surface properties.  Values below
+                                ! 20190101 recover the answers from the end of 2018, while higher values use
+                                ! updated and more robust forms of the same expressions.  If both
+                                ! SURFACE_2018_ANSWERS and SURFACE_ANSWER_DATE are specified, the latter takes
+                                ! precedence.
 USE_DIABATIC_TIME_BUG = False   !   [Boolean] default = False
                                 ! If true, uses the wrong calendar time for diabatic processes, as was done in
                                 ! MOM6 versions prior to February 2018. This is not recommended.
@@ -129,6 +145,9 @@ WRITE_GEOM = 1                  ! default = 1
                                 ! If =0, never write the geometry and vertical grid files. If =1, write the
                                 ! geometry and vertical grid files only for a new simulation. If =2, always
                                 ! write the geometry and vertical grid files. Other values are invalid.
+USE_DBCLIENT = False            !   [Boolean] default = False
+                                ! If true, initialize a client to a remote database that can be used for online
+                                ! analysis and machine-learning inference.
 ICE_SHELF = False               !   [Boolean] default = False
                                 ! If true, enables the ice shelf model.
 USE_PARTICLES = False           !   [Boolean] default = False
@@ -270,6 +289,8 @@ CHANNEL_CONFIG = "none"         ! default = "none"
                                 !       test case.
                                 !     file - Read open face widths everywhere from a
                                 !       NetCDF file on the model grid.
+SUBGRID_TOPO_AT_VEL = False     !   [Boolean] default = False
+                                ! If true, use variables from TOPO_AT_VEL_FILE as parameters for porous barrier.
 ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -534,6 +555,13 @@ REMAPPING_2018_ANSWERS = False  !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use updated and more robust forms of the
                                 ! same expressions.
+REMAPPING_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the expressions and order of arithmetic to use for remapping.
+                                ! Values below 20190101 result in the use of older, less accurate expressions
+                                ! that were in use at the end of 2018.  Higher values result in the use of more
+                                ! robust and accurate forms of mathematically equivalent expressions.  If both
+                                ! REMAPPING_2018_ANSWERS and REMAPPING_ANSWER_DATE are specified, the latter
+                                ! takes precedence.
 USE_GRID_SPACE_DIAGNOSTIC_AXES = False !   [Boolean] default = False
                                 ! If true, use a grid index coordinate convention for diagnostic axes.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
@@ -610,6 +638,9 @@ USE_STORED_SLOPES = False       !   [Boolean] default = False
 VERY_SMALL_FREQUENCY = 1.0E-17  !   [s-1] default = 1.0E-17
                                 ! A miniscule frequency that is used to avoid division by 0.  The default value
                                 ! is roughly (pi / (the age of the universe)).
+USE_STANLEY_ISO = False         !   [Boolean] default = False
+                                ! If true, turn on Stanley SGS T variance parameterization in isopycnal slope
+                                ! code.
 USE_QG_LEITH_GM = False         !   [Boolean] default = False
                                 ! If true, use the QG Leith viscosity as the GM coefficient.
 
@@ -618,10 +649,21 @@ SET_VISC_2018_ANSWERS = False   !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use updated and more robust forms of the
                                 ! same expressions.
+SET_VISC_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the order of arithmetic and expressions in the set viscosity
+                                ! calculations.  Values below 20190101 recover the answers from the end of 2018,
+                                ! while higher values use updated and more robust forms of the same expressions.
+                                ! If both SET_VISC_2018_ANSWERS and SET_VISC_ANSWER_DATE are specified, the
+                                ! latter takes precedence.
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
                                 ! If true, the bottom stress is calculated with a drag law of the form
                                 ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
                                 ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
+DRAG_AS_BODY_FORCE = False      !   [Boolean] default = False
+                                ! If true, the bottom stress is imposed as an explicit body force applied over a
+                                ! fixed distance from the bottom, rather than as an implicit calculation based
+                                ! on an enhanced near-bottom viscosity. The thickness of the bottom boundary
+                                ! layer is HBBL.
 CHANNEL_DRAG = False            !   [Boolean] default = False
                                 ! If true, the bottom drag is exerted directly on each layer proportional to the
                                 ! fraction of the bottom it overlies.
@@ -709,10 +751,8 @@ KD_SMOOTH = 1.0E-06             !   [m2 s-1] default = 1.0E-06
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
                                 ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
                                 ! effectively emphasizes graver vertical modes by smoothing in the vertical.
-STANLEY_PRM_DET_COEFF = -1.0    !   [nondim] default = -1.0
-                                ! The coefficient correlating SGS temperature variance with the mean temperature
-                                ! gradient in the deterministic part of the Stanley parameterization. Negative
-                                ! values disable the scheme.
+USE_STANLEY_GM = False          !   [Boolean] default = False
+                                ! If true, turn on Stanley SGS T variance parameterization in GM code.
 MEKE_GM_SRC_ALT = False         !   [Boolean] default = False
                                 ! If true, use the GM energy conversion form S^2*N^2*kappa rather than the
                                 ! streamfunction for the GM source term.
@@ -727,6 +767,30 @@ USE_GME = False                 !   [Boolean] default = False
 USE_GM_WORK_BUG = False         !   [Boolean] default = False
                                 ! If true, compute the top-layer work tendency on the u-grid with the incorrect
                                 ! sign, for legacy reproducibility.
+STOCH_EOS = False               !   [Boolean] default = False
+                                ! If true, stochastic perturbations are applied to the EOS in the PGF.
+STANLEY_COEFF = -1.0            !   [not defined] default = -1.0
+                                ! Coefficient correlating the temperature gradient and SGS T variance.
+STANLEY_A = 1.0                 !   [not defined] default = 1.0
+                                ! Coefficient a which scales chi in stochastic perturbation of the SGS T
+                                ! variance.
+
+! === module MOM_porous_barriers ===
+PORBAR_ANSWER_DATE = 99991231   ! default = 99991231
+                                ! The vintage of the porous barrier weight function calculations.  Values below
+                                ! 20220806 recover the old answers in which the layer averaged weights are not
+                                ! strictly limited by an upper-bound of 1.0 .
+PORBAR_MASKING_DEPTH = 0.0      !   [m] default = 0.0
+                                ! If the effective average depth at the velocity cell is shallower than this
+                                ! number, then porous barrier is not applied at that location.
+                                ! PORBAR_MASKING_DEPTH is assumed to be positive below the sea surface.
+PORBAR_ETA_INTERP = "MAX"       ! default = "MAX"
+                                ! A string describing the method that decicdes how the interface heights at the
+                                ! velocity points are calculated. Valid values are:
+                                !    MAX (the default) - maximum of the adjacent cells
+                                !    MIN - minimum of the adjacent cells
+                                !    ARITHMETIC - arithmetic mean of the adjacent cells
+                                !    HARMOINIC - harmonic mean of the adjacent cells
 
 ! === module MOM_dynamics_split_RK2 ===
 TIDES = False                   !   [Boolean] default = False
@@ -858,16 +922,20 @@ BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
                                 ! If true, the reconstruction of T & S for pressure in boundary cells is
                                 ! extrapolated, rather than using PCM in these cells. If true, the same order
                                 ! polynomial is used as is used for the interior cells.
-PGF_STANLEY_T2_DET_COEFF = -1.0 !   [nondim] default = -1.0
-                                ! The coefficient correlating SGS temperature variance with the mean temperature
-                                ! gradient in the deterministic part of the Stanley form of the Brankart
-                                ! correction. Negative values disable the scheme.
+USE_STANLEY_PGF = False         !   [Boolean] default = False
+                                ! If true, turn on Stanley SGS T variance parameterization in PGF code.
 
 ! === module MOM_hor_visc ===
 HOR_VISC_2018_ANSWERS = False   !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use updated and more robust forms of the
                                 ! same expressions.
+HOR_VISC_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the order of arithmetic and expressions in the horizontal
+                                ! viscosity calculations.  Values below 20190101 recover the answers from the
+                                ! end of 2018, while higher values use updated and more robust forms of the same
+                                ! expressions.  If both HOR_VISC_2018_ANSWERS and HOR_VISC_ANSWER_DATE are
+                                ! specified, the latter takes precedence.
 LAPLACIAN = False               !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 BIHARMONIC = True               !   [Boolean] default = True
@@ -920,6 +988,13 @@ VERT_FRICTION_2018_ANSWERS = False !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use expressions that do not use an arbitrary
                                 ! hard-coded maximum viscous coupling coefficient between layers.
+VERT_FRICTION_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the order of arithmetic and expressions in the viscous
+                                ! calculations.  Values below 20190101 recover the answers from the end of 2018,
+                                ! while higher values use expressions that do not use an arbitrary hard-coded
+                                ! maximum viscous coupling coefficient  between layers.  If both
+                                ! VERT_FRICTION_2018_ANSWERS and VERT_FRICTION_ANSWER_DATE are specified, the
+                                ! latter takes precedence.
 DIRECT_STRESS = False           !   [Boolean] default = False
                                 ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
                                 ! (like in HYCOM), and KVML may be set to a very small value.
@@ -1001,6 +1076,11 @@ BT_CORIOLIS_SCALE = 1.0         !   [nondim] default = 1.0
 BAROTROPIC_2018_ANSWERS = False !   [Boolean] default = False
                                 ! If true, use expressions for the barotropic solver that recover the answers
                                 ! from the end of 2018.  Otherwise, use more efficient or general expressions.
+BAROTROPIC_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the expressions in the barotropic solver. Values below 20190101
+                                ! recover the answers from the end of 2018, while higher values uuse more
+                                ! efficient or general expressions.  If both BAROTROPIC_2018_ANSWERS and
+                                ! BAROTROPIC_ANSWER_DATE are specified, the latter takes precedence.
 SADOURNY = True                 !   [Boolean] default = True
                                 ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
                                 ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
@@ -1073,6 +1153,8 @@ FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
                                 ! energy to the large-scale geostrophic kinetic energy or 1 plus the square of
                                 ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
                                 ! (2010)
+USE_STANLEY_ML = False          !   [Boolean] default = False
+                                ! If true, turn on Stanley SGS T variance parameterization in ML restrat code.
 
 ! === module MOM_diagnostics ===
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
@@ -1178,6 +1260,12 @@ SET_DIFF_2018_ANSWERS = False   !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use updated and more robust forms of the
                                 ! same expressions.
+SET_DIFF_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the order of arithmetic and expressions in the set diffusivity
+                                ! calculations.  Values below 20190101 recover the answers from the end of 2018,
+                                ! while higher values use updated and more robust forms of the same expressions.
+                                ! If both SET_DIFF_2018_ANSWERS and SET_DIFF_ANSWER_DATE are specified, the
+                                ! latter takes precedence.
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
@@ -1477,6 +1565,12 @@ OPTICS_2018_ANSWERS = False     !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use updated expressions for handling the
                                 ! absorption of small remaining shortwave fluxes.
+OPTICS_ANSWER_DATE = 99991231   ! default = 99991231
+                                ! The vintage of the order of arithmetic and expressions in the optics
+                                ! calculations.  Values below 20190101 recover the answers from the end of 2018,
+                                ! while higher values use updated and more robust forms of the same expressions.
+                                ! If both OPTICS_2018_ANSWERS and OPTICS_ANSWER_DATE are specified, the latter
+                                ! takes precedence.
 PEN_SW_FLUX_ABSORB = 2.5E-11    !   [degC m s-1] default = 2.5E-11
                                 ! A minimum remaining shortwave heating rate that will be simply absorbed in the
                                 ! next sufficiently thick layers for computational efficiency, instead of

--- a/ocean_only/MESO_025_23L/MOM_parameter_doc.short
+++ b/ocean_only/MESO_025_23L/MOM_parameter_doc.short
@@ -224,6 +224,8 @@ KV = 0.001                      !   [m2 s-1]
 KHTH = 600.0                    !   [m2 s-1] default = 0.0
                                 ! The background horizontal thickness diffusivity.
 
+! === module MOM_porous_barriers ===
+
 ! === module MOM_dynamics_split_RK2 ===
 
 ! === module MOM_continuity ===

--- a/ocean_only/MESO_025_63L/MOM_parameter_doc.all
+++ b/ocean_only/MESO_025_63L/MOM_parameter_doc.all
@@ -45,6 +45,9 @@ THICKNESSDIFFUSE = False        !   [Boolean] default = False
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
                                 ! If true, do thickness diffusion before dynamics. This is only used if
                                 ! THICKNESSDIFFUSE is true.
+USE_POROUS_BARRIER = True       !   [Boolean] default = True
+                                ! If true, use porous barrier to constrain the widths and face areas at the
+                                ! edges of the grid cells.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
                                 ! If true, there are separate values for the basin depths at velocity points.
                                 ! Otherwise the effects of topography are entirely determined from thickness
@@ -85,6 +88,11 @@ DO_GEOTHERMAL = False           !   [Boolean] default = False
 BOUND_SALINITY = False          !   [Boolean] default = False
                                 ! If true, limit salinity to being positive. (The sea-ice model may ask for more
                                 ! salt than is available and drive the salinity negative otherwise.)
+SALINITY_UNDERFLOW = 0.0        !   [PPT] default = 0.0
+                                ! A tiny value of salinity below which the it is set to 0.  For reference, one
+                                ! molecule of salt per square meter of ocean is of order 1e-29 ppt.
+TEMPERATURE_UNDERFLOW = 0.0     !   [degC] default = 0.0
+                                ! A tiny magnitude of temperatures below which they are set to 0.
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
                                 ! The heat capacity of sea water, approximated as a constant. This is only used
                                 ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
@@ -112,12 +120,20 @@ ALTERNATE_FIRST_DIRECTION = False !   [Boolean] default = False
                                 ! first direction can not be found in the restart file.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
+DEFAULT_ANSWER_DATE = 99991231  ! default = 99991231
+                                ! This sets the default value for the various _ANSWER_DATE parameters.
 DEFAULT_2018_ANSWERS = False    !   [Boolean] default = False
                                 ! This sets the default value for the various _2018_ANSWERS parameters.
 SURFACE_2018_ANSWERS = False    !   [Boolean] default = False
                                 ! If true, use expressions for the surface properties that recover the answers
                                 ! from the end of 2018. Otherwise, use more appropriate expressions that differ
                                 ! at roundoff for non-Boussinesq cases.
+SURFACE_ANSWER_DATE = 99991231  ! default = 99991231
+                                ! The vintage of the expressions for the surface properties.  Values below
+                                ! 20190101 recover the answers from the end of 2018, while higher values use
+                                ! updated and more robust forms of the same expressions.  If both
+                                ! SURFACE_2018_ANSWERS and SURFACE_ANSWER_DATE are specified, the latter takes
+                                ! precedence.
 USE_DIABATIC_TIME_BUG = False   !   [Boolean] default = False
                                 ! If true, uses the wrong calendar time for diabatic processes, as was done in
                                 ! MOM6 versions prior to February 2018. This is not recommended.
@@ -129,6 +145,9 @@ WRITE_GEOM = 1                  ! default = 1
                                 ! If =0, never write the geometry and vertical grid files. If =1, write the
                                 ! geometry and vertical grid files only for a new simulation. If =2, always
                                 ! write the geometry and vertical grid files. Other values are invalid.
+USE_DBCLIENT = False            !   [Boolean] default = False
+                                ! If true, initialize a client to a remote database that can be used for online
+                                ! analysis and machine-learning inference.
 ICE_SHELF = False               !   [Boolean] default = False
                                 ! If true, enables the ice shelf model.
 USE_PARTICLES = False           !   [Boolean] default = False
@@ -270,6 +289,8 @@ CHANNEL_CONFIG = "none"         ! default = "none"
                                 !       test case.
                                 !     file - Read open face widths everywhere from a
                                 !       NetCDF file on the model grid.
+SUBGRID_TOPO_AT_VEL = False     !   [Boolean] default = False
+                                ! If true, use variables from TOPO_AT_VEL_FILE as parameters for porous barrier.
 ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -536,6 +557,13 @@ REMAPPING_2018_ANSWERS = False  !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use updated and more robust forms of the
                                 ! same expressions.
+REMAPPING_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the expressions and order of arithmetic to use for remapping.
+                                ! Values below 20190101 result in the use of older, less accurate expressions
+                                ! that were in use at the end of 2018.  Higher values result in the use of more
+                                ! robust and accurate forms of mathematically equivalent expressions.  If both
+                                ! REMAPPING_2018_ANSWERS and REMAPPING_ANSWER_DATE are specified, the latter
+                                ! takes precedence.
 USE_GRID_SPACE_DIAGNOSTIC_AXES = False !   [Boolean] default = False
                                 ! If true, use a grid index coordinate convention for diagnostic axes.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
@@ -612,6 +640,9 @@ USE_STORED_SLOPES = False       !   [Boolean] default = False
 VERY_SMALL_FREQUENCY = 1.0E-17  !   [s-1] default = 1.0E-17
                                 ! A miniscule frequency that is used to avoid division by 0.  The default value
                                 ! is roughly (pi / (the age of the universe)).
+USE_STANLEY_ISO = False         !   [Boolean] default = False
+                                ! If true, turn on Stanley SGS T variance parameterization in isopycnal slope
+                                ! code.
 USE_QG_LEITH_GM = False         !   [Boolean] default = False
                                 ! If true, use the QG Leith viscosity as the GM coefficient.
 
@@ -620,10 +651,21 @@ SET_VISC_2018_ANSWERS = False   !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use updated and more robust forms of the
                                 ! same expressions.
+SET_VISC_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the order of arithmetic and expressions in the set viscosity
+                                ! calculations.  Values below 20190101 recover the answers from the end of 2018,
+                                ! while higher values use updated and more robust forms of the same expressions.
+                                ! If both SET_VISC_2018_ANSWERS and SET_VISC_ANSWER_DATE are specified, the
+                                ! latter takes precedence.
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
                                 ! If true, the bottom stress is calculated with a drag law of the form
                                 ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
                                 ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
+DRAG_AS_BODY_FORCE = False      !   [Boolean] default = False
+                                ! If true, the bottom stress is imposed as an explicit body force applied over a
+                                ! fixed distance from the bottom, rather than as an implicit calculation based
+                                ! on an enhanced near-bottom viscosity. The thickness of the bottom boundary
+                                ! layer is HBBL.
 CHANNEL_DRAG = False            !   [Boolean] default = False
                                 ! If true, the bottom drag is exerted directly on each layer proportional to the
                                 ! fraction of the bottom it overlies.
@@ -723,10 +765,8 @@ KD_SMOOTH = 1.0E-06             !   [m2 s-1] default = 1.0E-06
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
                                 ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
                                 ! effectively emphasizes graver vertical modes by smoothing in the vertical.
-STANLEY_PRM_DET_COEFF = -1.0    !   [nondim] default = -1.0
-                                ! The coefficient correlating SGS temperature variance with the mean temperature
-                                ! gradient in the deterministic part of the Stanley parameterization. Negative
-                                ! values disable the scheme.
+USE_STANLEY_GM = False          !   [Boolean] default = False
+                                ! If true, turn on Stanley SGS T variance parameterization in GM code.
 MEKE_GM_SRC_ALT = False         !   [Boolean] default = False
                                 ! If true, use the GM energy conversion form S^2*N^2*kappa rather than the
                                 ! streamfunction for the GM source term.
@@ -741,6 +781,30 @@ USE_GME = False                 !   [Boolean] default = False
 USE_GM_WORK_BUG = False         !   [Boolean] default = False
                                 ! If true, compute the top-layer work tendency on the u-grid with the incorrect
                                 ! sign, for legacy reproducibility.
+STOCH_EOS = False               !   [Boolean] default = False
+                                ! If true, stochastic perturbations are applied to the EOS in the PGF.
+STANLEY_COEFF = -1.0            !   [not defined] default = -1.0
+                                ! Coefficient correlating the temperature gradient and SGS T variance.
+STANLEY_A = 1.0                 !   [not defined] default = 1.0
+                                ! Coefficient a which scales chi in stochastic perturbation of the SGS T
+                                ! variance.
+
+! === module MOM_porous_barriers ===
+PORBAR_ANSWER_DATE = 99991231   ! default = 99991231
+                                ! The vintage of the porous barrier weight function calculations.  Values below
+                                ! 20220806 recover the old answers in which the layer averaged weights are not
+                                ! strictly limited by an upper-bound of 1.0 .
+PORBAR_MASKING_DEPTH = 0.0      !   [m] default = 0.0
+                                ! If the effective average depth at the velocity cell is shallower than this
+                                ! number, then porous barrier is not applied at that location.
+                                ! PORBAR_MASKING_DEPTH is assumed to be positive below the sea surface.
+PORBAR_ETA_INTERP = "MAX"       ! default = "MAX"
+                                ! A string describing the method that decicdes how the interface heights at the
+                                ! velocity points are calculated. Valid values are:
+                                !    MAX (the default) - maximum of the adjacent cells
+                                !    MIN - minimum of the adjacent cells
+                                !    ARITHMETIC - arithmetic mean of the adjacent cells
+                                !    HARMOINIC - harmonic mean of the adjacent cells
 
 ! === module MOM_dynamics_split_RK2 ===
 TIDES = False                   !   [Boolean] default = False
@@ -872,16 +936,20 @@ BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
                                 ! If true, the reconstruction of T & S for pressure in boundary cells is
                                 ! extrapolated, rather than using PCM in these cells. If true, the same order
                                 ! polynomial is used as is used for the interior cells.
-PGF_STANLEY_T2_DET_COEFF = -1.0 !   [nondim] default = -1.0
-                                ! The coefficient correlating SGS temperature variance with the mean temperature
-                                ! gradient in the deterministic part of the Stanley form of the Brankart
-                                ! correction. Negative values disable the scheme.
+USE_STANLEY_PGF = False         !   [Boolean] default = False
+                                ! If true, turn on Stanley SGS T variance parameterization in PGF code.
 
 ! === module MOM_hor_visc ===
 HOR_VISC_2018_ANSWERS = False   !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use updated and more robust forms of the
                                 ! same expressions.
+HOR_VISC_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the order of arithmetic and expressions in the horizontal
+                                ! viscosity calculations.  Values below 20190101 recover the answers from the
+                                ! end of 2018, while higher values use updated and more robust forms of the same
+                                ! expressions.  If both HOR_VISC_2018_ANSWERS and HOR_VISC_ANSWER_DATE are
+                                ! specified, the latter takes precedence.
 LAPLACIAN = False               !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 BIHARMONIC = True               !   [Boolean] default = True
@@ -934,6 +1002,13 @@ VERT_FRICTION_2018_ANSWERS = False !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use expressions that do not use an arbitrary
                                 ! hard-coded maximum viscous coupling coefficient between layers.
+VERT_FRICTION_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the order of arithmetic and expressions in the viscous
+                                ! calculations.  Values below 20190101 recover the answers from the end of 2018,
+                                ! while higher values use expressions that do not use an arbitrary hard-coded
+                                ! maximum viscous coupling coefficient  between layers.  If both
+                                ! VERT_FRICTION_2018_ANSWERS and VERT_FRICTION_ANSWER_DATE are specified, the
+                                ! latter takes precedence.
 DIRECT_STRESS = False           !   [Boolean] default = False
                                 ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
                                 ! (like in HYCOM), and KVML may be set to a very small value.
@@ -1015,6 +1090,11 @@ BT_CORIOLIS_SCALE = 1.0         !   [nondim] default = 1.0
 BAROTROPIC_2018_ANSWERS = False !   [Boolean] default = False
                                 ! If true, use expressions for the barotropic solver that recover the answers
                                 ! from the end of 2018.  Otherwise, use more efficient or general expressions.
+BAROTROPIC_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the expressions in the barotropic solver. Values below 20190101
+                                ! recover the answers from the end of 2018, while higher values uuse more
+                                ! efficient or general expressions.  If both BAROTROPIC_2018_ANSWERS and
+                                ! BAROTROPIC_ANSWER_DATE are specified, the latter takes precedence.
 SADOURNY = True                 !   [Boolean] default = True
                                 ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
                                 ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
@@ -1087,6 +1167,8 @@ FOX_KEMPER_ML_RESTRAT_COEF = 5.0 !   [nondim] default = 0.0
                                 ! energy to the large-scale geostrophic kinetic energy or 1 plus the square of
                                 ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
                                 ! (2010)
+USE_STANLEY_ML = False          !   [Boolean] default = False
+                                ! If true, turn on Stanley SGS T variance parameterization in ML restrat code.
 
 ! === module MOM_diagnostics ===
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
@@ -1192,6 +1274,12 @@ SET_DIFF_2018_ANSWERS = False   !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use updated and more robust forms of the
                                 ! same expressions.
+SET_DIFF_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the order of arithmetic and expressions in the set diffusivity
+                                ! calculations.  Values below 20190101 recover the answers from the end of 2018,
+                                ! while higher values use updated and more robust forms of the same expressions.
+                                ! If both SET_DIFF_2018_ANSWERS and SET_DIFF_ANSWER_DATE are specified, the
+                                ! latter takes precedence.
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
@@ -1513,6 +1601,12 @@ OPTICS_2018_ANSWERS = False     !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use updated expressions for handling the
                                 ! absorption of small remaining shortwave fluxes.
+OPTICS_ANSWER_DATE = 99991231   ! default = 99991231
+                                ! The vintage of the order of arithmetic and expressions in the optics
+                                ! calculations.  Values below 20190101 recover the answers from the end of 2018,
+                                ! while higher values use updated and more robust forms of the same expressions.
+                                ! If both OPTICS_2018_ANSWERS and OPTICS_ANSWER_DATE are specified, the latter
+                                ! takes precedence.
 PEN_SW_FLUX_ABSORB = 2.5E-11    !   [degC m s-1] default = 2.5E-11
                                 ! A minimum remaining shortwave heating rate that will be simply absorbed in the
                                 ! next sufficiently thick layers for computational efficiency, instead of

--- a/ocean_only/MESO_025_63L/MOM_parameter_doc.short
+++ b/ocean_only/MESO_025_63L/MOM_parameter_doc.short
@@ -242,6 +242,8 @@ KV = 0.001                      !   [m2 s-1]
 
 ! === module MOM_thickness_diffuse ===
 
+! === module MOM_porous_barriers ===
+
 ! === module MOM_dynamics_split_RK2 ===
 
 ! === module MOM_continuity ===

--- a/ocean_only/Phillips_2layer/MOM_input
+++ b/ocean_only/Phillips_2layer/MOM_input
@@ -292,7 +292,7 @@ HARMONIC_VISC = True            !   [Boolean] default = False
 HMIX_FIXED = 20.0               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08

--- a/ocean_only/Phillips_2layer/MOM_parameter_doc.all
+++ b/ocean_only/Phillips_2layer/MOM_parameter_doc.all
@@ -915,7 +915,7 @@ HMIX_FIXED = 20.0               !   [m]
                                 ! elevated when the bulk mixed layer is not used.
 HMIX_STRESS = 20.0              !   [m] default = 20.0
                                 ! The depth over which the wind stress is applied if DIRECT_STRESS is true.
-KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08

--- a/ocean_only/Phillips_2layer/MOM_parameter_doc.short
+++ b/ocean_only/Phillips_2layer/MOM_parameter_doc.short
@@ -285,7 +285,7 @@ HARMONIC_VISC = True            !   [Boolean] default = False
 HMIX_FIXED = 20.0               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08

--- a/ocean_only/SCM_idealized_hurricane/MOM_input
+++ b/ocean_only/SCM_idealized_hurricane/MOM_input
@@ -248,6 +248,9 @@ HARMONIC_VISC = True            !   [Boolean] default = False
 HMIX_FIXED = 0.01               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity components are truncated.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0

--- a/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.all
+++ b/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.all
@@ -1025,7 +1025,7 @@ HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
 HMIX_FIXED = 0.01               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVML = 1.0E-04                  !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08

--- a/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.short
+++ b/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.short
@@ -239,6 +239,9 @@ HARMONIC_VISC = True            !   [Boolean] default = False
 HMIX_FIXED = 0.01               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity components are truncated.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0

--- a/ocean_only/buoy_forced_basin/MOM_input
+++ b/ocean_only/buoy_forced_basin/MOM_input
@@ -186,7 +186,7 @@ SMAG_BI_CONST = 0.05            !   [nondim] default = 0.0
 HMIX_FIXED = 20.0               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08

--- a/ocean_only/buoy_forced_basin/MOM_parameter_doc.all
+++ b/ocean_only/buoy_forced_basin/MOM_parameter_doc.all
@@ -904,7 +904,7 @@ HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
 HMIX_FIXED = 20.0               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 KVBBL = 1.0E-04                 !   [m2 s-1] default = 1.0E-04

--- a/ocean_only/buoy_forced_basin/MOM_parameter_doc.all
+++ b/ocean_only/buoy_forced_basin/MOM_parameter_doc.all
@@ -45,6 +45,9 @@ THICKNESSDIFFUSE = False        !   [Boolean] default = False
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
                                 ! If true, do thickness diffusion before dynamics. This is only used if
                                 ! THICKNESSDIFFUSE is true.
+USE_POROUS_BARRIER = True       !   [Boolean] default = True
+                                ! If true, use porous barrier to constrain the widths and face areas at the
+                                ! edges of the grid cells.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
                                 ! If true, there are separate values for the basin depths at velocity points.
                                 ! Otherwise the effects of topography are entirely determined from thickness
@@ -95,12 +98,20 @@ ALTERNATE_FIRST_DIRECTION = False !   [Boolean] default = False
                                 ! first direction can not be found in the restart file.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
+DEFAULT_ANSWER_DATE = 99991231  ! default = 99991231
+                                ! This sets the default value for the various _ANSWER_DATE parameters.
 DEFAULT_2018_ANSWERS = False    !   [Boolean] default = False
                                 ! This sets the default value for the various _2018_ANSWERS parameters.
 SURFACE_2018_ANSWERS = False    !   [Boolean] default = False
                                 ! If true, use expressions for the surface properties that recover the answers
                                 ! from the end of 2018. Otherwise, use more appropriate expressions that differ
                                 ! at roundoff for non-Boussinesq cases.
+SURFACE_ANSWER_DATE = 99991231  ! default = 99991231
+                                ! The vintage of the expressions for the surface properties.  Values below
+                                ! 20190101 recover the answers from the end of 2018, while higher values use
+                                ! updated and more robust forms of the same expressions.  If both
+                                ! SURFACE_2018_ANSWERS and SURFACE_ANSWER_DATE are specified, the latter takes
+                                ! precedence.
 USE_DIABATIC_TIME_BUG = False   !   [Boolean] default = False
                                 ! If true, uses the wrong calendar time for diabatic processes, as was done in
                                 ! MOM6 versions prior to February 2018. This is not recommended.
@@ -112,6 +123,9 @@ WRITE_GEOM = 1                  ! default = 1
                                 ! If =0, never write the geometry and vertical grid files. If =1, write the
                                 ! geometry and vertical grid files only for a new simulation. If =2, always
                                 ! write the geometry and vertical grid files. Other values are invalid.
+USE_DBCLIENT = False            !   [Boolean] default = False
+                                ! If true, initialize a client to a remote database that can be used for online
+                                ! analysis and machine-learning inference.
 ICE_SHELF = False               !   [Boolean] default = False
                                 ! If true, enables the ice shelf model.
 USE_PARTICLES = False           !   [Boolean] default = False
@@ -242,6 +256,8 @@ CHANNEL_CONFIG = "none"         ! default = "none"
                                 !       test case.
                                 !     file - Read open face widths everywhere from a
                                 !       NetCDF file on the model grid.
+SUBGRID_TOPO_AT_VEL = False     !   [Boolean] default = False
+                                ! If true, use variables from TOPO_AT_VEL_FILE as parameters for porous barrier.
 ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -432,6 +448,13 @@ REMAPPING_2018_ANSWERS = False  !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use updated and more robust forms of the
                                 ! same expressions.
+REMAPPING_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the expressions and order of arithmetic to use for remapping.
+                                ! Values below 20190101 result in the use of older, less accurate expressions
+                                ! that were in use at the end of 2018.  Higher values result in the use of more
+                                ! robust and accurate forms of mathematically equivalent expressions.  If both
+                                ! REMAPPING_2018_ANSWERS and REMAPPING_ANSWER_DATE are specified, the latter
+                                ! takes precedence.
 USE_GRID_SPACE_DIAGNOSTIC_AXES = False !   [Boolean] default = False
                                 ! If true, use a grid index coordinate convention for diagnostic axes.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
@@ -508,6 +531,9 @@ USE_STORED_SLOPES = False       !   [Boolean] default = False
 VERY_SMALL_FREQUENCY = 1.0E-17  !   [s-1] default = 1.0E-17
                                 ! A miniscule frequency that is used to avoid division by 0.  The default value
                                 ! is roughly (pi / (the age of the universe)).
+USE_STANLEY_ISO = False         !   [Boolean] default = False
+                                ! If true, turn on Stanley SGS T variance parameterization in isopycnal slope
+                                ! code.
 USE_QG_LEITH_GM = False         !   [Boolean] default = False
                                 ! If true, use the QG Leith viscosity as the GM coefficient.
 
@@ -516,6 +542,12 @@ SET_VISC_2018_ANSWERS = False   !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use updated and more robust forms of the
                                 ! same expressions.
+SET_VISC_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the order of arithmetic and expressions in the set viscosity
+                                ! calculations.  Values below 20190101 recover the answers from the end of 2018,
+                                ! while higher values use updated and more robust forms of the same expressions.
+                                ! If both SET_VISC_2018_ANSWERS and SET_VISC_ANSWER_DATE are specified, the
+                                ! latter takes precedence.
 BOTTOMDRAGLAW = False           !   [Boolean] default = True
                                 ! If true, the bottom stress is calculated with a drag law of the form
                                 ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
@@ -591,10 +623,8 @@ KD_SMOOTH = 1.0E-06             !   [m2 s-1] default = 1.0E-06
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
                                 ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
                                 ! effectively emphasizes graver vertical modes by smoothing in the vertical.
-STANLEY_PRM_DET_COEFF = -1.0    !   [nondim] default = -1.0
-                                ! The coefficient correlating SGS temperature variance with the mean temperature
-                                ! gradient in the deterministic part of the Stanley parameterization. Negative
-                                ! values disable the scheme.
+USE_STANLEY_GM = False          !   [Boolean] default = False
+                                ! If true, turn on Stanley SGS T variance parameterization in GM code.
 MEKE_GM_SRC_ALT = False         !   [Boolean] default = False
                                 ! If true, use the GM energy conversion form S^2*N^2*kappa rather than the
                                 ! streamfunction for the GM source term.
@@ -609,6 +639,30 @@ USE_GME = False                 !   [Boolean] default = False
 USE_GM_WORK_BUG = False         !   [Boolean] default = False
                                 ! If true, compute the top-layer work tendency on the u-grid with the incorrect
                                 ! sign, for legacy reproducibility.
+STOCH_EOS = False               !   [Boolean] default = False
+                                ! If true, stochastic perturbations are applied to the EOS in the PGF.
+STANLEY_COEFF = -1.0            !   [not defined] default = -1.0
+                                ! Coefficient correlating the temperature gradient and SGS T variance.
+STANLEY_A = 1.0                 !   [not defined] default = 1.0
+                                ! Coefficient a which scales chi in stochastic perturbation of the SGS T
+                                ! variance.
+
+! === module MOM_porous_barriers ===
+PORBAR_ANSWER_DATE = 99991231   ! default = 99991231
+                                ! The vintage of the porous barrier weight function calculations.  Values below
+                                ! 20220806 recover the old answers in which the layer averaged weights are not
+                                ! strictly limited by an upper-bound of 1.0 .
+PORBAR_MASKING_DEPTH = 0.0      !   [m] default = 0.0
+                                ! If the effective average depth at the velocity cell is shallower than this
+                                ! number, then porous barrier is not applied at that location.
+                                ! PORBAR_MASKING_DEPTH is assumed to be positive below the sea surface.
+PORBAR_ETA_INTERP = "MAX"       ! default = "MAX"
+                                ! A string describing the method that decicdes how the interface heights at the
+                                ! velocity points are calculated. Valid values are:
+                                !    MAX (the default) - maximum of the adjacent cells
+                                !    MIN - minimum of the adjacent cells
+                                !    ARITHMETIC - arithmetic mean of the adjacent cells
+                                !    HARMOINIC - harmonic mean of the adjacent cells
 
 ! === module MOM_dynamics_split_RK2 ===
 TIDES = False                   !   [Boolean] default = False
@@ -740,16 +794,20 @@ BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
                                 ! If true, the reconstruction of T & S for pressure in boundary cells is
                                 ! extrapolated, rather than using PCM in these cells. If true, the same order
                                 ! polynomial is used as is used for the interior cells.
-PGF_STANLEY_T2_DET_COEFF = -1.0 !   [nondim] default = -1.0
-                                ! The coefficient correlating SGS temperature variance with the mean temperature
-                                ! gradient in the deterministic part of the Stanley form of the Brankart
-                                ! correction. Negative values disable the scheme.
+USE_STANLEY_PGF = False         !   [Boolean] default = False
+                                ! If true, turn on Stanley SGS T variance parameterization in PGF code.
 
 ! === module MOM_hor_visc ===
 HOR_VISC_2018_ANSWERS = False   !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use updated and more robust forms of the
                                 ! same expressions.
+HOR_VISC_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the order of arithmetic and expressions in the horizontal
+                                ! viscosity calculations.  Values below 20190101 recover the answers from the
+                                ! end of 2018, while higher values use updated and more robust forms of the same
+                                ! expressions.  If both HOR_VISC_2018_ANSWERS and HOR_VISC_ANSWER_DATE are
+                                ! specified, the latter takes precedence.
 LAPLACIAN = True                !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 KH = 1000.0                     !   [m2 s-1] default = 0.0
@@ -826,6 +884,13 @@ VERT_FRICTION_2018_ANSWERS = False !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use expressions that do not use an arbitrary
                                 ! hard-coded maximum viscous coupling coefficient between layers.
+VERT_FRICTION_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the order of arithmetic and expressions in the viscous
+                                ! calculations.  Values below 20190101 recover the answers from the end of 2018,
+                                ! while higher values use expressions that do not use an arbitrary hard-coded
+                                ! maximum viscous coupling coefficient  between layers.  If both
+                                ! VERT_FRICTION_2018_ANSWERS and VERT_FRICTION_ANSWER_DATE are specified, the
+                                ! latter takes precedence.
 DIRECT_STRESS = False           !   [Boolean] default = False
                                 ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
                                 ! (like in HYCOM), and KVML may be set to a very small value.
@@ -913,6 +978,11 @@ BT_CORIOLIS_SCALE = 1.0         !   [nondim] default = 1.0
 BAROTROPIC_2018_ANSWERS = False !   [Boolean] default = False
                                 ! If true, use expressions for the barotropic solver that recover the answers
                                 ! from the end of 2018.  Otherwise, use more efficient or general expressions.
+BAROTROPIC_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the expressions in the barotropic solver. Values below 20190101
+                                ! recover the answers from the end of 2018, while higher values uuse more
+                                ! efficient or general expressions.  If both BAROTROPIC_2018_ANSWERS and
+                                ! BAROTROPIC_ANSWER_DATE are specified, the latter takes precedence.
 SADOURNY = True                 !   [Boolean] default = True
                                 ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
                                 ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
@@ -1077,6 +1147,12 @@ SET_DIFF_2018_ANSWERS = False   !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use updated and more robust forms of the
                                 ! same expressions.
+SET_DIFF_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the order of arithmetic and expressions in the set diffusivity
+                                ! calculations.  Values below 20190101 recover the answers from the end of 2018,
+                                ! while higher values use updated and more robust forms of the same expressions.
+                                ! If both SET_DIFF_2018_ANSWERS and SET_DIFF_ANSWER_DATE are specified, the
+                                ! latter takes precedence.
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization

--- a/ocean_only/buoy_forced_basin/MOM_parameter_doc.short
+++ b/ocean_only/buoy_forced_basin/MOM_parameter_doc.short
@@ -151,6 +151,8 @@ KV = 1.0E-04                    !   [m2 s-1]
 
 ! === module MOM_thickness_diffuse ===
 
+! === module MOM_porous_barriers ===
+
 ! === module MOM_dynamics_split_RK2 ===
 
 ! === module MOM_continuity ===

--- a/ocean_only/buoy_forced_basin/MOM_parameter_doc.short
+++ b/ocean_only/buoy_forced_basin/MOM_parameter_doc.short
@@ -179,7 +179,7 @@ SMAG_BI_CONST = 0.05            !   [nondim] default = 0.0
 HMIX_FIXED = 20.0               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08

--- a/ocean_only/circle_obcs/MOM_input
+++ b/ocean_only/circle_obcs/MOM_input
@@ -277,7 +277,7 @@ HARMONIC_VISC = True            !   [Boolean] default = False
 HMIX_FIXED = 20.0               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08

--- a/ocean_only/circle_obcs/MOM_parameter_doc.all
+++ b/ocean_only/circle_obcs/MOM_parameter_doc.all
@@ -1023,7 +1023,7 @@ HMIX_FIXED = 20.0               !   [m]
                                 ! elevated when the bulk mixed layer is not used.
 HMIX_STRESS = 20.0              !   [m] default = 20.0
                                 ! The depth over which the wind stress is applied if DIRECT_STRESS is true.
-KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08

--- a/ocean_only/circle_obcs/MOM_parameter_doc.short
+++ b/ocean_only/circle_obcs/MOM_parameter_doc.short
@@ -270,7 +270,7 @@ HARMONIC_VISC = True            !   [Boolean] default = False
 HMIX_FIXED = 20.0               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08

--- a/ocean_only/external_gwave/MOM_input
+++ b/ocean_only/external_gwave/MOM_input
@@ -277,6 +277,9 @@ BIHARMONIC = False              !   [Boolean] default = True
 HMIX_FIXED = 1.0E-10            !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity components are truncated.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0

--- a/ocean_only/external_gwave/MOM_parameter_doc.all
+++ b/ocean_only/external_gwave/MOM_parameter_doc.all
@@ -964,7 +964,7 @@ HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
 HMIX_FIXED = 1.0E-10            !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVML = 1.0E-04                  !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08

--- a/ocean_only/external_gwave/MOM_parameter_doc.short
+++ b/ocean_only/external_gwave/MOM_parameter_doc.short
@@ -270,6 +270,9 @@ BIHARMONIC = False              !   [Boolean] default = True
 HMIX_FIXED = 1.0E-10            !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity components are truncated.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0

--- a/ocean_only/flow_downslope/common/MOM_input
+++ b/ocean_only/flow_downslope/common/MOM_input
@@ -295,7 +295,7 @@ DIRECT_STRESS = True            !   [Boolean] default = False
 HMIX_FIXED = 20.0               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08

--- a/ocean_only/flow_downslope/layer/MOM_parameter_doc.all
+++ b/ocean_only/flow_downslope/layer/MOM_parameter_doc.all
@@ -975,7 +975,7 @@ HMIX_FIXED = 20.0               !   [m]
                                 ! elevated when the bulk mixed layer is not used.
 HMIX_STRESS = 20.0              !   [m] default = 20.0
                                 ! The depth over which the wind stress is applied if DIRECT_STRESS is true.
-KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08

--- a/ocean_only/flow_downslope/layer/MOM_parameter_doc.short
+++ b/ocean_only/flow_downslope/layer/MOM_parameter_doc.short
@@ -288,7 +288,7 @@ DIRECT_STRESS = True            !   [Boolean] default = False
 HMIX_FIXED = 20.0               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08

--- a/ocean_only/flow_downslope/rho/MOM_parameter_doc.all
+++ b/ocean_only/flow_downslope/rho/MOM_parameter_doc.all
@@ -1119,7 +1119,7 @@ HMIX_FIXED = 20.0               !   [m]
                                 ! elevated when the bulk mixed layer is not used.
 HMIX_STRESS = 20.0              !   [m] default = 20.0
                                 ! The depth over which the wind stress is applied if DIRECT_STRESS is true.
-KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08

--- a/ocean_only/flow_downslope/rho/MOM_parameter_doc.short
+++ b/ocean_only/flow_downslope/rho/MOM_parameter_doc.short
@@ -337,7 +337,7 @@ DIRECT_STRESS = True            !   [Boolean] default = False
 HMIX_FIXED = 20.0               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08

--- a/ocean_only/flow_downslope/sigma/MOM_parameter_doc.all
+++ b/ocean_only/flow_downslope/sigma/MOM_parameter_doc.all
@@ -1078,7 +1078,7 @@ HMIX_FIXED = 20.0               !   [m]
                                 ! elevated when the bulk mixed layer is not used.
 HMIX_STRESS = 20.0              !   [m] default = 20.0
                                 ! The depth over which the wind stress is applied if DIRECT_STRESS is true.
-KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08

--- a/ocean_only/flow_downslope/sigma/MOM_parameter_doc.short
+++ b/ocean_only/flow_downslope/sigma/MOM_parameter_doc.short
@@ -315,7 +315,7 @@ DIRECT_STRESS = True            !   [Boolean] default = False
 HMIX_FIXED = 20.0               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08

--- a/ocean_only/flow_downslope/z/MOM_parameter_doc.all
+++ b/ocean_only/flow_downslope/z/MOM_parameter_doc.all
@@ -1078,7 +1078,7 @@ HMIX_FIXED = 20.0               !   [m]
                                 ! elevated when the bulk mixed layer is not used.
 HMIX_STRESS = 20.0              !   [m] default = 20.0
                                 ! The depth over which the wind stress is applied if DIRECT_STRESS is true.
-KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08

--- a/ocean_only/flow_downslope/z/MOM_parameter_doc.short
+++ b/ocean_only/flow_downslope/z/MOM_parameter_doc.short
@@ -315,7 +315,7 @@ DIRECT_STRESS = True            !   [Boolean] default = False
 HMIX_FIXED = 20.0               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08

--- a/ocean_only/global/MOM_input
+++ b/ocean_only/global/MOM_input
@@ -347,6 +347,10 @@ BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! use a predictor continuity step to find the pressure field, and then to do a
                                 ! corrector continuity step using a weighted average of the old and new
                                 ! velocities, with weights of (1-BEBT) and BEBT.
+BAROTROPIC_TIDAL_SAL_BUG = False !   [Boolean] default = True
+                                ! If true, the tidal self-attraction and loading anomaly in the barotropic
+                                ! solver has the wrong sign, replicating a long-standing bug with a scalar
+                                ! self-attraction and loading term or the SAL term from a previous simulation.
 BEBT = 0.2                      !   [nondim] default = 0.1
                                 ! BEBT determines whether the barotropic time stepping uses the forward-backward
                                 ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range

--- a/ocean_only/global/MOM_parameter_doc.all
+++ b/ocean_only/global/MOM_parameter_doc.all
@@ -45,6 +45,9 @@ THICKNESSDIFFUSE = True         !   [Boolean] default = False
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
                                 ! If true, do thickness diffusion before dynamics. This is only used if
                                 ! THICKNESSDIFFUSE is true.
+USE_POROUS_BARRIER = True       !   [Boolean] default = True
+                                ! If true, use porous barrier to constrain the widths and face areas at the
+                                ! edges of the grid cells.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
                                 ! If true, there are separate values for the basin depths at velocity points.
                                 ! Otherwise the effects of topography are entirely determined from thickness
@@ -87,6 +90,11 @@ BOUND_SALINITY = True           !   [Boolean] default = False
                                 ! salt than is available and drive the salinity negative otherwise.)
 MIN_SALINITY = 0.0              !   [PPT] default = 0.0
                                 ! The minimum value of salinity when BOUND_SALINITY=True.
+SALINITY_UNDERFLOW = 0.0        !   [PPT] default = 0.0
+                                ! A tiny value of salinity below which the it is set to 0.  For reference, one
+                                ! molecule of salt per square meter of ocean is of order 1e-29 ppt.
+TEMPERATURE_UNDERFLOW = 0.0     !   [degC] default = 0.0
+                                ! A tiny magnitude of temperatures below which they are set to 0.
 C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
                                 ! The heat capacity of sea water, approximated as a constant. This is only used
                                 ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
@@ -114,12 +122,20 @@ ALTERNATE_FIRST_DIRECTION = False !   [Boolean] default = False
                                 ! first direction can not be found in the restart file.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
+DEFAULT_ANSWER_DATE = 99991231  ! default = 99991231
+                                ! This sets the default value for the various _ANSWER_DATE parameters.
 DEFAULT_2018_ANSWERS = False    !   [Boolean] default = False
                                 ! This sets the default value for the various _2018_ANSWERS parameters.
 SURFACE_2018_ANSWERS = False    !   [Boolean] default = False
                                 ! If true, use expressions for the surface properties that recover the answers
                                 ! from the end of 2018. Otherwise, use more appropriate expressions that differ
                                 ! at roundoff for non-Boussinesq cases.
+SURFACE_ANSWER_DATE = 99991231  ! default = 99991231
+                                ! The vintage of the expressions for the surface properties.  Values below
+                                ! 20190101 recover the answers from the end of 2018, while higher values use
+                                ! updated and more robust forms of the same expressions.  If both
+                                ! SURFACE_2018_ANSWERS and SURFACE_ANSWER_DATE are specified, the latter takes
+                                ! precedence.
 USE_DIABATIC_TIME_BUG = False   !   [Boolean] default = False
                                 ! If true, uses the wrong calendar time for diabatic processes, as was done in
                                 ! MOM6 versions prior to February 2018. This is not recommended.
@@ -131,6 +147,9 @@ WRITE_GEOM = 1                  ! default = 1
                                 ! If =0, never write the geometry and vertical grid files. If =1, write the
                                 ! geometry and vertical grid files only for a new simulation. If =2, always
                                 ! write the geometry and vertical grid files. Other values are invalid.
+USE_DBCLIENT = False            !   [Boolean] default = False
+                                ! If true, initialize a client to a remote database that can be used for online
+                                ! analysis and machine-learning inference.
 ICE_SHELF = False               !   [Boolean] default = False
                                 ! If true, enables the ice shelf model.
 USE_PARTICLES = False           !   [Boolean] default = False
@@ -190,6 +209,8 @@ GRID_FILE = "ocean_hgrid.nc"    !
 USE_TRIPOLAR_GEOLONB_BUG = False !   [Boolean] default = False
                                 ! If true, use older code that incorrectly sets the longitude in some points
                                 ! along the tripolar fold to be off by 360 degrees.
+RAD_EARTH = 6.378E+06           !   [m] default = 6.378E+06
+                                ! The radius of the Earth.
 TOPO_CONFIG = "file"            !
                                 ! This specifies how bathymetry is specified:
                                 !     file - read bathymetric information from the file
@@ -252,6 +273,8 @@ CHANNEL_CONFIG = "global_1deg"  ! default = "none"
                                 !       test case.
                                 !     file - Read open face widths everywhere from a
                                 !       NetCDF file on the model grid.
+SUBGRID_TOPO_AT_VEL = False     !   [Boolean] default = False
+                                ! If true, use variables from TOPO_AT_VEL_FILE as parameters for porous barrier.
 ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -508,6 +531,13 @@ REMAPPING_2018_ANSWERS = False  !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use updated and more robust forms of the
                                 ! same expressions.
+REMAPPING_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the expressions and order of arithmetic to use for remapping.
+                                ! Values below 20190101 result in the use of older, less accurate expressions
+                                ! that were in use at the end of 2018.  Higher values result in the use of more
+                                ! robust and accurate forms of mathematically equivalent expressions.  If both
+                                ! REMAPPING_2018_ANSWERS and REMAPPING_ANSWER_DATE are specified, the latter
+                                ! takes precedence.
 USE_GRID_SPACE_DIAGNOSTIC_AXES = False !   [Boolean] default = False
                                 ! If true, use a grid index coordinate convention for diagnostic axes.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
@@ -541,6 +571,14 @@ DIAG_COORD_DEF_Z = "WOA09"      ! default = "WOA09"
 USE_MEKE = True                 !   [Boolean] default = False
                                 ! If true, turns on the MEKE scheme which calculates a sub-grid mesoscale eddy
                                 ! kinetic energy budget.
+MEKE_IN_DYNAMICS = True         !   [Boolean] default = True
+                                ! If true, step MEKE forward with the dynamicsotherwise with the tracer
+                                ! timestep.
+EKE_SOURCE = "prog"             ! default = "prog"
+                                ! Determine the where EKE comes from:
+                                !   'prog': Calculated solving EKE equation
+                                !   'file': Read in from a file
+                                !   'dbclient': Retrieved from ML-database
 MEKE_DAMPING = 0.0              !   [s-1] default = 0.0
                                 ! The local depth-independent MEKE dissipation rate.
 MEKE_CD_SCALE = 0.0             !   [nondim] default = 0.0
@@ -712,6 +750,9 @@ USE_STORED_SLOPES = False       !   [Boolean] default = False
 VERY_SMALL_FREQUENCY = 1.0E-17  !   [s-1] default = 1.0E-17
                                 ! A miniscule frequency that is used to avoid division by 0.  The default value
                                 ! is roughly (pi / (the age of the universe)).
+USE_STANLEY_ISO = False         !   [Boolean] default = False
+                                ! If true, turn on Stanley SGS T variance parameterization in isopycnal slope
+                                ! code.
 USE_SIMPLER_EADY_GROWTH_RATE = False !   [Boolean] default = False
                                 ! If true, use a simpler method to calculate the Eady growth rate that avoids
                                 ! division by layer thickness. Recommended.
@@ -760,10 +801,21 @@ SET_VISC_2018_ANSWERS = False   !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use updated and more robust forms of the
                                 ! same expressions.
+SET_VISC_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the order of arithmetic and expressions in the set viscosity
+                                ! calculations.  Values below 20190101 recover the answers from the end of 2018,
+                                ! while higher values use updated and more robust forms of the same expressions.
+                                ! If both SET_VISC_2018_ANSWERS and SET_VISC_ANSWER_DATE are specified, the
+                                ! latter takes precedence.
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
                                 ! If true, the bottom stress is calculated with a drag law of the form
                                 ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
                                 ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
+DRAG_AS_BODY_FORCE = False      !   [Boolean] default = False
+                                ! If true, the bottom stress is imposed as an explicit body force applied over a
+                                ! fixed distance from the bottom, rather than as an implicit calculation based
+                                ! on an enhanced near-bottom viscosity. The thickness of the bottom boundary
+                                ! layer is HBBL.
 CHANNEL_DRAG = True             !   [Boolean] default = False
                                 ! If true, the bottom drag is exerted directly on each layer proportional to the
                                 ! fraction of the bottom it overlies.
@@ -831,6 +883,11 @@ SMAG_CONST_CHANNEL = 0.15       !   [nondim] default = 0.15
                                 ! channel drag if it is enabled.  The default is to use the same value as
                                 ! SMAG_LAP_CONST if it is defined, or 0.15 if it is not. The value used is also
                                 ! 0.15 if the specified value is negative.
+CHANNEL_DRAG_MAX_BBL_THICK = 5.0 !   [m] default = 5.0
+                                ! The maximum bottom boundary layer thickness over which the channel drag is
+                                ! exerted, or a negative value for no fixed limit, instead basing the BBL
+                                ! thickness on the bottom stress, rotation and stratification.  The default is
+                                ! proportional to HBBL if USE_JACKSON_PARAM or DRAG_AS_BODY_FORCE is true.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 10.0                     !   [m2 s-1] default = 0.0
@@ -865,10 +922,8 @@ KD_SMOOTH = 1.0E-06             !   [m2 s-1] default = 1.0E-06
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
                                 ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
                                 ! effectively emphasizes graver vertical modes by smoothing in the vertical.
-STANLEY_PRM_DET_COEFF = -1.0    !   [nondim] default = -1.0
-                                ! The coefficient correlating SGS temperature variance with the mean temperature
-                                ! gradient in the deterministic part of the Stanley parameterization. Negative
-                                ! values disable the scheme.
+USE_STANLEY_GM = False          !   [Boolean] default = False
+                                ! If true, turn on Stanley SGS T variance parameterization in GM code.
 USE_KH_IN_MEKE = False          !   [Boolean] default = False
                                 ! If true, uses the thickness diffusivity calculated here to diffuse MEKE.
 USE_GME = False                 !   [Boolean] default = False
@@ -877,6 +932,30 @@ USE_GME = False                 !   [Boolean] default = False
 USE_GM_WORK_BUG = False         !   [Boolean] default = False
                                 ! If true, compute the top-layer work tendency on the u-grid with the incorrect
                                 ! sign, for legacy reproducibility.
+STOCH_EOS = False               !   [Boolean] default = False
+                                ! If true, stochastic perturbations are applied to the EOS in the PGF.
+STANLEY_COEFF = -1.0            !   [not defined] default = -1.0
+                                ! Coefficient correlating the temperature gradient and SGS T variance.
+STANLEY_A = 1.0                 !   [not defined] default = 1.0
+                                ! Coefficient a which scales chi in stochastic perturbation of the SGS T
+                                ! variance.
+
+! === module MOM_porous_barriers ===
+PORBAR_ANSWER_DATE = 99991231   ! default = 99991231
+                                ! The vintage of the porous barrier weight function calculations.  Values below
+                                ! 20220806 recover the old answers in which the layer averaged weights are not
+                                ! strictly limited by an upper-bound of 1.0 .
+PORBAR_MASKING_DEPTH = 0.0      !   [m] default = 0.0
+                                ! If the effective average depth at the velocity cell is shallower than this
+                                ! number, then porous barrier is not applied at that location.
+                                ! PORBAR_MASKING_DEPTH is assumed to be positive below the sea surface.
+PORBAR_ETA_INTERP = "MAX"       ! default = "MAX"
+                                ! A string describing the method that decicdes how the interface heights at the
+                                ! velocity points are calculated. Valid values are:
+                                !    MAX (the default) - maximum of the adjacent cells
+                                !    MIN - minimum of the adjacent cells
+                                !    ARITHMETIC - arithmetic mean of the adjacent cells
+                                !    HARMOINIC - harmonic mean of the adjacent cells
 
 ! === module MOM_dynamics_split_RK2 ===
 TIDES = True                    !   [Boolean] default = False
@@ -1068,16 +1147,20 @@ BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
                                 ! If true, the reconstruction of T & S for pressure in boundary cells is
                                 ! extrapolated, rather than using PCM in these cells. If true, the same order
                                 ! polynomial is used as is used for the interior cells.
-PGF_STANLEY_T2_DET_COEFF = -1.0 !   [nondim] default = -1.0
-                                ! The coefficient correlating SGS temperature variance with the mean temperature
-                                ! gradient in the deterministic part of the Stanley form of the Brankart
-                                ! correction. Negative values disable the scheme.
+USE_STANLEY_PGF = False         !   [Boolean] default = False
+                                ! If true, turn on Stanley SGS T variance parameterization in PGF code.
 
 ! === module MOM_hor_visc ===
 HOR_VISC_2018_ANSWERS = False   !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use updated and more robust forms of the
                                 ! same expressions.
+HOR_VISC_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the order of arithmetic and expressions in the horizontal
+                                ! viscosity calculations.  Values below 20190101 recover the answers from the
+                                ! end of 2018, while higher values use updated and more robust forms of the same
+                                ! expressions.  If both HOR_VISC_2018_ANSWERS and HOR_VISC_ANSWER_DATE are
+                                ! specified, the latter takes precedence.
 LAPLACIAN = True                !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 KH = 0.0                        !   [m2 s-1] default = 0.0
@@ -1161,6 +1244,13 @@ VERT_FRICTION_2018_ANSWERS = False !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use expressions that do not use an arbitrary
                                 ! hard-coded maximum viscous coupling coefficient between layers.
+VERT_FRICTION_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the order of arithmetic and expressions in the viscous
+                                ! calculations.  Values below 20190101 recover the answers from the end of 2018,
+                                ! while higher values use expressions that do not use an arbitrary hard-coded
+                                ! maximum viscous coupling coefficient  between layers.  If both
+                                ! VERT_FRICTION_2018_ANSWERS and VERT_FRICTION_ANSWER_DATE are specified, the
+                                ! latter takes precedence.
 DIRECT_STRESS = False           !   [Boolean] default = False
                                 ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
                                 ! (like in HYCOM), and KVML may be set to a very small value.
@@ -1242,7 +1332,12 @@ BT_CORIOLIS_SCALE = 1.0         !   [nondim] default = 1.0
 BAROTROPIC_2018_ANSWERS = False !   [Boolean] default = False
                                 ! If true, use expressions for the barotropic solver that recover the answers
                                 ! from the end of 2018.  Otherwise, use more efficient or general expressions.
-BAROTROPIC_TIDAL_SAL_BUG = True !   [Boolean] default = True
+BAROTROPIC_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the expressions in the barotropic solver. Values below 20190101
+                                ! recover the answers from the end of 2018, while higher values uuse more
+                                ! efficient or general expressions.  If both BAROTROPIC_2018_ANSWERS and
+                                ! BAROTROPIC_ANSWER_DATE are specified, the latter takes precedence.
+BAROTROPIC_TIDAL_SAL_BUG = False !   [Boolean] default = True
                                 ! If true, the tidal self-attraction and loading anomaly in the barotropic
                                 ! solver has the wrong sign, replicating a long-standing bug with a scalar
                                 ! self-attraction and loading term or the SAL term from a previous simulation.
@@ -1318,6 +1413,8 @@ FOX_KEMPER_ML_RESTRAT_COEF = 20.0 !   [nondim] default = 0.0
                                 ! energy to the large-scale geostrophic kinetic energy or 1 plus the square of
                                 ! the grid spacing over the deformation radius, as detailed by Fox-Kemper et al.
                                 ! (2010)
+USE_STANLEY_ML = False          !   [Boolean] default = False
+                                ! If true, turn on Stanley SGS T variance parameterization in ML restrat code.
 
 ! === module MOM_diagnostics ===
 DIAG_EBT_MONO_N2_COLUMN_FRACTION = 0.0 !   [nondim] default = 0.0
@@ -1431,6 +1528,12 @@ SET_DIFF_2018_ANSWERS = False   !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use updated and more robust forms of the
                                 ! same expressions.
+SET_DIFF_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the order of arithmetic and expressions in the set diffusivity
+                                ! calculations.  Values below 20190101 recover the answers from the end of 2018,
+                                ! while higher values use updated and more robust forms of the same expressions.
+                                ! If both SET_DIFF_2018_ANSWERS and SET_DIFF_ANSWER_DATE are specified, the
+                                ! latter takes precedence.
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
@@ -1443,6 +1546,12 @@ TIDAL_MIXING_2018_ANSWERS = False !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use updated and more robust forms of the
                                 ! same expressions.
+TIDAL_MIXING_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the order of arithmetic and expressions in the tidal mixing
+                                ! calculations.  Values below 20190101 recover the answers from the end of 2018,
+                                ! while higher values use updated and more robust forms of the same expressions.
+                                ! If both TIDAL_MIXING_2018_ANSWERS and TIDAL_MIXING_ANSWER_DATE are specified,
+                                ! the latter takes precedence.
 INT_TIDE_PROFILE = "STLAURENT_02" ! default = "STLAURENT_02"
                                 ! INT_TIDE_PROFILE selects the vertical profile of energy dissipation with
                                 ! INT_TIDE_DISSIPATION. Valid values are:
@@ -1815,6 +1924,12 @@ OPTICS_2018_ANSWERS = False     !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use updated expressions for handling the
                                 ! absorption of small remaining shortwave fluxes.
+OPTICS_ANSWER_DATE = 99991231   ! default = 99991231
+                                ! The vintage of the order of arithmetic and expressions in the optics
+                                ! calculations.  Values below 20190101 recover the answers from the end of 2018,
+                                ! while higher values use updated and more robust forms of the same expressions.
+                                ! If both OPTICS_2018_ANSWERS and OPTICS_ANSWER_DATE are specified, the latter
+                                ! takes precedence.
 PEN_SW_FLUX_ABSORB = 2.5E-11    !   [degC m s-1] default = 2.5E-11
                                 ! A minimum remaining shortwave heating rate that will be simply absorbed in the
                                 ! next sufficiently thick layers for computational efficiency, instead of

--- a/ocean_only/global/MOM_parameter_doc.short
+++ b/ocean_only/global/MOM_parameter_doc.short
@@ -271,6 +271,8 @@ KHTH = 10.0                     !   [m2 s-1] default = 0.0
 KHTH_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 
+! === module MOM_porous_barriers ===
+
 ! === module MOM_dynamics_split_RK2 ===
 TIDES = True                    !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
@@ -338,6 +340,10 @@ BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! use a predictor continuity step to find the pressure field, and then to do a
                                 ! corrector continuity step using a weighted average of the old and new
                                 ! velocities, with weights of (1-BEBT) and BEBT.
+BAROTROPIC_TIDAL_SAL_BUG = False !   [Boolean] default = True
+                                ! If true, the tidal self-attraction and loading anomaly in the barotropic
+                                ! solver has the wrong sign, replicating a long-standing bug with a scalar
+                                ! self-attraction and loading term or the SAL term from a previous simulation.
 BEBT = 0.2                      !   [nondim] default = 0.1
                                 ! BEBT determines whether the barotropic time stepping uses the forward-backward
                                 ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range

--- a/ocean_only/global_ALE/SLight/MOM_override
+++ b/ocean_only/global_ALE/SLight/MOM_override
@@ -31,3 +31,6 @@ Z_INIT_REMAP_GENERAL = True
 Z_INIT_REMAP_FULL_COLUMN = True
 REMAP_AFTER_INITIALIZATION = False
 REGRID_TIME_SCALE = 86400.0
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.

--- a/ocean_only/global_ALE/common/MOM_input
+++ b/ocean_only/global_ALE/common/MOM_input
@@ -174,6 +174,10 @@ Z_INIT_FILE_PTEMP_VAR = "PTEMP" ! default = "ptemp"
                                 ! The name of the potential temperature variable in TEMP_Z_INIT_FILE.
 Z_INIT_FILE_SALT_VAR = "SALT"   ! default = "salt"
                                 ! The name of the salinity variable in SALT_Z_INIT_FILE.
+LAYER_Z_INIT_IC_EXTRAP_BUG = False !   [Boolean] default = True
+                                ! If true use an expression with a vertical indexing bug for extrapolating the
+                                ! densities at the bottom of unstable profiles from data when finding the
+                                ! initial interface locations in layered mode from a dataset of T and S.
 
 ! === module MOM_diag_mediator ===
 
@@ -306,6 +310,10 @@ BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! use a predictor continuity step to find the pressure field, and then to do a
                                 ! corrector continuity step using a weighted average of the old and new
                                 ! velocities, with weights of (1-BEBT) and BEBT.
+BAROTROPIC_TIDAL_SAL_BUG = False !   [Boolean] default = True
+                                ! If true, the tidal self-attraction and loading anomaly in the barotropic
+                                ! solver has the wrong sign, replicating a long-standing bug with a scalar
+                                ! self-attraction and loading term or the SAL term from a previous simulation.
 BEBT = 0.2                      !   [nondim] default = 0.1
                                 ! BEBT determines whether the barotropic time stepping uses the forward-backward
                                 ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range

--- a/ocean_only/global_ALE/hycom/MOM_override
+++ b/ocean_only/global_ALE/hycom/MOM_override
@@ -30,3 +30,6 @@ Z_INIT_REMAP_FULL_COLUMN = True
 REMAP_AFTER_INITIALIZATION = False
 REGRID_TIME_SCALE = 86400.0
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = True
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.

--- a/ocean_only/global_ALE/hycom/MOM_parameter_doc.all
+++ b/ocean_only/global_ALE/hycom/MOM_parameter_doc.all
@@ -1404,7 +1404,7 @@ HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
 HMIX_FIXED = 0.5                !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVML = 1.0E-04                  !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08

--- a/ocean_only/global_ALE/hycom/MOM_parameter_doc.all
+++ b/ocean_only/global_ALE/hycom/MOM_parameter_doc.all
@@ -1483,7 +1483,7 @@ BAROTROPIC_ANSWER_DATE = 99991231 ! default = 99991231
                                 ! recover the answers from the end of 2018, while higher values uuse more
                                 ! efficient or general expressions.  If both BAROTROPIC_2018_ANSWERS and
                                 ! BAROTROPIC_ANSWER_DATE are specified, the latter takes precedence.
-BAROTROPIC_TIDAL_SAL_BUG = True !   [Boolean] default = True
+BAROTROPIC_TIDAL_SAL_BUG = False !   [Boolean] default = True
                                 ! If true, the tidal self-attraction and loading anomaly in the barotropic
                                 ! solver has the wrong sign, replicating a long-standing bug with a scalar
                                 ! self-attraction and loading term or the SAL term from a previous simulation.

--- a/ocean_only/global_ALE/hycom/MOM_parameter_doc.short
+++ b/ocean_only/global_ALE/hycom/MOM_parameter_doc.short
@@ -371,6 +371,9 @@ SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
 HMIX_FIXED = 0.5                !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity components are truncated.
 CFL_TRUNCATE_RAMP_TIME = 7200.0 !   [s] default = 0.0

--- a/ocean_only/global_ALE/hycom/MOM_parameter_doc.short
+++ b/ocean_only/global_ALE/hycom/MOM_parameter_doc.short
@@ -387,6 +387,10 @@ BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! use a predictor continuity step to find the pressure field, and then to do a
                                 ! corrector continuity step using a weighted average of the old and new
                                 ! velocities, with weights of (1-BEBT) and BEBT.
+BAROTROPIC_TIDAL_SAL_BUG = False !   [Boolean] default = True
+                                ! If true, the tidal self-attraction and loading anomaly in the barotropic
+                                ! solver has the wrong sign, replicating a long-standing bug with a scalar
+                                ! self-attraction and loading term or the SAL term from a previous simulation.
 BEBT = 0.2                      !   [nondim] default = 0.1
                                 ! BEBT determines whether the barotropic time stepping uses the forward-backward
                                 ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range

--- a/ocean_only/global_ALE/layer/MOM_parameter_doc.all
+++ b/ocean_only/global_ALE/layer/MOM_parameter_doc.all
@@ -504,7 +504,7 @@ Z_INIT_SEPARATE_MIXED_LAYER = False !   [Boolean] default = False
                                 ! If true, distribute the topmost Z_INIT_HMIX_DEPTH of water over NKML layers,
                                 ! and do not correct the density of the topmost NKML+NKBL layers.  Otherwise all
                                 ! layers are initialized based on the depths of their target densities.
-LAYER_Z_INIT_IC_EXTRAP_BUG = True !   [Boolean] default = True
+LAYER_Z_INIT_IC_EXTRAP_BUG = False !   [Boolean] default = True
                                 ! If true use an expression with a vertical indexing bug for extrapolating the
                                 ! densities at the bottom of unstable profiles from data when finding the
                                 ! initial interface locations in layered mode from a dataset of T and S.
@@ -1346,7 +1346,7 @@ BAROTROPIC_ANSWER_DATE = 99991231 ! default = 99991231
                                 ! recover the answers from the end of 2018, while higher values uuse more
                                 ! efficient or general expressions.  If both BAROTROPIC_2018_ANSWERS and
                                 ! BAROTROPIC_ANSWER_DATE are specified, the latter takes precedence.
-BAROTROPIC_TIDAL_SAL_BUG = True !   [Boolean] default = True
+BAROTROPIC_TIDAL_SAL_BUG = False !   [Boolean] default = True
                                 ! If true, the tidal self-attraction and loading anomaly in the barotropic
                                 ! solver has the wrong sign, replicating a long-standing bug with a scalar
                                 ! self-attraction and loading term or the SAL term from a previous simulation.

--- a/ocean_only/global_ALE/layer/MOM_parameter_doc.short
+++ b/ocean_only/global_ALE/layer/MOM_parameter_doc.short
@@ -173,6 +173,10 @@ Z_INIT_FILE_SALT_VAR = "SALT"   ! default = "salt"
 ADJUST_THICKNESS = True         !   [Boolean] default = False
                                 ! If true, all mass below the bottom removed if the topography is shallower than
                                 ! the thickness input file would indicate.
+LAYER_Z_INIT_IC_EXTRAP_BUG = False !   [Boolean] default = True
+                                ! If true use an expression with a vertical indexing bug for extrapolating the
+                                ! densities at the bottom of unstable profiles from data when finding the
+                                ! initial interface locations in layered mode from a dataset of T and S.
 
 ! === module MOM_diag_mediator ===
 
@@ -304,6 +308,10 @@ BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! use a predictor continuity step to find the pressure field, and then to do a
                                 ! corrector continuity step using a weighted average of the old and new
                                 ! velocities, with weights of (1-BEBT) and BEBT.
+BAROTROPIC_TIDAL_SAL_BUG = False !   [Boolean] default = True
+                                ! If true, the tidal self-attraction and loading anomaly in the barotropic
+                                ! solver has the wrong sign, replicating a long-standing bug with a scalar
+                                ! self-attraction and loading term or the SAL term from a previous simulation.
 BEBT = 0.2                      !   [nondim] default = 0.1
                                 ! BEBT determines whether the barotropic time stepping uses the forward-backward
                                 ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range

--- a/ocean_only/global_ALE/z/MOM_override
+++ b/ocean_only/global_ALE/z/MOM_override
@@ -15,3 +15,6 @@ Z_INIT_ALE_REMAPPING = True
 ENERGETICS_SFC_PBL = True
 USE_MLD_ITERATION = False
 MASS_WEIGHT_IN_PRESSURE_GRADIENT = True
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.

--- a/ocean_only/global_ALE/z/MOM_parameter_doc.all
+++ b/ocean_only/global_ALE/z/MOM_parameter_doc.all
@@ -1440,7 +1440,7 @@ BAROTROPIC_ANSWER_DATE = 99991231 ! default = 99991231
                                 ! recover the answers from the end of 2018, while higher values uuse more
                                 ! efficient or general expressions.  If both BAROTROPIC_2018_ANSWERS and
                                 ! BAROTROPIC_ANSWER_DATE are specified, the latter takes precedence.
-BAROTROPIC_TIDAL_SAL_BUG = True !   [Boolean] default = True
+BAROTROPIC_TIDAL_SAL_BUG = False !   [Boolean] default = True
                                 ! If true, the tidal self-attraction and loading anomaly in the barotropic
                                 ! solver has the wrong sign, replicating a long-standing bug with a scalar
                                 ! self-attraction and loading term or the SAL term from a previous simulation.

--- a/ocean_only/global_ALE/z/MOM_parameter_doc.all
+++ b/ocean_only/global_ALE/z/MOM_parameter_doc.all
@@ -1361,7 +1361,7 @@ HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
 HMIX_FIXED = 0.5                !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVML = 1.0E-04                  !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08

--- a/ocean_only/global_ALE/z/MOM_parameter_doc.short
+++ b/ocean_only/global_ALE/z/MOM_parameter_doc.short
@@ -362,6 +362,10 @@ BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! use a predictor continuity step to find the pressure field, and then to do a
                                 ! corrector continuity step using a weighted average of the old and new
                                 ! velocities, with weights of (1-BEBT) and BEBT.
+BAROTROPIC_TIDAL_SAL_BUG = False !   [Boolean] default = True
+                                ! If true, the tidal self-attraction and loading anomaly in the barotropic
+                                ! solver has the wrong sign, replicating a long-standing bug with a scalar
+                                ! self-attraction and loading term or the SAL term from a previous simulation.
 BEBT = 0.2                      !   [nondim] default = 0.1
                                 ! BEBT determines whether the barotropic time stepping uses the forward-backward
                                 ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range

--- a/ocean_only/global_ALE/z/MOM_parameter_doc.short
+++ b/ocean_only/global_ALE/z/MOM_parameter_doc.short
@@ -346,6 +346,9 @@ SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
 HMIX_FIXED = 0.5                !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity components are truncated.
 CFL_TRUNCATE_RAMP_TIME = 7200.0 !   [s] default = 0.0

--- a/ocean_only/idealized_hurricane/MOM_input
+++ b/ocean_only/idealized_hurricane/MOM_input
@@ -239,6 +239,9 @@ SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
 HMIX_FIXED = 0.01               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-06
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 
 ! === module MOM_barotropic ===
 DTBT = 30.0                     !   [s or nondim] default = -0.98

--- a/ocean_only/idealized_hurricane/MOM_input
+++ b/ocean_only/idealized_hurricane/MOM_input
@@ -281,6 +281,10 @@ USE_JACKSON_PARAM = True        !   [Boolean] default = False
 VERTEX_SHEAR = True             !   [Boolean] default = False
                                 ! If true, do the calculations of the shear-driven mixing at the cell vertices
                                 ! (i.e., the vorticity points).
+KAPPA_SHEAR_VERTEX_PSURF_BUG = False !   [Boolean] default = True
+                                ! If true, do a simple average of the cell surface pressures to get a pressure
+                                ! at the corner if VERTEX_SHEAR=True.  Otherwise mask out any land points in the
+                                ! average.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.

--- a/ocean_only/idealized_hurricane/MOM_parameter_doc.all
+++ b/ocean_only/idealized_hurricane/MOM_parameter_doc.all
@@ -45,6 +45,9 @@ THICKNESSDIFFUSE = False        !   [Boolean] default = False
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
                                 ! If true, do thickness diffusion before dynamics. This is only used if
                                 ! THICKNESSDIFFUSE is true.
+USE_POROUS_BARRIER = True       !   [Boolean] default = True
+                                ! If true, use porous barrier to constrain the widths and face areas at the
+                                ! edges of the grid cells.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
                                 ! If true, there are separate values for the basin depths at velocity points.
                                 ! Otherwise the effects of topography are entirely determined from thickness
@@ -93,6 +96,11 @@ DO_GEOTHERMAL = False           !   [Boolean] default = False
 BOUND_SALINITY = False          !   [Boolean] default = False
                                 ! If true, limit salinity to being positive. (The sea-ice model may ask for more
                                 ! salt than is available and drive the salinity negative otherwise.)
+SALINITY_UNDERFLOW = 0.0        !   [PPT] default = 0.0
+                                ! A tiny value of salinity below which the it is set to 0.  For reference, one
+                                ! molecule of salt per square meter of ocean is of order 1e-29 ppt.
+TEMPERATURE_UNDERFLOW = 0.0     !   [degC] default = 0.0
+                                ! A tiny magnitude of temperatures below which they are set to 0.
 C_P = 3991.86795711963          !   [J kg-1 K-1] default = 3991.86795711963
                                 ! The heat capacity of sea water, approximated as a constant. This is only used
                                 ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
@@ -115,12 +123,20 @@ ALTERNATE_FIRST_DIRECTION = False !   [Boolean] default = False
                                 ! first direction can not be found in the restart file.
 CHECK_BAD_SURFACE_VALS = False  !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
+DEFAULT_ANSWER_DATE = 99991231  ! default = 99991231
+                                ! This sets the default value for the various _ANSWER_DATE parameters.
 DEFAULT_2018_ANSWERS = False    !   [Boolean] default = False
                                 ! This sets the default value for the various _2018_ANSWERS parameters.
 SURFACE_2018_ANSWERS = False    !   [Boolean] default = False
                                 ! If true, use expressions for the surface properties that recover the answers
                                 ! from the end of 2018. Otherwise, use more appropriate expressions that differ
                                 ! at roundoff for non-Boussinesq cases.
+SURFACE_ANSWER_DATE = 99991231  ! default = 99991231
+                                ! The vintage of the expressions for the surface properties.  Values below
+                                ! 20190101 recover the answers from the end of 2018, while higher values use
+                                ! updated and more robust forms of the same expressions.  If both
+                                ! SURFACE_2018_ANSWERS and SURFACE_ANSWER_DATE are specified, the latter takes
+                                ! precedence.
 USE_DIABATIC_TIME_BUG = False   !   [Boolean] default = False
                                 ! If true, uses the wrong calendar time for diabatic processes, as was done in
                                 ! MOM6 versions prior to February 2018. This is not recommended.
@@ -132,6 +148,9 @@ WRITE_GEOM = 1                  ! default = 1
                                 ! If =0, never write the geometry and vertical grid files. If =1, write the
                                 ! geometry and vertical grid files only for a new simulation. If =2, always
                                 ! write the geometry and vertical grid files. Other values are invalid.
+USE_DBCLIENT = False            !   [Boolean] default = False
+                                ! If true, initialize a client to a remote database that can be used for online
+                                ! analysis and machine-learning inference.
 ICE_SHELF = False               !   [Boolean] default = False
                                 ! If true, enables the ice shelf model.
 USE_PARTICLES = False           !   [Boolean] default = False
@@ -254,6 +273,8 @@ CHANNEL_CONFIG = "none"         ! default = "none"
                                 !       test case.
                                 !     file - Read open face widths everywhere from a
                                 !       NetCDF file on the model grid.
+SUBGRID_TOPO_AT_VEL = False     !   [Boolean] default = False
+                                ! If true, use variables from TOPO_AT_VEL_FILE as parameters for porous barrier.
 ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -467,6 +488,13 @@ REMAPPING_2018_ANSWERS = False  !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use updated and more robust forms of the
                                 ! same expressions.
+REMAPPING_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the expressions and order of arithmetic to use for remapping.
+                                ! Values below 20190101 result in the use of older, less accurate expressions
+                                ! that were in use at the end of 2018.  Higher values result in the use of more
+                                ! robust and accurate forms of mathematically equivalent expressions.  If both
+                                ! REMAPPING_2018_ANSWERS and REMAPPING_ANSWER_DATE are specified, the latter
+                                ! takes precedence.
 PARTIAL_CELL_VELOCITY_REMAP = False !   [Boolean] default = False
                                 ! If true, use partial cell thicknesses at velocity points that are masked out
                                 ! where they extend below the shallower of the neighboring bathymetry for
@@ -677,6 +705,9 @@ USE_STORED_SLOPES = False       !   [Boolean] default = False
 VERY_SMALL_FREQUENCY = 1.0E-17  !   [s-1] default = 1.0E-17
                                 ! A miniscule frequency that is used to avoid division by 0.  The default value
                                 ! is roughly (pi / (the age of the universe)).
+USE_STANLEY_ISO = False         !   [Boolean] default = False
+                                ! If true, turn on Stanley SGS T variance parameterization in isopycnal slope
+                                ! code.
 USE_QG_LEITH_GM = False         !   [Boolean] default = False
                                 ! If true, use the QG Leith viscosity as the GM coefficient.
 
@@ -685,10 +716,21 @@ SET_VISC_2018_ANSWERS = False   !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use updated and more robust forms of the
                                 ! same expressions.
+SET_VISC_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the order of arithmetic and expressions in the set viscosity
+                                ! calculations.  Values below 20190101 recover the answers from the end of 2018,
+                                ! while higher values use updated and more robust forms of the same expressions.
+                                ! If both SET_VISC_2018_ANSWERS and SET_VISC_ANSWER_DATE are specified, the
+                                ! latter takes precedence.
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
                                 ! If true, the bottom stress is calculated with a drag law of the form
                                 ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
                                 ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
+DRAG_AS_BODY_FORCE = False      !   [Boolean] default = False
+                                ! If true, the bottom stress is imposed as an explicit body force applied over a
+                                ! fixed distance from the bottom, rather than as an implicit calculation based
+                                ! on an enhanced near-bottom viscosity. The thickness of the bottom boundary
+                                ! layer is HBBL.
 CHANNEL_DRAG = False            !   [Boolean] default = False
                                 ! If true, the bottom drag is exerted directly on each layer proportional to the
                                 ! fraction of the bottom it overlies.
@@ -778,10 +820,8 @@ KD_SMOOTH = 1.0E-06             !   [m2 s-1] default = 1.0E-06
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
                                 ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
                                 ! effectively emphasizes graver vertical modes by smoothing in the vertical.
-STANLEY_PRM_DET_COEFF = -1.0    !   [nondim] default = -1.0
-                                ! The coefficient correlating SGS temperature variance with the mean temperature
-                                ! gradient in the deterministic part of the Stanley parameterization. Negative
-                                ! values disable the scheme.
+USE_STANLEY_GM = False          !   [Boolean] default = False
+                                ! If true, turn on Stanley SGS T variance parameterization in GM code.
 MEKE_GM_SRC_ALT = False         !   [Boolean] default = False
                                 ! If true, use the GM energy conversion form S^2*N^2*kappa rather than the
                                 ! streamfunction for the GM source term.
@@ -796,6 +836,30 @@ USE_GME = False                 !   [Boolean] default = False
 USE_GM_WORK_BUG = False         !   [Boolean] default = False
                                 ! If true, compute the top-layer work tendency on the u-grid with the incorrect
                                 ! sign, for legacy reproducibility.
+STOCH_EOS = False               !   [Boolean] default = False
+                                ! If true, stochastic perturbations are applied to the EOS in the PGF.
+STANLEY_COEFF = -1.0            !   [not defined] default = -1.0
+                                ! Coefficient correlating the temperature gradient and SGS T variance.
+STANLEY_A = 1.0                 !   [not defined] default = 1.0
+                                ! Coefficient a which scales chi in stochastic perturbation of the SGS T
+                                ! variance.
+
+! === module MOM_porous_barriers ===
+PORBAR_ANSWER_DATE = 99991231   ! default = 99991231
+                                ! The vintage of the porous barrier weight function calculations.  Values below
+                                ! 20220806 recover the old answers in which the layer averaged weights are not
+                                ! strictly limited by an upper-bound of 1.0 .
+PORBAR_MASKING_DEPTH = 0.0      !   [m] default = 0.0
+                                ! If the effective average depth at the velocity cell is shallower than this
+                                ! number, then porous barrier is not applied at that location.
+                                ! PORBAR_MASKING_DEPTH is assumed to be positive below the sea surface.
+PORBAR_ETA_INTERP = "MAX"       ! default = "MAX"
+                                ! A string describing the method that decicdes how the interface heights at the
+                                ! velocity points are calculated. Valid values are:
+                                !    MAX (the default) - maximum of the adjacent cells
+                                !    MIN - minimum of the adjacent cells
+                                !    ARITHMETIC - arithmetic mean of the adjacent cells
+                                !    HARMOINIC - harmonic mean of the adjacent cells
 
 ! === module MOM_dynamics_split_RK2 ===
 TIDES = False                   !   [Boolean] default = False
@@ -927,16 +991,20 @@ BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
                                 ! If true, the reconstruction of T & S for pressure in boundary cells is
                                 ! extrapolated, rather than using PCM in these cells. If true, the same order
                                 ! polynomial is used as is used for the interior cells.
-PGF_STANLEY_T2_DET_COEFF = -1.0 !   [nondim] default = -1.0
-                                ! The coefficient correlating SGS temperature variance with the mean temperature
-                                ! gradient in the deterministic part of the Stanley form of the Brankart
-                                ! correction. Negative values disable the scheme.
+USE_STANLEY_PGF = False         !   [Boolean] default = False
+                                ! If true, turn on Stanley SGS T variance parameterization in PGF code.
 
 ! === module MOM_hor_visc ===
 HOR_VISC_2018_ANSWERS = False   !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use updated and more robust forms of the
                                 ! same expressions.
+HOR_VISC_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the order of arithmetic and expressions in the horizontal
+                                ! viscosity calculations.  Values below 20190101 recover the answers from the
+                                ! end of 2018, while higher values use updated and more robust forms of the same
+                                ! expressions.  If both HOR_VISC_2018_ANSWERS and HOR_VISC_ANSWER_DATE are
+                                ! specified, the latter takes precedence.
 LAPLACIAN = True                !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 KH = 0.0                        !   [m2 s-1] default = 0.0
@@ -1013,6 +1081,13 @@ VERT_FRICTION_2018_ANSWERS = False !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use expressions that do not use an arbitrary
                                 ! hard-coded maximum viscous coupling coefficient between layers.
+VERT_FRICTION_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the order of arithmetic and expressions in the viscous
+                                ! calculations.  Values below 20190101 recover the answers from the end of 2018,
+                                ! while higher values use expressions that do not use an arbitrary hard-coded
+                                ! maximum viscous coupling coefficient  between layers.  If both
+                                ! VERT_FRICTION_2018_ANSWERS and VERT_FRICTION_ANSWER_DATE are specified, the
+                                ! latter takes precedence.
 DIRECT_STRESS = False           !   [Boolean] default = False
                                 ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
                                 ! (like in HYCOM), and KVML may be set to a very small value.
@@ -1096,6 +1171,11 @@ BT_CORIOLIS_SCALE = 1.0         !   [nondim] default = 1.0
 BAROTROPIC_2018_ANSWERS = False !   [Boolean] default = False
                                 ! If true, use expressions for the barotropic solver that recover the answers
                                 ! from the end of 2018.  Otherwise, use more efficient or general expressions.
+BAROTROPIC_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the expressions in the barotropic solver. Values below 20190101
+                                ! recover the answers from the end of 2018, while higher values uuse more
+                                ! efficient or general expressions.  If both BAROTROPIC_2018_ANSWERS and
+                                ! BAROTROPIC_ANSWER_DATE are specified, the latter takes precedence.
 SADOURNY = True                 !   [Boolean] default = True
                                 ! If true, the Coriolis terms are discretized with the Sadourny (1975) energy
                                 ! conserving scheme, otherwise the Arakawa & Hsu scheme is used.  If the
@@ -1246,9 +1326,8 @@ KPP%
 PASSIVE = False                 !   [Boolean] default = False
                                 ! If True, puts KPP into a passive-diagnostic mode.
 APPLY_NONLOCAL_TRANSPORT = True !   [Boolean] default = True
-                                ! If True, applies the non-local transport to heat and scalars. If False,
-                                ! calculates the non-local transport and tendencies but purely for diagnostic
-                                ! purposes.
+                                ! If True, applies the non-local transport to all tracers. If False, calculates
+                                ! the non-local transport and tendencies but purely for diagnostic purposes.
 N_SMOOTH = 0                    ! default = 0
                                 ! The number of times the 1-1-4-1-1 Laplacian filter is applied on OBL depth.
 RI_CRIT = 0.25                  !   [nondim] default = 0.3
@@ -1352,6 +1431,12 @@ SET_DIFF_2018_ANSWERS = False   !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use updated and more robust forms of the
                                 ! same expressions.
+SET_DIFF_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the order of arithmetic and expressions in the set diffusivity
+                                ! calculations.  Values below 20190101 recover the answers from the end of 2018,
+                                ! while higher values use updated and more robust forms of the same expressions.
+                                ! If both SET_DIFF_2018_ANSWERS and SET_DIFF_ANSWER_DATE are specified, the
+                                ! latter takes precedence.
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
@@ -1495,7 +1580,7 @@ KAPPA_SHEAR_MAX_KAP_SRC_CHG = 10.0 !   [nondim] default = 10.0
                                 ! relative to the local source; this must be greater than 1.  The lower limit
                                 ! for the permitted fractional decrease is (1 - 0.5/kappa_src_max_chg).  These
                                 ! limits could perhaps be made dynamic with an improved iterative solver.
-KAPPA_SHEAR_VERTEX_PSURF_BUG = True !   [Boolean] default = True
+KAPPA_SHEAR_VERTEX_PSURF_BUG = False !   [Boolean] default = True
                                 ! If true, do a simple average of the cell surface pressures to get a pressure
                                 ! at the corner if VERTEX_SHEAR=True.  Otherwise mask out any land points in the
                                 ! average.
@@ -1570,6 +1655,12 @@ OPTICS_2018_ANSWERS = False     !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use updated expressions for handling the
                                 ! absorption of small remaining shortwave fluxes.
+OPTICS_ANSWER_DATE = 99991231   ! default = 99991231
+                                ! The vintage of the order of arithmetic and expressions in the optics
+                                ! calculations.  Values below 20190101 recover the answers from the end of 2018,
+                                ! while higher values use updated and more robust forms of the same expressions.
+                                ! If both OPTICS_2018_ANSWERS and OPTICS_ANSWER_DATE are specified, the latter
+                                ! takes precedence.
 PEN_SW_FLUX_ABSORB = 2.5E-11    !   [degC m s-1] default = 2.5E-11
                                 ! A minimum remaining shortwave heating rate that will be simply absorbed in the
                                 ! next sufficiently thick layers for computational efficiency, instead of
@@ -1743,6 +1834,12 @@ IDL_HURR_2018_ANSWERS = False   !   [Boolean] default = False
                                 ! If true, use expressions driving the idealized hurricane test case that
                                 ! recover the answers from the end of 2018.  Otherwise use expressions that are
                                 ! rescalable and respect rotational symmetry.
+IDL_HURR_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the expressions in the idealized hurricane test case.  Values
+                                ! below 20190101 recover the answers from the end of 2018, while higher values
+                                ! use expressions that are rescalable and respect rotational symmetry.  If both
+                                ! IDL_HURR_2018_ANSWERS and IDL_HURR_ANSWER_DATE are specified, the latter takes
+                                ! precedence.
 
 ! === module MOM_restart ===
 USE_WAVES = False               !   [Boolean] default = False

--- a/ocean_only/idealized_hurricane/MOM_parameter_doc.all
+++ b/ocean_only/idealized_hurricane/MOM_parameter_doc.all
@@ -1101,7 +1101,7 @@ HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
 HMIX_FIXED = 0.01               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVML = 1.0E-06                  !   [m2 s-1] default = 1.0E-06
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-06
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 3.0E+08                !   [m s-1] default = 3.0E+08

--- a/ocean_only/idealized_hurricane/MOM_parameter_doc.short
+++ b/ocean_only/idealized_hurricane/MOM_parameter_doc.short
@@ -201,6 +201,8 @@ KV = 1.0E-06                    !   [m2 s-1]
 
 ! === module MOM_thickness_diffuse ===
 
+! === module MOM_porous_barriers ===
+
 ! === module MOM_dynamics_split_RK2 ===
 
 ! === module MOM_continuity ===
@@ -271,6 +273,10 @@ USE_JACKSON_PARAM = True        !   [Boolean] default = False
 VERTEX_SHEAR = True             !   [Boolean] default = False
                                 ! If true, do the calculations of the shear-driven mixing at the cell vertices
                                 ! (i.e., the vorticity points).
+KAPPA_SHEAR_VERTEX_PSURF_BUG = False !   [Boolean] default = True
+                                ! If true, do a simple average of the cell surface pressures to get a pressure
+                                ! at the corner if VERTEX_SHEAR=True.  Otherwise mask out any land points in the
+                                ! average.
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.

--- a/ocean_only/idealized_hurricane/MOM_parameter_doc.short
+++ b/ocean_only/idealized_hurricane/MOM_parameter_doc.short
@@ -231,6 +231,9 @@ SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
 HMIX_FIXED = 0.01               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-06
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 
 ! === module MOM_barotropic ===
 DTBT = 30.0                     !   [s or nondim] default = -0.98

--- a/ocean_only/lock_exchange/MOM_input
+++ b/ocean_only/lock_exchange/MOM_input
@@ -271,6 +271,9 @@ BIHARMONIC = False              !   [Boolean] default = True
 HMIX_FIXED = 1.0E-10            !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity components are truncated.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0

--- a/ocean_only/lock_exchange/MOM_parameter_doc.all
+++ b/ocean_only/lock_exchange/MOM_parameter_doc.all
@@ -967,7 +967,7 @@ HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
 HMIX_FIXED = 1.0E-10            !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVML = 1.0E-04                  !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08

--- a/ocean_only/lock_exchange/MOM_parameter_doc.short
+++ b/ocean_only/lock_exchange/MOM_parameter_doc.short
@@ -264,6 +264,9 @@ BIHARMONIC = False              !   [Boolean] default = True
 HMIX_FIXED = 1.0E-10            !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity components are truncated.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0

--- a/ocean_only/mixed_layer_restrat_2d/MOM_input
+++ b/ocean_only/mixed_layer_restrat_2d/MOM_input
@@ -313,6 +313,9 @@ DIRECT_STRESS = True            !   [Boolean] default = False
 HMIX_FIXED = 0.001              !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity components are truncated.
 

--- a/ocean_only/mixed_layer_restrat_2d/MOM_parameter_doc.all
+++ b/ocean_only/mixed_layer_restrat_2d/MOM_parameter_doc.all
@@ -1067,7 +1067,7 @@ HMIX_FIXED = 0.001              !   [m]
                                 ! elevated when the bulk mixed layer is not used.
 HMIX_STRESS = 0.001             !   [m] default = 0.001
                                 ! The depth over which the wind stress is applied if DIRECT_STRESS is true.
-KVML = 1.0E-04                  !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08

--- a/ocean_only/mixed_layer_restrat_2d/MOM_parameter_doc.short
+++ b/ocean_only/mixed_layer_restrat_2d/MOM_parameter_doc.short
@@ -310,6 +310,9 @@ DIRECT_STRESS = True            !   [Boolean] default = False
 HMIX_FIXED = 0.001              !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity components are truncated.
 

--- a/ocean_only/nonBous_global/MOM_input
+++ b/ocean_only/nonBous_global/MOM_input
@@ -352,6 +352,10 @@ BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! use a predictor continuity step to find the pressure field, and then to do a
                                 ! corrector continuity step using a weighted average of the old and new
                                 ! velocities, with weights of (1-BEBT) and BEBT.
+BAROTROPIC_TIDAL_SAL_BUG = False !   [Boolean] default = True
+                                ! If true, the tidal self-attraction and loading anomaly in the barotropic
+                                ! solver has the wrong sign, replicating a long-standing bug with a scalar
+                                ! self-attraction and loading term or the SAL term from a previous simulation.
 BEBT = 0.2                      !   [nondim] default = 0.1
                                 ! BEBT determines whether the barotropic time stepping uses the forward-backward
                                 ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range

--- a/ocean_only/nonBous_global/MOM_parameter_doc.all
+++ b/ocean_only/nonBous_global/MOM_parameter_doc.all
@@ -1208,7 +1208,7 @@ BAROTROPIC_ANSWER_DATE = 99991231 ! default = 99991231
                                 ! recover the answers from the end of 2018, while higher values uuse more
                                 ! efficient or general expressions.  If both BAROTROPIC_2018_ANSWERS and
                                 ! BAROTROPIC_ANSWER_DATE are specified, the latter takes precedence.
-BAROTROPIC_TIDAL_SAL_BUG = True !   [Boolean] default = True
+BAROTROPIC_TIDAL_SAL_BUG = False !   [Boolean] default = True
                                 ! If true, the tidal self-attraction and loading anomaly in the barotropic
                                 ! solver has the wrong sign, replicating a long-standing bug with a scalar
                                 ! self-attraction and loading term or the SAL term from a previous simulation.

--- a/ocean_only/nonBous_global/MOM_parameter_doc.short
+++ b/ocean_only/nonBous_global/MOM_parameter_doc.short
@@ -345,6 +345,10 @@ BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! use a predictor continuity step to find the pressure field, and then to do a
                                 ! corrector continuity step using a weighted average of the old and new
                                 ! velocities, with weights of (1-BEBT) and BEBT.
+BAROTROPIC_TIDAL_SAL_BUG = False !   [Boolean] default = True
+                                ! If true, the tidal self-attraction and loading anomaly in the barotropic
+                                ! solver has the wrong sign, replicating a long-standing bug with a scalar
+                                ! self-attraction and loading term or the SAL term from a previous simulation.
 BEBT = 0.2                      !   [nondim] default = 0.1
                                 ! BEBT determines whether the barotropic time stepping uses the forward-backward
                                 ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range

--- a/ocean_only/resting/common/MOM_input
+++ b/ocean_only/resting/common/MOM_input
@@ -264,7 +264,7 @@ DIRECT_STRESS = True            !   [Boolean] default = False
 HMIX_FIXED = 20.0               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVML = 0.01                     !   [m2 s-1] default = 0.0
+KVML = 0.0                      !   [m2 s-1] default = 0.0
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08

--- a/ocean_only/resting/layer/MOM_parameter_doc.all
+++ b/ocean_only/resting/layer/MOM_parameter_doc.all
@@ -964,7 +964,7 @@ HMIX_FIXED = 20.0               !   [m]
                                 ! elevated when the bulk mixed layer is not used.
 HMIX_STRESS = 20.0              !   [m] default = 20.0
                                 ! The depth over which the wind stress is applied if DIRECT_STRESS is true.
-KVML = 0.01                     !   [m2 s-1] default = 0.0
+KVML = 0.0                      !   [m2 s-1] default = 0.0
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08

--- a/ocean_only/resting/layer/MOM_parameter_doc.short
+++ b/ocean_only/resting/layer/MOM_parameter_doc.short
@@ -257,9 +257,6 @@ DIRECT_STRESS = True            !   [Boolean] default = False
 HMIX_FIXED = 20.0               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVML = 0.01                     !   [m2 s-1] default = 0.0
-                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
-                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity components are truncated.
 

--- a/ocean_only/resting/z/MOM_parameter_doc.all
+++ b/ocean_only/resting/z/MOM_parameter_doc.all
@@ -1067,7 +1067,7 @@ HMIX_FIXED = 20.0               !   [m]
                                 ! elevated when the bulk mixed layer is not used.
 HMIX_STRESS = 20.0              !   [m] default = 20.0
                                 ! The depth over which the wind stress is applied if DIRECT_STRESS is true.
-KVML = 0.01                     !   [m2 s-1] default = 0.0
+KVML = 0.0                      !   [m2 s-1] default = 0.0
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08

--- a/ocean_only/resting/z/MOM_parameter_doc.short
+++ b/ocean_only/resting/z/MOM_parameter_doc.short
@@ -272,9 +272,6 @@ DIRECT_STRESS = True            !   [Boolean] default = False
 HMIX_FIXED = 20.0               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVML = 0.01                     !   [m2 s-1] default = 0.0
-                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
-                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity components are truncated.
 

--- a/ocean_only/rotating_gravity_current/Layersetup_2D/MOM_input
+++ b/ocean_only/rotating_gravity_current/Layersetup_2D/MOM_input
@@ -311,7 +311,7 @@ HMIX_FIXED = 20.0               !   [m]
 KV = 1.0E-5                     !   [m2 s-1]
                                 ! The background kinematic viscosity in the interior.
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
-KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical
                                 ! value is ~1e-2 m2 s-1. KVML is not used if
                                 ! BULKMIXEDLAYER is true.  The default is set by KV.

--- a/ocean_only/rotating_gravity_current/Layersetup_3D/MOM_input
+++ b/ocean_only/rotating_gravity_current/Layersetup_3D/MOM_input
@@ -312,7 +312,7 @@ HMIX_FIXED = 20.0               !   [m]
 KV = 1.0E-5                     !   [m2 s-1]
                                 ! The background kinematic viscosity in the interior.
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
-KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical
                                 ! value is ~1e-2 m2 s-1. KVML is not used if
                                 ! BULKMIXEDLAYER is true.  The default is set by KV.

--- a/ocean_only/rotating_gravity_current/Zsetup_2D/MOM_input
+++ b/ocean_only/rotating_gravity_current/Zsetup_2D/MOM_input
@@ -285,7 +285,7 @@ HMIX_FIXED = 20.0               !   [m]
 KV = 1.0E-5                     !   [m2 s-1]
                                 ! The background kinematic viscosity in the interior.
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
-KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical
                                 ! value is ~1e-2 m2 s-1. KVML is not used if
                                 ! BULKMIXEDLAYER is true.  The default is set by KV.

--- a/ocean_only/rotating_gravity_current/Zsetup_3D/MOM_input
+++ b/ocean_only/rotating_gravity_current/Zsetup_3D/MOM_input
@@ -280,7 +280,7 @@ HMIX_FIXED = 20.0               !   [m]
 KV = 1.0E-5                     !   [m2 s-1]
                                 ! The background kinematic viscosity in the interior.
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
-KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical
                                 ! value is ~1e-2 m2 s-1. KVML is not used if
                                 ! BULKMIXEDLAYER is true.  The default is set by KV.

--- a/ocean_only/seamount/common/MOM_input
+++ b/ocean_only/seamount/common/MOM_input
@@ -295,7 +295,7 @@ DIRECT_STRESS = True            !   [Boolean] default = False
 HMIX_FIXED = 20.0               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08

--- a/ocean_only/seamount/layer/MOM_parameter_doc.all
+++ b/ocean_only/seamount/layer/MOM_parameter_doc.all
@@ -997,7 +997,7 @@ HMIX_FIXED = 20.0               !   [m]
                                 ! elevated when the bulk mixed layer is not used.
 HMIX_STRESS = 20.0              !   [m] default = 20.0
                                 ! The depth over which the wind stress is applied if DIRECT_STRESS is true.
-KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08

--- a/ocean_only/seamount/layer/MOM_parameter_doc.short
+++ b/ocean_only/seamount/layer/MOM_parameter_doc.short
@@ -287,7 +287,7 @@ DIRECT_STRESS = True            !   [Boolean] default = False
 HMIX_FIXED = 20.0               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08

--- a/ocean_only/seamount/rho/MOM_parameter_doc.all
+++ b/ocean_only/seamount/rho/MOM_parameter_doc.all
@@ -1139,7 +1139,7 @@ HMIX_FIXED = 20.0               !   [m]
                                 ! elevated when the bulk mixed layer is not used.
 HMIX_STRESS = 20.0              !   [m] default = 20.0
                                 ! The depth over which the wind stress is applied if DIRECT_STRESS is true.
-KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08

--- a/ocean_only/seamount/rho/MOM_parameter_doc.short
+++ b/ocean_only/seamount/rho/MOM_parameter_doc.short
@@ -337,7 +337,7 @@ DIRECT_STRESS = True            !   [Boolean] default = False
 HMIX_FIXED = 20.0               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08

--- a/ocean_only/seamount/sigma/MOM_parameter_doc.all
+++ b/ocean_only/seamount/sigma/MOM_parameter_doc.all
@@ -1095,7 +1095,7 @@ HMIX_FIXED = 20.0               !   [m]
                                 ! elevated when the bulk mixed layer is not used.
 HMIX_STRESS = 20.0              !   [m] default = 20.0
                                 ! The depth over which the wind stress is applied if DIRECT_STRESS is true.
-KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08

--- a/ocean_only/seamount/sigma/MOM_parameter_doc.short
+++ b/ocean_only/seamount/sigma/MOM_parameter_doc.short
@@ -314,7 +314,7 @@ DIRECT_STRESS = True            !   [Boolean] default = False
 HMIX_FIXED = 20.0               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08

--- a/ocean_only/seamount/z/MOM_parameter_doc.all
+++ b/ocean_only/seamount/z/MOM_parameter_doc.all
@@ -1095,7 +1095,7 @@ HMIX_FIXED = 20.0               !   [m]
                                 ! elevated when the bulk mixed layer is not used.
 HMIX_STRESS = 20.0              !   [m] default = 20.0
                                 ! The depth over which the wind stress is applied if DIRECT_STRESS is true.
-KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08

--- a/ocean_only/seamount/z/MOM_parameter_doc.short
+++ b/ocean_only/seamount/z/MOM_parameter_doc.short
@@ -314,7 +314,7 @@ DIRECT_STRESS = True            !   [Boolean] default = False
 HMIX_FIXED = 20.0               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08

--- a/ocean_only/single_column/BML/MOM_input
+++ b/ocean_only/single_column/BML/MOM_input
@@ -149,6 +149,10 @@ Z_INIT_HOMOGENIZE = True        !   [Boolean] default = False
 ADJUST_THICKNESS = True         !   [Boolean] default = False
                                 ! If true, all mass below the bottom removed if the topography is shallower than
                                 ! the thickness input file would indicate.
+LAYER_Z_INIT_IC_EXTRAP_BUG = False !   [Boolean] default = True
+                                ! If true use an expression with a vertical indexing bug for extrapolating the
+                                ! densities at the bottom of unstable profiles from data when finding the
+                                ! initial interface locations in layered mode from a dataset of T and S.
 
 ! === module MOM_diag_mediator ===
 

--- a/ocean_only/single_column/BML/MOM_parameter_doc.all
+++ b/ocean_only/single_column/BML/MOM_parameter_doc.all
@@ -465,7 +465,7 @@ Z_INIT_SEPARATE_MIXED_LAYER = False !   [Boolean] default = False
                                 ! If true, distribute the topmost Z_INIT_HMIX_DEPTH of water over NKML layers,
                                 ! and do not correct the density of the topmost NKML+NKBL layers.  Otherwise all
                                 ! layers are initialized based on the depths of their target densities.
-LAYER_Z_INIT_IC_EXTRAP_BUG = True !   [Boolean] default = True
+LAYER_Z_INIT_IC_EXTRAP_BUG = False !   [Boolean] default = True
                                 ! If true use an expression with a vertical indexing bug for extrapolating the
                                 ! densities at the bottom of unstable profiles from data when finding the
                                 ! initial interface locations in layered mode from a dataset of T and S.

--- a/ocean_only/single_column/BML/MOM_parameter_doc.short
+++ b/ocean_only/single_column/BML/MOM_parameter_doc.short
@@ -144,6 +144,10 @@ Z_INIT_HOMOGENIZE = True        !   [Boolean] default = False
 ADJUST_THICKNESS = True         !   [Boolean] default = False
                                 ! If true, all mass below the bottom removed if the topography is shallower than
                                 ! the thickness input file would indicate.
+LAYER_Z_INIT_IC_EXTRAP_BUG = False !   [Boolean] default = True
+                                ! If true use an expression with a vertical indexing bug for extrapolating the
+                                ! densities at the bottom of unstable profiles from data when finding the
+                                ! initial interface locations in layered mode from a dataset of T and S.
 
 ! === module MOM_diag_mediator ===
 

--- a/ocean_only/single_column/EPBL/MOM_input
+++ b/ocean_only/single_column/EPBL/MOM_input
@@ -238,6 +238,9 @@ HARMONIC_VISC = True            !   [Boolean] default = False
 HMIX_FIXED = 0.01               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity components are truncated.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0

--- a/ocean_only/single_column/EPBL/MOM_parameter_doc.all
+++ b/ocean_only/single_column/EPBL/MOM_parameter_doc.all
@@ -995,7 +995,7 @@ HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
 HMIX_FIXED = 0.01               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVML = 1.0E-04                  !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08

--- a/ocean_only/single_column/EPBL/MOM_parameter_doc.short
+++ b/ocean_only/single_column/EPBL/MOM_parameter_doc.short
@@ -231,6 +231,9 @@ HARMONIC_VISC = True            !   [Boolean] default = False
 HMIX_FIXED = 0.01               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity components are truncated.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0

--- a/ocean_only/single_column/KPP/MOM_input
+++ b/ocean_only/single_column/KPP/MOM_input
@@ -238,6 +238,9 @@ HARMONIC_VISC = True            !   [Boolean] default = False
 HMIX_FIXED = 0.01               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity components are truncated.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0

--- a/ocean_only/single_column/KPP/MOM_parameter_doc.all
+++ b/ocean_only/single_column/KPP/MOM_parameter_doc.all
@@ -995,7 +995,7 @@ HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
 HMIX_FIXED = 0.01               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVML = 1.0E-04                  !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08

--- a/ocean_only/single_column/KPP/MOM_parameter_doc.short
+++ b/ocean_only/single_column/KPP/MOM_parameter_doc.short
@@ -231,6 +231,9 @@ HARMONIC_VISC = True            !   [Boolean] default = False
 HMIX_FIXED = 0.01               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity components are truncated.
 VEL_UNDERFLOW = 1.0E-30         !   [m s-1] default = 0.0

--- a/ocean_only/sloshing/common/MOM_input
+++ b/ocean_only/sloshing/common/MOM_input
@@ -296,7 +296,7 @@ DIRECT_STRESS = True            !   [Boolean] default = False
 HMIX_FIXED = 20.0               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVML = 0.01                     !   [m2 s-1] default = 0.0
+KVML = 0.0                      !   [m2 s-1] default = 0.0
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08

--- a/ocean_only/sloshing/layer/MOM_parameter_doc.all
+++ b/ocean_only/sloshing/layer/MOM_parameter_doc.all
@@ -976,7 +976,7 @@ HMIX_FIXED = 20.0               !   [m]
                                 ! elevated when the bulk mixed layer is not used.
 HMIX_STRESS = 20.0              !   [m] default = 20.0
                                 ! The depth over which the wind stress is applied if DIRECT_STRESS is true.
-KVML = 0.01                     !   [m2 s-1] default = 0.0
+KVML = 0.0                      !   [m2 s-1] default = 0.0
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08

--- a/ocean_only/sloshing/layer/MOM_parameter_doc.short
+++ b/ocean_only/sloshing/layer/MOM_parameter_doc.short
@@ -287,9 +287,6 @@ DIRECT_STRESS = True            !   [Boolean] default = False
 HMIX_FIXED = 20.0               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVML = 0.01                     !   [m2 s-1] default = 0.0
-                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
-                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity components are truncated.
 

--- a/ocean_only/sloshing/rho/MOM_parameter_doc.all
+++ b/ocean_only/sloshing/rho/MOM_parameter_doc.all
@@ -1120,7 +1120,7 @@ HMIX_FIXED = 20.0               !   [m]
                                 ! elevated when the bulk mixed layer is not used.
 HMIX_STRESS = 20.0              !   [m] default = 20.0
                                 ! The depth over which the wind stress is applied if DIRECT_STRESS is true.
-KVML = 0.01                     !   [m2 s-1] default = 0.0
+KVML = 0.0                      !   [m2 s-1] default = 0.0
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08

--- a/ocean_only/sloshing/rho/MOM_parameter_doc.short
+++ b/ocean_only/sloshing/rho/MOM_parameter_doc.short
@@ -334,9 +334,6 @@ DIRECT_STRESS = True            !   [Boolean] default = False
 HMIX_FIXED = 20.0               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVML = 0.01                     !   [m2 s-1] default = 0.0
-                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
-                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity components are truncated.
 

--- a/ocean_only/sloshing/z/MOM_parameter_doc.all
+++ b/ocean_only/sloshing/z/MOM_parameter_doc.all
@@ -1079,7 +1079,7 @@ HMIX_FIXED = 20.0               !   [m]
                                 ! elevated when the bulk mixed layer is not used.
 HMIX_STRESS = 20.0              !   [m] default = 20.0
                                 ! The depth over which the wind stress is applied if DIRECT_STRESS is true.
-KVML = 0.01                     !   [m2 s-1] default = 0.0
+KVML = 0.0                      !   [m2 s-1] default = 0.0
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08

--- a/ocean_only/sloshing/z/MOM_parameter_doc.short
+++ b/ocean_only/sloshing/z/MOM_parameter_doc.short
@@ -314,9 +314,6 @@ DIRECT_STRESS = True            !   [Boolean] default = False
 HMIX_FIXED = 20.0               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVML = 0.01                     !   [m2 s-1] default = 0.0
-                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
-                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity components are truncated.
 

--- a/ocean_only/tides_025/MOM_input
+++ b/ocean_only/tides_025/MOM_input
@@ -286,6 +286,10 @@ BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! use a predictor continuity step to find the pressure field, and then to do a
                                 ! corrector continuity step using a weighted average of the old and new
                                 ! velocities, with weights of (1-BEBT) and BEBT.
+BAROTROPIC_TIDAL_SAL_BUG = False !   [Boolean] default = True
+                                ! If true, the tidal self-attraction and loading anomaly in the barotropic
+                                ! solver has the wrong sign, replicating a long-standing bug with a scalar
+                                ! self-attraction and loading term or the SAL term from a previous simulation.
 BEBT = 0.2                      !   [nondim] default = 0.1
                                 ! BEBT determines whether the barotropic time stepping uses the forward-backward
                                 ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range

--- a/ocean_only/tides_025/MOM_input
+++ b/ocean_only/tides_025/MOM_input
@@ -270,7 +270,7 @@ DIRECT_STRESS = True            !   [Boolean] default = False
 HMIX_FIXED = 20.0               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08

--- a/ocean_only/tides_025/MOM_parameter_doc.all
+++ b/ocean_only/tides_025/MOM_parameter_doc.all
@@ -1037,7 +1037,7 @@ HMIX_FIXED = 20.0               !   [m]
                                 ! elevated when the bulk mixed layer is not used.
 HMIX_STRESS = 20.0              !   [m] default = 20.0
                                 ! The depth over which the wind stress is applied if DIRECT_STRESS is true.
-KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08

--- a/ocean_only/tides_025/MOM_parameter_doc.all
+++ b/ocean_only/tides_025/MOM_parameter_doc.all
@@ -45,6 +45,9 @@ THICKNESSDIFFUSE = False        !   [Boolean] default = False
 THICKNESSDIFFUSE_FIRST = False  !   [Boolean] default = False
                                 ! If true, do thickness diffusion before dynamics. This is only used if
                                 ! THICKNESSDIFFUSE is true.
+USE_POROUS_BARRIER = True       !   [Boolean] default = True
+                                ! If true, use porous barrier to constrain the widths and face areas at the
+                                ! edges of the grid cells.
 BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
                                 ! If true, there are separate values for the basin depths at velocity points.
                                 ! Otherwise the effects of topography are entirely determined from thickness
@@ -110,12 +113,20 @@ BAD_VAL_SST_MIN = -2.1          !   [deg C] default = -2.1
 BAD_VAL_COLUMN_THICKNESS = 0.0  !   [m] default = 0.0
                                 ! The value of column thickness below which a bad value message is triggered, if
                                 ! CHECK_BAD_SURFACE_VALS is true.
+DEFAULT_ANSWER_DATE = 99991231  ! default = 99991231
+                                ! This sets the default value for the various _ANSWER_DATE parameters.
 DEFAULT_2018_ANSWERS = False    !   [Boolean] default = False
                                 ! This sets the default value for the various _2018_ANSWERS parameters.
 SURFACE_2018_ANSWERS = False    !   [Boolean] default = False
                                 ! If true, use expressions for the surface properties that recover the answers
                                 ! from the end of 2018. Otherwise, use more appropriate expressions that differ
                                 ! at roundoff for non-Boussinesq cases.
+SURFACE_ANSWER_DATE = 99991231  ! default = 99991231
+                                ! The vintage of the expressions for the surface properties.  Values below
+                                ! 20190101 recover the answers from the end of 2018, while higher values use
+                                ! updated and more robust forms of the same expressions.  If both
+                                ! SURFACE_2018_ANSWERS and SURFACE_ANSWER_DATE are specified, the latter takes
+                                ! precedence.
 USE_DIABATIC_TIME_BUG = False   !   [Boolean] default = False
                                 ! If true, uses the wrong calendar time for diabatic processes, as was done in
                                 ! MOM6 versions prior to February 2018. This is not recommended.
@@ -127,6 +138,9 @@ WRITE_GEOM = 1                  ! default = 1
                                 ! If =0, never write the geometry and vertical grid files. If =1, write the
                                 ! geometry and vertical grid files only for a new simulation. If =2, always
                                 ! write the geometry and vertical grid files. Other values are invalid.
+USE_DBCLIENT = False            !   [Boolean] default = False
+                                ! If true, initialize a client to a remote database that can be used for online
+                                ! analysis and machine-learning inference.
 ICE_SHELF = False               !   [Boolean] default = False
                                 ! If true, enables the ice shelf model.
 USE_PARTICLES = False           !   [Boolean] default = False
@@ -186,6 +200,8 @@ GRID_FILE = "ocean_hgrid.nc"    !
 USE_TRIPOLAR_GEOLONB_BUG = False !   [Boolean] default = False
                                 ! If true, use older code that incorrectly sets the longitude in some points
                                 ! along the tripolar fold to be off by 360 degrees.
+RAD_EARTH = 6.378E+06           !   [m] default = 6.378E+06
+                                ! The radius of the Earth.
 TOPO_CONFIG = "file"            !
                                 ! This specifies how bathymetry is specified:
                                 !     file - read bathymetric information from the file
@@ -256,6 +272,8 @@ CHANNEL_LIST_360_LON_CHECK = True !   [Boolean] default = True
 FATAL_UNUSED_CHANNEL_WIDTHS = False !   [Boolean] default = False
                                 ! If true, trigger a fatal error if there are any channel widths in
                                 ! CHANNEL_LIST_FILE that do not cause any open face widths to change.
+SUBGRID_TOPO_AT_VEL = False     !   [Boolean] default = False
+                                ! If true, use variables from TOPO_AT_VEL_FILE as parameters for porous barrier.
 ROTATION = "2omegasinlat"       ! default = "2omegasinlat"
                                 ! This specifies how the Coriolis parameter is specified:
                                 !     2omegasinlat - Use twice the planetary rotation rate
@@ -438,6 +456,13 @@ REMAPPING_2018_ANSWERS = False  !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use updated and more robust forms of the
                                 ! same expressions.
+REMAPPING_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the expressions and order of arithmetic to use for remapping.
+                                ! Values below 20190101 result in the use of older, less accurate expressions
+                                ! that were in use at the end of 2018.  Higher values result in the use of more
+                                ! robust and accurate forms of mathematically equivalent expressions.  If both
+                                ! REMAPPING_2018_ANSWERS and REMAPPING_ANSWER_DATE are specified, the latter
+                                ! takes precedence.
 USE_GRID_SPACE_DIAGNOSTIC_AXES = False !   [Boolean] default = False
                                 ! If true, use a grid index coordinate convention for diagnostic axes.
 DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
@@ -514,6 +539,9 @@ USE_STORED_SLOPES = False       !   [Boolean] default = False
 VERY_SMALL_FREQUENCY = 1.0E-17  !   [s-1] default = 1.0E-17
                                 ! A miniscule frequency that is used to avoid division by 0.  The default value
                                 ! is roughly (pi / (the age of the universe)).
+USE_STANLEY_ISO = False         !   [Boolean] default = False
+                                ! If true, turn on Stanley SGS T variance parameterization in isopycnal slope
+                                ! code.
 KH_RES_SCALE_COEF = 1.0         !   [nondim] default = 1.0
                                 ! A coefficient that determines how KhTh is scaled away if RESOLN_SCALED_... is
                                 ! true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).
@@ -554,10 +582,21 @@ SET_VISC_2018_ANSWERS = False   !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use updated and more robust forms of the
                                 ! same expressions.
+SET_VISC_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the order of arithmetic and expressions in the set viscosity
+                                ! calculations.  Values below 20190101 recover the answers from the end of 2018,
+                                ! while higher values use updated and more robust forms of the same expressions.
+                                ! If both SET_VISC_2018_ANSWERS and SET_VISC_ANSWER_DATE are specified, the
+                                ! latter takes precedence.
 BOTTOMDRAGLAW = True            !   [Boolean] default = True
                                 ! If true, the bottom stress is calculated with a drag law of the form
                                 ! c_drag*|u|*u. The velocity magnitude may be an assumed value or it may be
                                 ! based on the actual velocity in the bottommost HBBL, depending on LINEAR_DRAG.
+DRAG_AS_BODY_FORCE = False      !   [Boolean] default = False
+                                ! If true, the bottom stress is imposed as an explicit body force applied over a
+                                ! fixed distance from the bottom, rather than as an implicit calculation based
+                                ! on an enhanced near-bottom viscosity. The thickness of the bottom boundary
+                                ! layer is HBBL.
 CHANNEL_DRAG = True             !   [Boolean] default = False
                                 ! If true, the bottom drag is exerted directly on each layer proportional to the
                                 ! fraction of the bottom it overlies.
@@ -612,6 +651,11 @@ SMAG_CONST_CHANNEL = 0.15       !   [nondim] default = 0.15
                                 ! channel drag if it is enabled.  The default is to use the same value as
                                 ! SMAG_LAP_CONST if it is defined, or 0.15 if it is not. The value used is also
                                 ! 0.15 if the specified value is negative.
+CHANNEL_DRAG_MAX_BBL_THICK = -1.0 !   [m] default = -1.0
+                                ! The maximum bottom boundary layer thickness over which the channel drag is
+                                ! exerted, or a negative value for no fixed limit, instead basing the BBL
+                                ! thickness on the bottom stress, rotation and stratification.  The default is
+                                ! proportional to HBBL if USE_JACKSON_PARAM or DRAG_AS_BODY_FORCE is true.
 
 ! === module MOM_thickness_diffuse ===
 KHTH = 0.0                      !   [m2 s-1] default = 0.0
@@ -646,10 +690,8 @@ KD_SMOOTH = 1.0E-06             !   [m2 s-1] default = 1.0E-06
 KHTH_USE_FGNV_STREAMFUNCTION = False !   [Boolean] default = False
                                 ! If true, use the streamfunction formulation of Ferrari et al., 2010, which
                                 ! effectively emphasizes graver vertical modes by smoothing in the vertical.
-STANLEY_PRM_DET_COEFF = -1.0    !   [nondim] default = -1.0
-                                ! The coefficient correlating SGS temperature variance with the mean temperature
-                                ! gradient in the deterministic part of the Stanley parameterization. Negative
-                                ! values disable the scheme.
+USE_STANLEY_GM = False          !   [Boolean] default = False
+                                ! If true, turn on Stanley SGS T variance parameterization in GM code.
 MEKE_GM_SRC_ALT = False         !   [Boolean] default = False
                                 ! If true, use the GM energy conversion form S^2*N^2*kappa rather than the
                                 ! streamfunction for the GM source term.
@@ -664,6 +706,30 @@ USE_GME = False                 !   [Boolean] default = False
 USE_GM_WORK_BUG = False         !   [Boolean] default = False
                                 ! If true, compute the top-layer work tendency on the u-grid with the incorrect
                                 ! sign, for legacy reproducibility.
+STOCH_EOS = False               !   [Boolean] default = False
+                                ! If true, stochastic perturbations are applied to the EOS in the PGF.
+STANLEY_COEFF = -1.0            !   [not defined] default = -1.0
+                                ! Coefficient correlating the temperature gradient and SGS T variance.
+STANLEY_A = 1.0                 !   [not defined] default = 1.0
+                                ! Coefficient a which scales chi in stochastic perturbation of the SGS T
+                                ! variance.
+
+! === module MOM_porous_barriers ===
+PORBAR_ANSWER_DATE = 99991231   ! default = 99991231
+                                ! The vintage of the porous barrier weight function calculations.  Values below
+                                ! 20220806 recover the old answers in which the layer averaged weights are not
+                                ! strictly limited by an upper-bound of 1.0 .
+PORBAR_MASKING_DEPTH = 0.0      !   [m] default = 0.0
+                                ! If the effective average depth at the velocity cell is shallower than this
+                                ! number, then porous barrier is not applied at that location.
+                                ! PORBAR_MASKING_DEPTH is assumed to be positive below the sea surface.
+PORBAR_ETA_INTERP = "MAX"       ! default = "MAX"
+                                ! A string describing the method that decicdes how the interface heights at the
+                                ! velocity points are calculated. Valid values are:
+                                !    MAX (the default) - maximum of the adjacent cells
+                                !    MIN - minimum of the adjacent cells
+                                !    ARITHMETIC - arithmetic mean of the adjacent cells
+                                !    HARMOINIC - harmonic mean of the adjacent cells
 
 ! === module MOM_dynamics_split_RK2 ===
 TIDES = True                    !   [Boolean] default = False
@@ -855,16 +921,20 @@ BOUNDARY_EXTRAPOLATION_PRESSURE = True !   [Boolean] default = True
                                 ! If true, the reconstruction of T & S for pressure in boundary cells is
                                 ! extrapolated, rather than using PCM in these cells. If true, the same order
                                 ! polynomial is used as is used for the interior cells.
-PGF_STANLEY_T2_DET_COEFF = -1.0 !   [nondim] default = -1.0
-                                ! The coefficient correlating SGS temperature variance with the mean temperature
-                                ! gradient in the deterministic part of the Stanley form of the Brankart
-                                ! correction. Negative values disable the scheme.
+USE_STANLEY_PGF = False         !   [Boolean] default = False
+                                ! If true, turn on Stanley SGS T variance parameterization in PGF code.
 
 ! === module MOM_hor_visc ===
 HOR_VISC_2018_ANSWERS = False   !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use updated and more robust forms of the
                                 ! same expressions.
+HOR_VISC_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the order of arithmetic and expressions in the horizontal
+                                ! viscosity calculations.  Values below 20190101 recover the answers from the
+                                ! end of 2018, while higher values use updated and more robust forms of the same
+                                ! expressions.  If both HOR_VISC_2018_ANSWERS and HOR_VISC_ANSWER_DATE are
+                                ! specified, the latter takes precedence.
 LAPLACIAN = True                !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
 KH = 0.0                        !   [m2 s-1] default = 0.0
@@ -945,6 +1015,13 @@ VERT_FRICTION_2018_ANSWERS = False !   [Boolean] default = False
                                 ! If true, use the order of arithmetic and expressions that recover the answers
                                 ! from the end of 2018.  Otherwise, use expressions that do not use an arbitrary
                                 ! hard-coded maximum viscous coupling coefficient between layers.
+VERT_FRICTION_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the order of arithmetic and expressions in the viscous
+                                ! calculations.  Values below 20190101 recover the answers from the end of 2018,
+                                ! while higher values use expressions that do not use an arbitrary hard-coded
+                                ! maximum viscous coupling coefficient  between layers.  If both
+                                ! VERT_FRICTION_2018_ANSWERS and VERT_FRICTION_ANSWER_DATE are specified, the
+                                ! latter takes precedence.
 DIRECT_STRESS = True            !   [Boolean] default = False
                                 ! If true, the wind stress is distributed over the topmost HMIX_STRESS of fluid
                                 ! (like in HYCOM), and KVML may be set to a very small value.
@@ -1034,7 +1111,12 @@ BT_CORIOLIS_SCALE = 1.0         !   [nondim] default = 1.0
 BAROTROPIC_2018_ANSWERS = False !   [Boolean] default = False
                                 ! If true, use expressions for the barotropic solver that recover the answers
                                 ! from the end of 2018.  Otherwise, use more efficient or general expressions.
-BAROTROPIC_TIDAL_SAL_BUG = True !   [Boolean] default = True
+BAROTROPIC_ANSWER_DATE = 99991231 ! default = 99991231
+                                ! The vintage of the expressions in the barotropic solver. Values below 20190101
+                                ! recover the answers from the end of 2018, while higher values uuse more
+                                ! efficient or general expressions.  If both BAROTROPIC_2018_ANSWERS and
+                                ! BAROTROPIC_ANSWER_DATE are specified, the latter takes precedence.
+BAROTROPIC_TIDAL_SAL_BUG = False !   [Boolean] default = True
                                 ! If true, the tidal self-attraction and loading anomaly in the barotropic
                                 ! solver has the wrong sign, replicating a long-standing bug with a scalar
                                 ! self-attraction and loading term or the SAL term from a previous simulation.

--- a/ocean_only/tides_025/MOM_parameter_doc.short
+++ b/ocean_only/tides_025/MOM_parameter_doc.short
@@ -204,6 +204,8 @@ KV = 1.0E-04                    !   [m2 s-1]
 
 ! === module MOM_thickness_diffuse ===
 
+! === module MOM_porous_barriers ===
+
 ! === module MOM_dynamics_split_RK2 ===
 TIDES = True                    !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
@@ -277,6 +279,10 @@ BT_PROJECT_VELOCITY = True      !   [Boolean] default = False
                                 ! use a predictor continuity step to find the pressure field, and then to do a
                                 ! corrector continuity step using a weighted average of the old and new
                                 ! velocities, with weights of (1-BEBT) and BEBT.
+BAROTROPIC_TIDAL_SAL_BUG = False !   [Boolean] default = True
+                                ! If true, the tidal self-attraction and loading anomaly in the barotropic
+                                ! solver has the wrong sign, replicating a long-standing bug with a scalar
+                                ! self-attraction and loading term or the SAL term from a previous simulation.
 BEBT = 0.2                      !   [nondim] default = 0.1
                                 ! BEBT determines whether the barotropic time stepping uses the forward-backward
                                 ! time-stepping scheme or a backward Euler scheme. BEBT is valid in the range

--- a/ocean_only/tides_025/MOM_parameter_doc.short
+++ b/ocean_only/tides_025/MOM_parameter_doc.short
@@ -263,7 +263,7 @@ DIRECT_STRESS = True            !   [Boolean] default = False
 HMIX_FIXED = 20.0               !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVML = 0.01                     !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 1.0E-04
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 MAXVEL = 6.0                    !   [m s-1] default = 3.0E+08

--- a/ocean_only/torus_advection_test/MOM_input
+++ b/ocean_only/torus_advection_test/MOM_input
@@ -216,10 +216,10 @@ BBL_THICK_MIN = 0.1             !   [m] default = 0.0
                                 ! The minimum bottom boundary layer thickness that can be used with
                                 ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
-KV = 1.0E-04                    !   [m2 s-1]
+KV = 0.0                        !   [m2 s-1]
                                 ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
                                 ! m2 s-1, may be used.
-KV_BBL_MIN = 1.0E-06            !   [m2 s-1] default = 1.0E-04
+KV_BBL_MIN = 0.0                !   [m2 s-1] default = 0.0
                                 ! The minimum viscosities in the bottom boundary layer.
 
 ! === module MOM_thickness_diffuse ===
@@ -260,7 +260,7 @@ BIHARMONIC = False              !   [Boolean] default = True
 HMIX_FIXED = 1.0E-10            !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVBBL = 0.0                     !   [m2 s-1] default = 1.0E-04
+KVBBL = 0.0                     !   [m2 s-1] default = 0.0
                                 ! The kinematic viscosity in the benthic boundary layer. A typical value is
                                 ! ~1e-2 m2 s-1. KVBBL is not used if BOTTOMDRAGLAW is true.  The default is set
                                 ! by KV.

--- a/ocean_only/torus_advection_test/MOM_input
+++ b/ocean_only/torus_advection_test/MOM_input
@@ -260,6 +260,9 @@ BIHARMONIC = False              !   [Boolean] default = True
 HMIX_FIXED = 1.0E-10            !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
+KVML = 0.0                      !   [m2 s-1] default = 0.0
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 KVBBL = 0.0                     !   [m2 s-1] default = 0.0
                                 ! The kinematic viscosity in the benthic boundary layer. A typical value is
                                 ! ~1e-2 m2 s-1. KVBBL is not used if BOTTOMDRAGLAW is true.  The default is set

--- a/ocean_only/torus_advection_test/MOM_parameter_doc.all
+++ b/ocean_only/torus_advection_test/MOM_parameter_doc.all
@@ -664,12 +664,12 @@ HTBL_SHELF_MIN = 0.1            !   [m] default = 0.1
 HTBL_SHELF = 1.0E-08            !   [m] default = 1.0E-08
                                 ! The thickness over which near-surface velocities are averaged for the drag law
                                 ! under an ice shelf.  By default this is the same as HBBL
-KV = 1.0E-04                    !   [m2 s-1]
+KV = 0.0                        !   [m2 s-1]
                                 ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
                                 ! m2 s-1, may be used.
-KV_BBL_MIN = 1.0E-06            !   [m2 s-1] default = 1.0E-04
+KV_BBL_MIN = 0.0                !   [m2 s-1] default = 0.0
                                 ! The minimum viscosities in the bottom boundary layer.
-KV_TBL_MIN = 1.0E-04            !   [m2 s-1] default = 1.0E-04
+KV_TBL_MIN = 0.0                !   [m2 s-1] default = 0.0
                                 ! The minimum viscosities in the top boundary layer.
 CORRECT_BBL_BOUNDS = False      !   [Boolean] default = False
                                 ! If true, uses the correct bounds on the BBL thickness and viscosity so that
@@ -956,10 +956,10 @@ HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
 HMIX_FIXED = 1.0E-10            !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVML = 1.0E-04                  !   [m2 s-1] default = 1.0E-04
+KVML = 0.0                      !   [m2 s-1] default = 0.0
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
-KVBBL = 0.0                     !   [m2 s-1] default = 1.0E-04
+KVBBL = 0.0                     !   [m2 s-1] default = 0.0
                                 ! The kinematic viscosity in the benthic boundary layer. A typical value is
                                 ! ~1e-2 m2 s-1. KVBBL is not used if BOTTOMDRAGLAW is true.  The default is set
                                 ! by KV.

--- a/ocean_only/torus_advection_test/MOM_parameter_doc.short
+++ b/ocean_only/torus_advection_test/MOM_parameter_doc.short
@@ -207,11 +207,9 @@ BBL_THICK_MIN = 0.1             !   [m] default = 0.0
                                 ! The minimum bottom boundary layer thickness that can be used with
                                 ! BOTTOMDRAGLAW. This might be Kv/(cdrag*drag_bg_vel) to give Kv as the minimum
                                 ! near-bottom viscosity.
-KV = 1.0E-04                    !   [m2 s-1]
+KV = 0.0                        !   [m2 s-1]
                                 ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
                                 ! m2 s-1, may be used.
-KV_BBL_MIN = 1.0E-06            !   [m2 s-1] default = 1.0E-04
-                                ! The minimum viscosities in the bottom boundary layer.
 
 ! === module MOM_thickness_diffuse ===
 
@@ -253,10 +251,6 @@ BIHARMONIC = False              !   [Boolean] default = True
 HMIX_FIXED = 1.0E-10            !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVBBL = 0.0                     !   [m2 s-1] default = 1.0E-04
-                                ! The kinematic viscosity in the benthic boundary layer. A typical value is
-                                ! ~1e-2 m2 s-1. KVBBL is not used if BOTTOMDRAGLAW is true.  The default is set
-                                ! by KV.
 MAXVEL = 10.0                   !   [m s-1] default = 3.0E+08
                                 ! The maximum velocity allowed before the velocity components are truncated.
 

--- a/ocean_only/unit_tests/MOM_input
+++ b/ocean_only/unit_tests/MOM_input
@@ -212,6 +212,9 @@ SIMPLE_2ND_PPM_CONTINUITY = True !   [Boolean] default = False
 HMIX_FIXED = 1.0                !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
+KVML = 0.0                      !   [m2 s-1] default = 1.0
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 
 ! === module MOM_mixed_layer_restrat ===
 

--- a/ocean_only/unit_tests/MOM_parameter_doc.all
+++ b/ocean_only/unit_tests/MOM_parameter_doc.all
@@ -828,7 +828,7 @@ HARMONIC_BL_SCALE = 0.0         !   [nondim] default = 0.0
 HMIX_FIXED = 1.0                !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
-KVML = 1.0                      !   [m2 s-1] default = 1.0
+KVML = 0.0                      !   [m2 s-1] default = 1.0
                                 ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
                                 ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 KVBBL = 1.0                     !   [m2 s-1] default = 1.0

--- a/ocean_only/unit_tests/MOM_parameter_doc.short
+++ b/ocean_only/unit_tests/MOM_parameter_doc.short
@@ -129,6 +129,9 @@ SIMPLE_2ND_PPM_CONTINUITY = True !   [Boolean] default = False
 HMIX_FIXED = 1.0                !   [m]
                                 ! The prescribed depth over which the near-surface viscosity and diffusivity are
                                 ! elevated when the bulk mixed layer is not used.
+KVML = 0.0                      !   [m2 s-1] default = 1.0
+                                ! The kinematic viscosity in the mixed layer.  A typical value is ~1e-2 m2 s-1.
+                                ! KVML is not used if BULKMIXEDLAYER is true.  The default is set by KV.
 
 ! === module MOM_diagnostics ===
 


### PR DESCRIPTION


  This PR includes a series of commits that migrate away from the use of runtime
parameters that recover bugs or unnecessarily use a nonzero value KVML option.  
Changes are primarily to the MOM_input or MOM_override files, with consequent
updates to the MOM_parameter_doc files for consistency.  These parameter changes
do change answers in numerous MOM6 tests, but not in any of the test cases (like
OM4_025 or OM4_1deg) that serve as the reference for important coupled model
configurations.

  The commits in this PR include:
  
- NOAA-GFDL/MOM6-examples@9d1104de *Set KVML = 0.0 in 31 cases
- NOAA-GFDL/MOM6-examples@2da17136 *Make torus_advection_test inviscid
- NOAA-GFDL/MOM6-examples@fdc762d0 Updated MOM_parameter_doc files for 5 cases
- NOAA-GFDL/MOM6-examples@32503559 *Avoid buggy options in 15 test cases
