### PR TITLE
*Set RHO_0 = 1024.0 in ocean_only/nonBous_global

### DIFF
--- a/ocean_only/nonBous_global/MOM_input
+++ b/ocean_only/nonBous_global/MOM_input
@@ -121,6 +121,10 @@ CHANNEL_CONFIG = "global_1deg"  ! default = "none"
 
 ! === module MOM_verticalGrid ===
 ! Parameters providing information about the vertical grid.
+RHO_0 = 1024.0                  !   [kg m-3] default = 1035.0
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = False              !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 NK = 63                         !   [nondim]

--- a/ocean_only/nonBous_global/MOM_parameter_doc.all
+++ b/ocean_only/nonBous_global/MOM_parameter_doc.all
@@ -295,7 +295,7 @@ GRID_ROTATION_ANGLE_BUGS = False !   [Boolean] default = False
 ! Parameters providing information about the vertical grid.
 G_EARTH = 9.8                   !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
-RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
+RHO_0 = 1024.0                  !   [kg m-3] default = 1035.0
                                 ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
                                 ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
                                 ! some parameters from vertical units of m to kg m-2.
@@ -305,7 +305,7 @@ SEMI_BOUSSINESQ = True          !   [Boolean] default = True
                                 ! If true, do non-Boussinesq pressure force calculations and use mass-based
                                 ! thicknesses, but use RHO_0 to convert layer thicknesses into certain height
                                 ! changes.  This only applies if BOUSSINESQ is false.
-RHO_KV_CONVERT = 1035.0         !   [kg m-3] default = 1035.0
+RHO_KV_CONVERT = 1024.0         !   [kg m-3] default = 1024.0
                                 ! The density used to convert input vertical distances into thickesses in
                                 ! non-BOUSSINESQ mode, and to convert kinematic viscosities into dynamic
                                 ! viscosities and similarly for vertical diffusivities.  GV%m_to_H is set using

--- a/ocean_only/nonBous_global/MOM_parameter_doc.short
+++ b/ocean_only/nonBous_global/MOM_parameter_doc.short
@@ -112,6 +112,10 @@ CHANNEL_CONFIG = "global_1deg"  ! default = "none"
 
 ! === module MOM_verticalGrid ===
 ! Parameters providing information about the vertical grid.
+RHO_0 = 1024.0                  !   [kg m-3] default = 1035.0
+                                ! The mean ocean density used with BOUSSINESQ true to calculate accelerations
+                                ! and the mass for conservation properties, or with BOUSSINSEQ false to convert
+                                ! some parameters from vertical units of m to kg m-2.
 BOUSSINESQ = False              !   [Boolean] default = True
                                 ! If true, make the Boussinesq approximation.
 NK = 63                         !   [nondim]


### PR DESCRIPTION
  Change the setting of RHO_0 to 1024.0 in the nonBous_global test case so that a number of mathematically equivalent revisions to the MOM6 code that are implementing a fully non-Boussinesq option in MOM6 will not be flagged as failing the automated regression tests.  This is the only non-Boussinesq test case, but it is not being used actively for any scientific studies, so although this commit changes answers, it should not impact any ongoing projects.