### PR TITLE
Added more Ubuntu templates via mkmf

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -24,7 +24,7 @@
 	url = https://github.com/NOAA-GFDL/land_null.git
 [submodule "src/mkmf"]
 	path = src/mkmf
-	url = https://github.com/NOAA-GFDL/mkmf.git
+	url = https://github.com/mom-ocean/mkmf.git
 [submodule "tools/analysis/mpl-cmocean"]
 	path = tools/analysis/mpl-cmocean
 	url = https://github.com/matplotlib/cmocean.git


### PR DESCRIPTION
- point submodule to the mom-ocean mkmf repo;
- use branch with working templates for Ubuntu-18, -20, and -22.

Needed so we can repair the wiki instructions in time for the tutorial.

Todo:
[ ] resolve recent evolution of mkmf with wiki instructions and our workflows