### PR TITLE
Makefile fixes to external build dirs

### DIFF
--- a/coupled_AM2_LM3_SIS2/Makefile
+++ b/coupled_AM2_LM3_SIS2/Makefile
@@ -4,11 +4,11 @@ MOM_MEMORY ?=
 SIS_MEMORY ?=
 
 # Dependencies
-FMS_BUILD ?= ../shared/fms/$(BUILD)
-AM2_BUILD ?= ../shared/AM2/$(BUILD)
-ICEBERGS_BUILD ?= ../shared/icebergs/$(BUILD)
-ICE_PARAM_BUILD ?= ../shared/ice_param/$(BUILD)
-LM3_BUILD ?= ../shared/LM3/$(BUILD)
+FMS_BUILD ?= ../shared/fms/build
+AM2_BUILD ?= ../shared/AM2/build
+ICEBERGS_BUILD ?= ../shared/icebergs/build
+ICE_PARAM_BUILD ?= ../shared/ice_param/build
+LM3_BUILD ?= ../shared/LM3/build
 
 # Autoconf configuration
 MOM_CODEBASE ?= ../src/MOM6
@@ -26,7 +26,6 @@ EXCLUDE ?=
 # Autoconf setup
 EXTRA_SRC_DIRS = \
   $(abspath ../src/SIS2/src) \
-  $(abspath ../src/SIS2/config_src/dynamic_symmetric) \
   $(abspath ../src/SIS2/config_src/external) \
   $(abspath ../src/coupler)
 
@@ -140,19 +139,28 @@ $(BUILD):
 # Dependencies
 
 $(FMS_BUILD)/libFMS.a:
-	$(MAKE) -C ../shared/fms BUILD=$(BUILD)
+	$(MAKE) -C ../shared/fms \
+	  BUILD=$(abspath $(FMS_BUILD))
 
 $(AM2_BUILD)/libAM2.a: $(FMS_BUILD)/libFMS.a
-	$(MAKE) -C ../shared/AM2 BUILD=$(BUILD)
+	$(MAKE) -C ../shared/AM2 \
+	  BUILD=$(abspath $(AM2_BUILD)) \
+	  FMS_BUILD=$(abspath $(FMS_BUILD))
 
 $(LM3_BUILD)/libLM3.a: $(FMS_BUILD)/libFMS.a
-	$(MAKE) -C ../shared/LM3 BUILD=$(BUILD)
+	$(MAKE) -C ../shared/LM3 \
+	  BUILD=$(abspath $(LM3_BUILD)) \
+	  FMS_BUILD=$(abspath $(FMS_BUILD))
 
 $(ICE_PARAM_BUILD)/libice_param.a: $(FMS_BUILD)/libFMS.a
-	$(MAKE) -C ../shared/ice_param BUILD=$(BUILD)
+	$(MAKE) -C ../shared/ice_param \
+	  BUILD=$(abspath $(ICE_PARAM_BUILD)) \
+	  FMS_BUILD=$(abspath $(FMS_BUILD))
 
 $(ICEBERGS_BUILD)/libicebergs.a: $(FMS_BUILD)/libFMS.a
-	$(MAKE) -C ../shared/icebergs BUILD=$(BUILD)
+	$(MAKE) -C ../shared/icebergs \
+	  BUILD=$(abspath $(ICEBERGS_BUILD)) \
+	  FMS_BUILD=$(abspath $(FMS_BUILD))
 
 
 #----

--- a/ice_ocean_SIS2/Makefile
+++ b/ice_ocean_SIS2/Makefile
@@ -4,11 +4,11 @@ MOM_MEMORY ?=
 SIS_MEMORY ?=
 
 # Dependencies
-FMS_BUILD ?= ../shared/fms/$(BUILD)
-ICEBERGS_BUILD ?= ../shared/icebergs/$(BUILD)
-ICE_PARAM_BUILD ?= ../shared/ice_param/$(BUILD)
-ATMOS_BUILD ?= ../shared/atmos_null/$(BUILD)
-LAND_BUILD ?= ../shared/land_null/$(BUILD)
+FMS_BUILD ?= ../shared/fms/build
+ICEBERGS_BUILD ?= ../shared/icebergs/build
+ICE_PARAM_BUILD ?= ../shared/ice_param/bould
+ATMOS_BUILD ?= ../shared/atmos_null/build
+LAND_BUILD ?= ../shared/land_null/build
 
 # Autoconf configuration
 MOM_CODEBASE ?= ../src/MOM6
@@ -142,19 +142,28 @@ $(BUILD):
 # Dependencies
 
 $(FMS_BUILD)/libFMS.a:
-	$(MAKE) -C ../shared/fms BUILD=$(BUILD)
+	$(MAKE) -C ../shared/fms \
+	  BUILD=$(abspath $(FMS_BUILD))
 
 $(ATMOS_BUILD)/libatmos_null.a: $(FMS_BUILD)/libFMS.a
-	$(MAKE) -C ../shared/atmos_null BUILD=$(BUILD)
+	$(MAKE) -C ../shared/atmos_null \
+	  BUILD=$(abspath $(ATMOS_BUILD)) \
+	  FMS_BUILD=$(abspath $(FMS_BUILD))
 
 $(LAND_BUILD)/libland_null.a: $(FMS_BUILD)/libFMS.a
-	$(MAKE) -C ../shared/land_null BUILD=$(BUILD)
+	$(MAKE) -C ../shared/land_null \
+	  BUILD=$(abspath $(LAND_BUILD)) \
+	  FMS_BUILD=$(abspath $(FMS_BUILD))
 
 $(ICE_PARAM_BUILD)/libice_param.a: $(FMS_BUILD)/libFMS.a
-	$(MAKE) -C ../shared/ice_param BUILD=$(BUILD)
+	$(MAKE) -C ../shared/ice_param \
+	  BUILD=$(abspath $(ICE_PARAM_BUILD)) \
+	  FMS_BUILD=$(abspath $(FMS_BUILD))
 
 $(ICEBERGS_BUILD)/libicebergs.a: $(FMS_BUILD)/libFMS.a
-	$(MAKE) -C ../shared/icebergs BUILD=$(BUILD)
+	$(MAKE) -C ../shared/icebergs \
+	  BUILD=$(abspath $(ICEBERGS_BUILD)) \
+	  FMS_BUILD=$(abspath $(FMS_BUILD))
 
 #----
 

--- a/ocean_only/Makefile
+++ b/ocean_only/Makefile
@@ -3,7 +3,7 @@ BUILD ?= build
 MOM_MEMORY ?=
 
 # Dependencies
-FMS_BUILD ?= ../shared/fms/$(BUILD)
+FMS_BUILD ?= ../shared/fms/build
 
 # Autoconf configuration
 CODEBASE ?= ../src/MOM6
@@ -98,7 +98,7 @@ $(BUILD):
 # Dependencies
 
 $(FMS_BUILD)/libFMS.a:
-	$(MAKE) -C ../shared/fms BUILD=$(BUILD)
+	$(MAKE) -C ../shared/fms BUILD=$(abspath $(FMS_BUILD))
 
 
 #----

--- a/shared/AM2/Makefile
+++ b/shared/AM2/Makefile
@@ -1,6 +1,6 @@
 # Configuration
 BUILD ?= build
-FMS_BUILD ?= ../fms/$(BUILD)
+FMS_BUILD ?= ../fms/build
 
 TARGET = libAM2.a
 CODEBASE = ../../src/AM2

--- a/shared/LM3/Makefile
+++ b/shared/LM3/Makefile
@@ -1,6 +1,6 @@
 # Configuration
 BUILD ?= build
-FMS_BUILD ?= ../fms/$(BUILD)
+FMS_BUILD ?= ../fms/build
 
 LM3_SRC ?= ../../src/LM3
 

--- a/shared/atmos_null/Makefile
+++ b/shared/atmos_null/Makefile
@@ -1,6 +1,6 @@
 # Configuration
 BUILD ?= build
-FMS_BUILD ?= ../fms/$(BUILD)
+FMS_BUILD ?= ../fms/build
 
 TARGET = libatmos_null.a
 CODEBASE = ../../src/atmos_null

--- a/shared/ice_param/Makefile
+++ b/shared/ice_param/Makefile
@@ -1,6 +1,6 @@
 # Configuration
 BUILD ?= build
-FMS_BUILD ?= ../fms/$(BUILD)
+FMS_BUILD ?= ../fms/build
 
 CODEBASE = ../../src/ice_param
 TARGET = libice_param.a

--- a/shared/icebergs/Makefile
+++ b/shared/icebergs/Makefile
@@ -1,6 +1,6 @@
 # Configuration
 BUILD ?= build
-FMS_BUILD ?= ../fms/$(BUILD)
+FMS_BUILD ?= ../fms/build
 
 CODEBASE = ../../src/icebergs/src
 TARGET = libicebergs.a

--- a/shared/land_null/Makefile
+++ b/shared/land_null/Makefile
@@ -1,6 +1,6 @@
 # Configuration
 BUILD ?= build
-FMS_BUILD ?= ../fms/$(BUILD)
+FMS_BUILD ?= ../fms/build
 
 TARGET = libland_null.a
 CODEBASE = ../../src/land_null


### PR DESCRIPTION
This patch fixes several issues related to building the components of the main supported models (ocean_only, ice_ocean_SIS2, coupled_AM2_LM3_SIS2).

The major fix is that $(BUILD), the build path for each model, was incorrectly being passed as the build path for supporting libraries (FMS, AM2, etc.).  This was covered up by default values which worked around the assumed defaults.  We fix this by passing, for example, FMS_BUILD as the BUILD of the FMS library Makefile.  We also address potential relative path problems by only passing the absolute path.

The other, related, fix is to explicitly add each of the library *_BUILD directories to each library build.  This might add some bloat, but now allows those builds to be more explicit.

Minor issues
* the coupled dynamic_nonsymmetric was adding the dynamic_symmetric path to its EXTRA_SRC_DIRS, causing the model to be built with both MOM_MEMORY.h headers.  This has been removed.

* $(BUILD) was used to define the default values of FMS_BUILD, etc in the model Makefiles.  This did not make much sense and could have caused new problems, so we just replace it with `build`.