### PR TITLE
Swap DEFAULT_ANSWER_DATE for DEFAULT_2018_ANSWERS

### DIFF
--- a/coupled_AM2_LM3_SIS/AM2_MOM6i_1deg/MOM_input
+++ b/coupled_AM2_LM3_SIS/AM2_MOM6i_1deg/MOM_input
@@ -65,8 +65,8 @@ C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
                                 ! The heat capacity of sea water, approximated as a constant. This is only used
                                 ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
                                 ! definition of conservative temperature.
-DEFAULT_2018_ANSWERS = True     !   [Boolean] default = True
-                                ! This sets the default value for the various _2018_ANSWERS parameters.
+DEFAULT_ANSWER_DATE = 20181231  ! default = 99991231
+                                ! This sets the default value for the various _ANSWER_DATE parameters.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
                                 ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 
@@ -281,6 +281,12 @@ KHTH = 10.0                     !   [m2 s-1] default = 0.0
                                 ! The background horizontal thickness diffusivity.
 KHTH_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
+
+! === module MOM_porous_barriers ===
+PORBAR_ANSWER_DATE = 99991231   ! default = 20181231
+                                ! The vintage of the porous barrier weight function calculations.  Values below
+                                ! 20220806 recover the old answers in which the layer averaged weights are not
+                                ! strictly limited by an upper-bound of 1.0 .
 
 ! === module MOM_continuity ===
 

--- a/coupled_AM2_LM3_SIS/CM2G63L/MOM_input
+++ b/coupled_AM2_LM3_SIS/CM2G63L/MOM_input
@@ -65,8 +65,8 @@ C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
                                 ! The heat capacity of sea water, approximated as a constant. This is only used
                                 ! if ENABLE_THERMODYNAMICS is true. The default value is from the TEOS-10
                                 ! definition of conservative temperature.
-DEFAULT_2018_ANSWERS = True     !   [Boolean] default = True
-                                ! This sets the default value for the various _2018_ANSWERS parameters.
+DEFAULT_ANSWER_DATE = 20181231  ! default = 99991231
+                                ! This sets the default value for the various _ANSWER_DATE parameters.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
                                 ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 
@@ -281,6 +281,12 @@ KHTH = 10.0                     !   [m2 s-1] default = 0.0
                                 ! The background horizontal thickness diffusivity.
 KHTH_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
+
+! === module MOM_porous_barriers ===
+PORBAR_ANSWER_DATE = 99991231   ! default = 20181231
+                                ! The vintage of the porous barrier weight function calculations.  Values below
+                                ! 20220806 recover the old answers in which the layer averaged weights are not
+                                ! strictly limited by an upper-bound of 1.0 .
 
 ! === module MOM_continuity ===
 

--- a/coupled_AM2_LM3_SIS2/AM2_SIS2B_MOM6i_1deg/MOM_input
+++ b/coupled_AM2_LM3_SIS2/AM2_SIS2B_MOM6i_1deg/MOM_input
@@ -76,8 +76,8 @@ NKML = 2                        !   [nondim] default = 2
 NKBL = 2                        !   [nondim] default = 2
                                 ! The number of layers that are used as variable density buffer layers if
                                 ! BULKMIXEDLAYER is true.
-DEFAULT_2018_ANSWERS = True     !   [Boolean] default = True
-                                ! This sets the default value for the various _2018_ANSWERS parameters.
+DEFAULT_ANSWER_DATE = 20181231  ! default = 99991231
+                                ! This sets the default value for the various _ANSWER_DATE parameters.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
                                 ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "GOLD_IC"      ! default = "MOM_IC"
@@ -298,6 +298,12 @@ KHTH = 10.0                     !   [m2 s-1] default = 0.0
                                 ! The background horizontal thickness diffusivity.
 KHTH_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
+
+! === module MOM_porous_barriers ===
+PORBAR_ANSWER_DATE = 99991231   ! default = 20181231
+                                ! The vintage of the porous barrier weight function calculations.  Values below
+                                ! 20220806 recover the old answers in which the layer averaged weights are not
+                                ! strictly limited by an upper-bound of 1.0 .
 
 ! === module MOM_continuity ===
 

--- a/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/MOM_input
+++ b/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/MOM_input
@@ -76,8 +76,8 @@ NKML = 2                        !   [nondim] default = 2
 NKBL = 2                        !   [nondim] default = 2
                                 ! The number of layers that are used as variable density buffer layers if
                                 ! BULKMIXEDLAYER is true.
-DEFAULT_2018_ANSWERS = True     !   [Boolean] default = True
-                                ! This sets the default value for the various _2018_ANSWERS parameters.
+DEFAULT_ANSWER_DATE = 20181231  ! default = 99991231
+                                ! This sets the default value for the various _ANSWER_DATE parameters.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
                                 ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "GOLD_IC"      ! default = "MOM_IC"
@@ -305,6 +305,12 @@ KHTH = 10.0                     !   [m2 s-1] default = 0.0
                                 ! The background horizontal thickness diffusivity.
 KHTH_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
+
+! === module MOM_porous_barriers ===
+PORBAR_ANSWER_DATE = 99991231   ! default = 20181231
+                                ! The vintage of the porous barrier weight function calculations.  Values below
+                                ! 20220806 recover the old answers in which the layer averaged weights are not
+                                ! strictly limited by an upper-bound of 1.0 .
 
 ! === module MOM_continuity ===
 

--- a/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/MOM_parameter_doc.short
+++ b/coupled_AM2_LM3_SIS2/AM2_SIS2_MOM6i_1deg/MOM_parameter_doc.short
@@ -38,8 +38,8 @@ C_P = 3925.0                    !   [J kg-1 K-1] default = 3991.86795711963
 USE_PSURF_IN_EOS = False        !   [Boolean] default = True
                                 ! If true, always include the surface pressure contributions in equation of
                                 ! state calculations.
-DEFAULT_2018_ANSWERS = True     !   [Boolean] default = False
-                                ! This sets the default value for the various _2018_ANSWERS parameters.
+DEFAULT_ANSWER_DATE = 20181231  ! default = 99991231
+                                ! This sets the default value for the various _ANSWER_DATE parameters.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
                                 ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 IC_OUTPUT_FILE = "GOLD_IC"      ! default = "MOM_IC"
@@ -264,6 +264,10 @@ KHTH_MAX = 900.0                !   [m2 s-1] default = 0.0
                                 ! The maximum horizontal thickness diffusivity.
 
 ! === module MOM_porous_barriers ===
+PORBAR_ANSWER_DATE = 99991231   ! default = 20181231
+                                ! The vintage of the porous barrier weight function calculations.  Values below
+                                ! 20220806 recover the old answers in which the layer averaged weights are not
+                                ! strictly limited by an upper-bound of 1.0 .
 
 ! === module MOM_dynamics_split_RK2 ===
 

--- a/ice_ocean_SIS2/Baltic_OM4_025/MOM_input
+++ b/ice_ocean_SIS2/Baltic_OM4_025/MOM_input
@@ -87,8 +87,8 @@ BAD_VAL_SST_MAX = 55.0          !   [deg C] default = 45.0
 BAD_VAL_SST_MIN = -3.0          !   [deg C] default = -2.1
                                 ! The value of SST below which a bad value message is triggered, if
                                 ! CHECK_BAD_SURFACE_VALS is true.
-DEFAULT_2018_ANSWERS = True     !   [Boolean] default = True
-                                ! This sets the default value for the various _2018_ANSWERS parameters.
+DEFAULT_ANSWER_DATE = 20181231  ! default = 99991231
+                                ! This sets the default value for the various _ANSWER_DATE parameters.
 WRITE_GEOM = 0                  ! default = 1
                                 ! If =0, never write the geometry and vertical grid files. If =1, write the
                                 ! geometry and vertical grid files only for a new simulation. If =2, always
@@ -424,6 +424,12 @@ KHTH_MAX_CFL = 0.1              !   [nondimensional] default = 0.8
 USE_GM_WORK_BUG = True          !   [Boolean] default = True
                                 ! If true, compute the top-layer work tendency on the u-grid with the incorrect
                                 ! sign, for legacy reproducibility.
+
+! === module MOM_porous_barriers ===
+PORBAR_ANSWER_DATE = 99991231   ! default = 20181231
+                                ! The vintage of the porous barrier weight function calculations.  Values below
+                                ! 20220806 recover the old answers in which the layer averaged weights are not
+                                ! strictly limited by an upper-bound of 1.0 .
 
 ! === module MOM_continuity ===
 

--- a/ice_ocean_SIS2/Baltic_OM4_025/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/Baltic_OM4_025/MOM_parameter_doc.short
@@ -55,8 +55,8 @@ BAD_VAL_SST_MAX = 55.0          !   [deg C] default = 45.0
 BAD_VAL_SST_MIN = -3.0          !   [deg C] default = -2.1
                                 ! The value of SST below which a bad value message is triggered, if
                                 ! CHECK_BAD_SURFACE_VALS is true.
-DEFAULT_2018_ANSWERS = True     !   [Boolean] default = False
-                                ! This sets the default value for the various _2018_ANSWERS parameters.
+DEFAULT_ANSWER_DATE = 20181231  ! default = 99991231
+                                ! This sets the default value for the various _ANSWER_DATE parameters.
 WRITE_GEOM = 0                  ! default = 1
                                 ! If =0, never write the geometry and vertical grid files. If =1, write the
                                 ! geometry and vertical grid files only for a new simulation. If =2, always
@@ -385,6 +385,10 @@ USE_GM_WORK_BUG = True          !   [Boolean] default = False
                                 ! sign, for legacy reproducibility.
 
 ! === module MOM_porous_barriers ===
+PORBAR_ANSWER_DATE = 99991231   ! default = 20181231
+                                ! The vintage of the porous barrier weight function calculations.  Values below
+                                ! 20220806 recover the old answers in which the layer averaged weights are not
+                                ! strictly limited by an upper-bound of 1.0 .
 
 ! === module MOM_dynamics_split_RK2 ===
 

--- a/ice_ocean_SIS2/Baltic_OM4_05/MOM_input
+++ b/ice_ocean_SIS2/Baltic_OM4_05/MOM_input
@@ -86,8 +86,8 @@ BAD_VAL_SST_MAX = 55.0          !   [deg C] default = 45.0
 BAD_VAL_SST_MIN = -3.0          !   [deg C] default = -2.1
                                 ! The value of SST below which a bad value message is triggered, if
                                 ! CHECK_BAD_SURFACE_VALS is true.
-DEFAULT_2018_ANSWERS = True     !   [Boolean] default = True
-                                ! This sets the default value for the various _2018_ANSWERS parameters.
+DEFAULT_ANSWER_DATE = 20181231  ! default = 99991231
+                                ! This sets the default value for the various _ANSWER_DATE parameters.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -440,6 +440,12 @@ FGNV_FILTER_SCALE = 0.1         !   [nondim] default = 1.0
 USE_GM_WORK_BUG = True          !   [Boolean] default = True
                                 ! If true, compute the top-layer work tendency on the u-grid with the incorrect
                                 ! sign, for legacy reproducibility.
+
+! === module MOM_porous_barriers ===
+PORBAR_ANSWER_DATE = 99991231   ! default = 20181231
+                                ! The vintage of the porous barrier weight function calculations.  Values below
+                                ! 20220806 recover the old answers in which the layer averaged weights are not
+                                ! strictly limited by an upper-bound of 1.0 .
 
 ! === module MOM_continuity ===
 

--- a/ice_ocean_SIS2/Baltic_OM4_05/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/Baltic_OM4_05/MOM_parameter_doc.short
@@ -55,8 +55,8 @@ BAD_VAL_SST_MAX = 55.0          !   [deg C] default = 45.0
 BAD_VAL_SST_MIN = -3.0          !   [deg C] default = -2.1
                                 ! The value of SST below which a bad value message is triggered, if
                                 ! CHECK_BAD_SURFACE_VALS is true.
-DEFAULT_2018_ANSWERS = True     !   [Boolean] default = False
-                                ! This sets the default value for the various _2018_ANSWERS parameters.
+DEFAULT_ANSWER_DATE = 20181231  ! default = 99991231
+                                ! This sets the default value for the various _ANSWER_DATE parameters.
 
 ! === module MOM_domains ===
 REENTRANT_X = False             !   [Boolean] default = True
@@ -402,6 +402,10 @@ USE_GM_WORK_BUG = True          !   [Boolean] default = False
                                 ! sign, for legacy reproducibility.
 
 ! === module MOM_porous_barriers ===
+PORBAR_ANSWER_DATE = 99991231   ! default = 20181231
+                                ! The vintage of the porous barrier weight function calculations.  Values below
+                                ! 20220806 recover the old answers in which the layer averaged weights are not
+                                ! strictly limited by an upper-bound of 1.0 .
 
 ! === module MOM_dynamics_split_RK2 ===
 

--- a/ice_ocean_SIS2/OM4_025.JRA/MOM_input
+++ b/ice_ocean_SIS2/OM4_025.JRA/MOM_input
@@ -87,8 +87,8 @@ BAD_VAL_SST_MAX = 55.0          !   [deg C] default = 45.0
 BAD_VAL_SST_MIN = -3.0          !   [deg C] default = -2.1
                                 ! The value of SST below which a bad value message is triggered, if
                                 ! CHECK_BAD_SURFACE_VALS is true.
-DEFAULT_2018_ANSWERS = True     !   [Boolean] default = True
-                                ! This sets the default value for the various _2018_ANSWERS parameters.
+DEFAULT_ANSWER_DATE = 20181231  ! default = 99991231
+                                ! This sets the default value for the various _ANSWER_DATE parameters.
 WRITE_GEOM = 0                  ! default = 1
                                 ! If =0, never write the geometry and vertical grid files. If =1, write the
                                 ! geometry and vertical grid files only for a new simulation. If =2, always
@@ -422,6 +422,12 @@ KHTH_MAX_CFL = 0.1              !   [nondimensional] default = 0.8
                                 ! thickness diffusivity. 1.0 is the marginally unstable value in a pure layered
                                 ! model, but much smaller numbers (e.g. 0.1) seem to work better for ALE-based
                                 ! models.
+
+! === module MOM_porous_barriers ===
+PORBAR_ANSWER_DATE = 99991231   ! default = 20181231
+                                ! The vintage of the porous barrier weight function calculations.  Values below
+                                ! 20220806 recover the old answers in which the layer averaged weights are not
+                                ! strictly limited by an upper-bound of 1.0 .
 
 ! === module MOM_continuity ===
 

--- a/ice_ocean_SIS2/OM4_025/MOM_input
+++ b/ice_ocean_SIS2/OM4_025/MOM_input
@@ -87,8 +87,8 @@ BAD_VAL_SST_MAX = 55.0          !   [deg C] default = 45.0
 BAD_VAL_SST_MIN = -3.0          !   [deg C] default = -2.1
                                 ! The value of SST below which a bad value message is triggered, if
                                 ! CHECK_BAD_SURFACE_VALS is true.
-DEFAULT_2018_ANSWERS = True     !   [Boolean] default = True
-                                ! This sets the default value for the various _2018_ANSWERS parameters.
+DEFAULT_ANSWER_DATE = 20181231  ! default = 99991231
+                                ! This sets the default value for the various _ANSWER_DATE parameters.
 WRITE_GEOM = 0                  ! default = 1
                                 ! If =0, never write the geometry and vertical grid files. If =1, write the
                                 ! geometry and vertical grid files only for a new simulation. If =2, always
@@ -430,6 +430,12 @@ KHTH_MAX_CFL = 0.1              !   [nondimensional] default = 0.8
 USE_GM_WORK_BUG = True          !   [Boolean] default = True
                                 ! If true, compute the top-layer work tendency on the u-grid with the incorrect
                                 ! sign, for legacy reproducibility.
+
+! === module MOM_porous_barriers ===
+PORBAR_ANSWER_DATE = 99991231   ! default = 20181231
+                                ! The vintage of the porous barrier weight function calculations.  Values below
+                                ! 20220806 recover the old answers in which the layer averaged weights are not
+                                ! strictly limited by an upper-bound of 1.0 .
 
 ! === module MOM_continuity ===
 

--- a/ice_ocean_SIS2/OM4_025/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/OM4_025/MOM_parameter_doc.short
@@ -55,8 +55,8 @@ BAD_VAL_SST_MAX = 55.0          !   [deg C] default = 45.0
 BAD_VAL_SST_MIN = -3.0          !   [deg C] default = -2.1
                                 ! The value of SST below which a bad value message is triggered, if
                                 ! CHECK_BAD_SURFACE_VALS is true.
-DEFAULT_2018_ANSWERS = True     !   [Boolean] default = False
-                                ! This sets the default value for the various _2018_ANSWERS parameters.
+DEFAULT_ANSWER_DATE = 20181231  ! default = 99991231
+                                ! This sets the default value for the various _ANSWER_DATE parameters.
 WRITE_GEOM = 0                  ! default = 1
                                 ! If =0, never write the geometry and vertical grid files. If =1, write the
                                 ! geometry and vertical grid files only for a new simulation. If =2, always
@@ -392,6 +392,10 @@ USE_GM_WORK_BUG = True          !   [Boolean] default = False
                                 ! sign, for legacy reproducibility.
 
 ! === module MOM_porous_barriers ===
+PORBAR_ANSWER_DATE = 99991231   ! default = 20181231
+                                ! The vintage of the porous barrier weight function calculations.  Values below
+                                ! 20220806 recover the old answers in which the layer averaged weights are not
+                                ! strictly limited by an upper-bound of 1.0 .
 
 ! === module MOM_dynamics_split_RK2 ===
 

--- a/ice_ocean_SIS2/OM4_05/MOM_input
+++ b/ice_ocean_SIS2/OM4_05/MOM_input
@@ -87,8 +87,8 @@ BAD_VAL_SST_MAX = 55.0          !   [deg C] default = 45.0
 BAD_VAL_SST_MIN = -3.0          !   [deg C] default = -2.1
                                 ! The value of SST below which a bad value message is triggered, if
                                 ! CHECK_BAD_SURFACE_VALS is true.
-DEFAULT_2018_ANSWERS = True     !   [Boolean] default = True
-                                ! This sets the default value for the various _2018_ANSWERS parameters.
+DEFAULT_ANSWER_DATE = 20181231  ! default = 99991231
+                                ! This sets the default value for the various _ANSWER_DATE parameters.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -445,6 +445,12 @@ FGNV_FILTER_SCALE = 0.1         !   [nondim] default = 1.0
 USE_GM_WORK_BUG = True          !   [Boolean] default = True
                                 ! If true, compute the top-layer work tendency on the u-grid with the incorrect
                                 ! sign, for legacy reproducibility.
+
+! === module MOM_porous_barriers ===
+PORBAR_ANSWER_DATE = 99991231   ! default = 20181231
+                                ! The vintage of the porous barrier weight function calculations.  Values below
+                                ! 20220806 recover the old answers in which the layer averaged weights are not
+                                ! strictly limited by an upper-bound of 1.0 .
 
 ! === module MOM_continuity ===
 

--- a/ice_ocean_SIS2/OM4_05/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/OM4_05/MOM_parameter_doc.short
@@ -55,8 +55,8 @@ BAD_VAL_SST_MAX = 55.0          !   [deg C] default = 45.0
 BAD_VAL_SST_MIN = -3.0          !   [deg C] default = -2.1
                                 ! The value of SST below which a bad value message is triggered, if
                                 ! CHECK_BAD_SURFACE_VALS is true.
-DEFAULT_2018_ANSWERS = True     !   [Boolean] default = False
-                                ! This sets the default value for the various _2018_ANSWERS parameters.
+DEFAULT_ANSWER_DATE = 20181231  ! default = 99991231
+                                ! This sets the default value for the various _ANSWER_DATE parameters.
 
 ! === module MOM_domains ===
 TRIPOLAR_N = True               !   [Boolean] default = False
@@ -407,6 +407,10 @@ USE_GM_WORK_BUG = True          !   [Boolean] default = False
                                 ! sign, for legacy reproducibility.
 
 ! === module MOM_porous_barriers ===
+PORBAR_ANSWER_DATE = 99991231   ! default = 20181231
+                                ! The vintage of the porous barrier weight function calculations.  Values below
+                                ! 20220806 recover the old answers in which the layer averaged weights are not
+                                ! strictly limited by an upper-bound of 1.0 .
 
 ! === module MOM_dynamics_split_RK2 ===
 

--- a/ice_ocean_SIS2/OM_1deg/MOM_input
+++ b/ice_ocean_SIS2/OM_1deg/MOM_input
@@ -61,8 +61,8 @@ BAD_VAL_SST_MAX = 55.0          !   [deg C] default = 45.0
 BAD_VAL_SST_MIN = -3.0          !   [deg C] default = -2.1
                                 ! The value of SST below which a bad value message is triggered, if
                                 ! CHECK_BAD_SURFACE_VALS is true.
-DEFAULT_2018_ANSWERS = True     !   [Boolean] default = False
-                                ! This sets the default value for the various _2018_ANSWERS parameters.
+DEFAULT_ANSWER_DATE = 20181231  ! default = 99991231
+                                ! This sets the default value for the various _ANSWER_DATE parameters.
 WRITE_GEOM = 0                  ! default = 1
                                 ! If =0, never write the geometry and vertical grid files. If =1, write the
                                 ! geometry and vertical grid files only for a new simulation. If =2, always
@@ -430,6 +430,12 @@ KV_TBL_MIN = 0.0                !   [m2 s-1] default = 1.0E-04
 USE_GM_WORK_BUG = True          !   [Boolean] default = False
                                 ! If true, compute the top-layer work tendency on the u-grid with the incorrect
                                 ! sign, for legacy reproducibility.
+
+! === module MOM_porous_barriers ===
+PORBAR_ANSWER_DATE = 99991231   ! default = 20181231
+                                ! The vintage of the porous barrier weight function calculations.  Values below
+                                ! 20220806 recover the old answers in which the layer averaged weights are not
+                                ! strictly limited by an upper-bound of 1.0 .
 
 ! === module MOM_dynamics_split_RK2 ===
 

--- a/ice_ocean_SIS2/OM_1deg/MOM_parameter_doc.short
+++ b/ice_ocean_SIS2/OM_1deg/MOM_parameter_doc.short
@@ -58,8 +58,8 @@ BAD_VAL_SST_MAX = 55.0          !   [deg C] default = 45.0
 BAD_VAL_SST_MIN = -3.0          !   [deg C] default = -2.1
                                 ! The value of SST below which a bad value message is triggered, if
                                 ! CHECK_BAD_SURFACE_VALS is true.
-DEFAULT_2018_ANSWERS = True     !   [Boolean] default = False
-                                ! This sets the default value for the various _2018_ANSWERS parameters.
+DEFAULT_ANSWER_DATE = 20181231  ! default = 99991231
+                                ! This sets the default value for the various _ANSWER_DATE parameters.
 WRITE_GEOM = 0                  ! default = 1
                                 ! If =0, never write the geometry and vertical grid files. If =1, write the
                                 ! geometry and vertical grid files only for a new simulation. If =2, always
@@ -419,6 +419,10 @@ USE_GM_WORK_BUG = True          !   [Boolean] default = False
                                 ! sign, for legacy reproducibility.
 
 ! === module MOM_porous_barriers ===
+PORBAR_ANSWER_DATE = 99991231   ! default = 20181231
+                                ! The vintage of the porous barrier weight function calculations.  Values below
+                                ! 20220806 recover the old answers in which the layer averaged weights are not
+                                ! strictly limited by an upper-bound of 1.0 .
 
 ! === module MOM_dynamics_split_RK2 ===
 

--- a/ocean_only/DOME/MOM_input
+++ b/ocean_only/DOME/MOM_input
@@ -38,8 +38,6 @@ DTBT_RESET_PERIOD = 8.64E+04    !   [s] default = 3600.0
                                 ! is negative, DTBT is set based only on information available at
                                 ! initialization.  If 0, DTBT will be set every dynamics time step. The default
                                 ! is set by DT_THERM.  This is only used if SPLIT is true.
-DEFAULT_2018_ANSWERS = False    !   [Boolean] default = False
-                                ! This sets the default value for the various _2018_ANSWERS parameters.
 
 ! === module MOM_fixed_initialization ===
 INPUTDIR = "INPUT"              ! default = "."

--- a/ocean_only/unit_tests/MOM_input
+++ b/ocean_only/unit_tests/MOM_input
@@ -48,8 +48,8 @@ DT = 8.64E+04                   !   [s]
                                 ! The (baroclinic) dynamics time step.  The time-step that is actually used will
                                 ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
                                 ! or the coupling timestep in coupled mode.)
-DEFAULT_2018_ANSWERS = True     !   [Boolean] default = True
-                                ! This sets the default value for the various _2018_ANSWERS parameters.
+DEFAULT_ANSWER_DATE = 20181231  ! default = 99991231
+                                ! This sets the default value for the various _ANSWER_DATE parameters.
 
 ! === module MOM_hor_index ===
 ! Sets the horizontal array index types.
@@ -189,6 +189,12 @@ KV = 1.0                        !   [m2 s-1]
                                 ! m2 s-1, may be used.
 
 ! === module MOM_thickness_diffuse ===
+
+! === module MOM_porous_barriers ===
+PORBAR_ANSWER_DATE = 99991231   ! default = 20181231
+                                ! The vintage of the porous barrier weight function calculations.  Values below
+                                ! 20220806 recover the old answers in which the layer averaged weights are not
+                                ! strictly limited by an upper-bound of 1.0 .
 
 ! === module MOM_continuity ===
 

--- a/ocean_only/unit_tests/MOM_parameter_doc.short
+++ b/ocean_only/unit_tests/MOM_parameter_doc.short
@@ -13,8 +13,8 @@ DT = 8.64E+04                   !   [s]
                                 ! The (baroclinic) dynamics time step.  The time-step that is actually used will
                                 ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
                                 ! or the coupling timestep in coupled mode.)
-DEFAULT_2018_ANSWERS = True     !   [Boolean] default = False
-                                ! This sets the default value for the various _2018_ANSWERS parameters.
+DEFAULT_ANSWER_DATE = 20181231  ! default = 99991231
+                                ! This sets the default value for the various _ANSWER_DATE parameters.
 
 ! === module MOM_domains ===
 NIGLOBAL = 4                    !
@@ -104,6 +104,10 @@ KV = 1.0                        !   [m2 s-1]
 ! === module MOM_thickness_diffuse ===
 
 ! === module MOM_porous_barriers ===
+PORBAR_ANSWER_DATE = 99991231   ! default = 20181231
+                                ! The vintage of the porous barrier weight function calculations.  Values below
+                                ! 20220806 recover the old answers in which the layer averaged weights are not
+                                ! strictly limited by an upper-bound of 1.0 .
 
 ! === module MOM_dynamics_unsplit ===
 


### PR DESCRIPTION
  Replace lines setting DEFAULT_2018_ANSWERS in the MOM_input files for 12 experiments with equivalent values of DEFAULT_ANSWER_DATE.  This is a necessary prelimiary to obsoleting all the _2018_ANSWERS runtime parameters.  Because of the atypical way that the default for PORBAR_ANSWER_DATE is set, this also has to be set explicitly to keep the previous settings.  All answers are bitwise identical, but there are differences in the contents of the MOM_parameter_doc files for these cases.